### PR TITLE
chore(LambdaCalculus/Untyped): golf

### DIFF
--- a/Cslib/Computability/LambdaCalculus/Untyped/Basic.lean
+++ b/Cslib/Computability/LambdaCalculus/Untyped/Basic.lean
@@ -125,8 +125,7 @@ completely captures the syntax of terms. -/
 theorem Context.complete (m : Term Var) :
     ∃ (c : Context Var) (x : Var), m = (c.fill (Term.var x)) := by
   induction m with
-  | var x =>
-    exists hole, x
+  | var x => exists hole, x
   | abs x n ih =>
     obtain ⟨c', y, ih⟩ := ih
     exists Context.abs x c', y

--- a/Cslib/Computability/LambdaCalculus/Untyped/Basic.lean
+++ b/Cslib/Computability/LambdaCalculus/Untyped/Basic.lean
@@ -34,15 +34,13 @@ inductive Term (Var : Type u) : Type u where
 deriving DecidableEq
 
 /-- Free variables. -/
-def Term.fv [DecidableEq Var] (m : Term Var) : Finset Var :=
-  match m with
+def Term.fv [DecidableEq Var] : Term Var → Finset Var
   | var x => {x}
   | abs x m => m.fv.erase x
   | app m n => m.fv ∪ n.fv
 
 /-- Bound variables. -/
-def Term.bv [DecidableEq Var] (m : Term Var) : Finset Var :=
-  match m with
+def Term.bv [DecidableEq Var] : Term Var → Finset Var
   | var _ => ∅
   | abs x m => m.bv ∪ {x} -- Could also be `insert x m.bv`
   | app m n => m.bv ∪ n.bv
@@ -72,20 +70,9 @@ def Term.rename [DecidableEq Var] (m : Term Var) (x y : Var) : Term Var :=
   | app n1 n2 => app (n1.rename x y) (n2.rename x y)
 
 /-- Renaming preserves size. -/
+@[simp]
 theorem Term.rename.eq_sizeOf {m : Term Var} {x y : Var} [DecidableEq Var] : sizeOf (m.rename x y) = sizeOf m := by
-  induction m
-  case var z =>
-    simp only [Term.rename]
-    by_cases hzx : z = x <;> simp [hzx]
-  case abs z m' ih =>
-    simp only [Term.rename]
-    by_cases hzx : z = x
-    case pos => simp [hzx]
-    case neg =>
-      simp [hzx]
-      apply ih
-  case app n1 n2 ih1 ih2 =>
-    simp [Term.rename, ih1, ih2]
+  induction m <;> aesop (add simp [Term.rename])
 
 /-- Capture-avoiding substitution. `m.subst x r` replaces the free occurrences of variable `x` in `m` with `r`. -/
 def Term.subst [DecidableEq Var] [HasFresh Var] (m : Term Var) (x : Var) (r : Term Var) : Term Var :=
@@ -100,19 +87,12 @@ def Term.subst [DecidableEq Var] [HasFresh Var] (m : Term Var) (x : Var) (r : Te
       let z := HasFresh.fresh (abs y m').vars
       abs z ((m'.rename y z).subst x r)
   | app m1 m2 => app (m1.subst x r) (m2.subst x r)
-termination_by
-  sizeOf m
-decreasing_by
-  · simp
-  · rw [Term.rename.eq_sizeOf]
-    simp
-  · simp
-    omega
-  · simp
+termination_by m
+decreasing_by all_goals grind [rename.eq_sizeOf, abs.sizeOf_spec, app.sizeOf_spec]
 
 /-- `Term.subst` is a substitution for λ-terms. Gives access to the notation `m[x := n]`. -/
 instance instHasSubstitutionTerm [DecidableEq Var] [HasFresh Var] :
-  HasSubstitution (Term Var) Var where
+    HasSubstitution (Term Var) Var where
   subst := Term.subst
 
 -- TODO
@@ -143,21 +123,18 @@ def Context.fill (c : Context Var) (m : Term Var) : Term Var :=
 /-- Any `Term` can be obtained by filling a `Context` with a variable. This proves that `Context`
 completely captures the syntax of terms. -/
 theorem Context.complete (m : Term Var) :
-  ∃ (c : Context Var) (x : Var), m = (c.fill (Term.var x)) := by
-  induction m
-  case var x =>
-    exists hole
-    simp [fill]
-  case abs x n ih =>
+    ∃ (c : Context Var) (x : Var), m = (c.fill (Term.var x)) := by
+  induction m with
+  | var x =>
+    exists hole, x
+  | abs x n ih =>
     obtain ⟨c', y, ih⟩ := ih
-    exists Context.abs x c'
-    exists y
-    simp [ih, fill]
-  case app n1 n2 ih1 ih2 =>
-    obtain ⟨c1, x1, ih1⟩ := ih1
-    exists Context.appL c1 n2
-    exists x1
-    simp [ih1, fill]
+    exists Context.abs x c', y
+    rw [ih, fill]
+  | app n₁ n₂ ih₁ ih₂ =>
+    obtain ⟨c₁, x₁, ih₁⟩ := ih₁
+    exists Context.appL c₁ n₂, x₁
+    rw [ih₁, fill]
 
 open Term
 


### PR DESCRIPTION
Some minor golfs and partial automation. This also generally sprefers `h₁` over `h1`, as mathlib4 does, and indents proof results over their actual proofs (as mathlib4 does).