### PR TITLE
Add proofs of exponential equivalences

### DIFF
--- a/Cslib/Logic/LinearLogic/CLL/Basic.lean
+++ b/Cslib/Logic/LinearLogic/CLL/Basic.lean
@@ -150,6 +150,18 @@ inductive Proof : @Sequent Atom → Prop where
 
 def Proposition.equiv (a b : @Proposition Atom) : Prop := Proof [a.dual, b] ∧ Proof [b.dual, a]
 
+namespace Proposition
+
+theorem exp_top_eq_one : @Proposition.equiv Atom (bang top) one := by
+  constructor
+  · apply Proof.weaken
+    exact Proof.one
+  · apply Proof.bot
+    apply Proof.bang
+    · intro _ _; contradiction
+    exact Proof.top
+
+end Proposition
 
 end CLL
 

--- a/Cslib/Logic/LinearLogic/CLL/Basic.lean
+++ b/Cslib/Logic/LinearLogic/CLL/Basic.lean
@@ -161,6 +161,17 @@ theorem exp_top_eq_one : @Proposition.equiv Atom (bang top) one := by
     · intro _ _; contradiction
     exact Proof.top
 
+theorem exp_zero_eq_bot : @Proposition.equiv Atom (quest zero) bot := by
+  constructor
+  · apply Proof.exchange (List.Perm.swap (bang top) bot [])
+    apply Proof.bot
+    apply Proof.bang
+    · intro _ _; contradiction
+    exact Proof.top
+  · apply Proof.exchange (List.Perm.swap one (quest zero) [])
+    apply Proof.weaken
+    exact Proof.one
+
 end Proposition
 
 end CLL

--- a/Cslib/Logic/LinearLogic/CLL/Basic.lean
+++ b/Cslib/Logic/LinearLogic/CLL/Basic.lean
@@ -147,6 +147,10 @@ inductive Proof : @Sequent Atom → Prop where
 | contract : Proof (quest a :: quest a :: Γ) → Proof (quest a :: Γ)
 | bang {Γ : @Sequent Atom} {a} : Γ.allQuest → Proof (a :: Γ) → Proof (bang a :: Γ)
 
+
+def Proposition.equiv (a b : @Proposition Atom) : Prop := Proof [a.dual, b] ∧ Proof [b.dual, a]
+
+
 end CLL
 
 end CLL


### PR DESCRIPTION
Hi! Added two classic linear logic equivalences:  
- `!⊤ ≡ 1` (`exp_top_eq_one`)  
- `?0 ≡ ⊥` (`exp_zero_eq_bot`)  

Inspired by Girard's right-sided sequents, I made this equivalence definition:  
`Proof [a.dual, b] ∧ Proof [b.dual, a]`

Would love your thoughts on this and the perm proofs too before tackling distributive laws next! 😊  