### PR TITLE
chore: skip nightly-testing workflows in forks

### DIFF
--- a/.github/workflows/bump_toolchain_nightly-testing.yml
+++ b/.github/workflows/bump_toolchain_nightly-testing.yml
@@ -9,6 +9,7 @@ on:
 
 jobs:
   update-toolchain:
+    if: github.repository == 'leanprover/cslib'
     runs-on: ubuntu-latest
     steps:
     - name: Checkout code

--- a/.github/workflows/merge_main_into_nightly-testing.yml
+++ b/.github/workflows/merge_main_into_nightly-testing.yml
@@ -10,6 +10,7 @@ on:
 
 jobs:
   merge-to-nightly-testing:
+    if: github.repository == 'leanprover/cslib'
     runs-on: ubuntu-latest
     steps:
       - name: Checkout nightly-testing 

--- a/.github/workflows/report_failures_nightly-testing.yml
+++ b/.github/workflows/report_failures_nightly-testing.yml
@@ -9,7 +9,8 @@ on:
 jobs:
   handle_failure:
 
-    if: ${{ github.event.workflow_run.conclusion == 'failure' &&
+    if: ${{ github.repository == 'leanprover/cslib' &&
+            github.event.workflow_run.conclusion == 'failure' &&
             github.event.workflow_run.head_branch == 'nightly-testing' }}
     runs-on: ubuntu-latest
 
@@ -28,7 +29,8 @@ jobs:
           You can `git fetch; git checkout nightly-testing` and push a fix.
 
   handle_success:
-    if: ${{ github.event.workflow_run.conclusion == 'success' &&
+    if: ${{ github.repository == 'leanprover/cslib' &&
+            github.event.workflow_run.conclusion == 'success' &&
             github.event.workflow_run.head_branch == 'nightly-testing' }}
     runs-on: ubuntu-latest
 


### PR DESCRIPTION
## Summary
Add repository checks to nightly-testing workflows to prevent them from running in forks.

🤖 Generated with [Claude Code](https://claude.com/claude-code)