### PR TITLE
chore: update mathlib name in nightly-testing workflow

### DIFF
--- a/.github/workflows/bump_toolchain_nightly-testing.yml
+++ b/.github/workflows/bump_toolchain_nightly-testing.yml
@@ -52,10 +52,11 @@ jobs:
       run: |
         # Update lean-toolchain file
         echo "leanprover/lean4:${RELEASE_TAG}" > lean-toolchain
-        
-        # Update the mathlib rev in lakefile.toml to use the nightly-testing tag
+
+        # Update the mathlib name and rev in lakefile.toml to use nightly-testing
+        sed -i "s/name = \"mathlib\"/name = \"mathlib-nightly-testing\"/" lakefile.toml
         sed -i "s/rev = \"[^\"]*\"/rev = \"${NIGHTLY_TESTING_TAG}\"/" lakefile.toml
-        
+
         # Update dependencies
         lake update
 


### PR DESCRIPTION
## Summary
- Updates `bump_toolchain_nightly-testing.yml` to change the mathlib dependency name from `mathlib` to `mathlib-nightly-testing` in `lakefile.toml`
- This ensures the workflow correctly references the nightly-testing variant of mathlib, not just updating the rev

## Changes
- Added `sed` command to update `name = "mathlib"` to `name = "mathlib-nightly-testing"` 
- This runs alongside the existing `rev` update

## Test plan
- [ ] Verify the workflow runs successfully on the next scheduled execution or manual trigger
- [ ] Confirm `lakefile.toml` on `nightly-testing` branch has both correct name and rev after workflow runs

🤖 Generated with [Claude Code](https://claude.com/claude-code)