### PR TITLE
chore: don't check docs toolchain unless in a PR or main branch

### DIFF
--- a/.github/workflows/lean_action_ci.yml
+++ b/.github/workflows/lean_action_ci.yml
@@ -10,7 +10,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - run: |
+      - if: github.event_name == 'pull_request' || (github.event_name == 'push' && github.ref == 'refs/heads/main')
+        run: |
           set -e
           cmp -s lean-toolchain docs/lean-toolchain
       - uses: leanprover/lean-action@v1


### PR DESCRIPTION
Normally we check that our library and documentation are using the same `lean-toolchain`. However the [nightly testing workflow](.github/workflows/merge_main_into_nightly-testing.yml) by design is meant to test a toolchain ahead of our current pinned version. To accommodate this, this PR changes the doc toolchain check to only happen during pull requests and commits to the `main` branch.