### PR TITLE
chore(Languages/CCS): Mathlib linting, more readable proof of Act.Co decidability

### DIFF
--- a/Cslib/Languages/CCS/Basic.lean
+++ b/Cslib/Languages/CCS/Basic.lean
@@ -4,6 +4,8 @@ Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Fabrizio Montesi
 -/
 
+import Mathlib.Init
+
 /-! # Calculus of Communicating Systems (CCS)
 
 CCS [Milner80], as presented in [Sangiorgi2011]. In the semantics (see `CCS.lts`), we adopt the
@@ -46,85 +48,51 @@ inductive Process (Name : Type u) (Constant : Type v) : Type (max u v) where
   | const (c : Constant)
 deriving DecidableEq
 
+namespace Act
+
 /-- An action is visible if it a name or a coname. -/
 @[grind]
-inductive Act.IsVisible : Act Name → Prop where
+inductive IsVisible : Act Name → Prop where
   | name : IsVisible (Act.name a)
   | coname : IsVisible (Act.coname a)
 
 /-- If an action is visible, it is not `τ`. -/
 @[grind, simp]
-theorem Act.isVisible_neq_τ {μ : Act Name} (h : μ.IsVisible) : μ ≠ Act.τ := by
+theorem isVisible_neq_τ {μ : Act Name} (h : μ.IsVisible) : μ ≠ Act.τ := by
   cases μ <;> grind
 
 /-- Checks that an action is the coaction of another. -/
 @[grind]
-inductive Act.Co {Name : Type u} : Act Name → Act Name → Prop where
-  | nc : Act.Co (Act.name a) (Act.coname a)
-  | cn : Act.Co (Act.coname a) (Act.name a)
+inductive Co {Name : Type u} : Act Name → Act Name → Prop where
+  | nc : Co (name a) (coname a)
+  | cn : Co (coname a) (name a)
 
 /-- `Act.Co` is symmetric. -/
 @[grind, symm]
-theorem Act.Co.symm (h : Act.Co μ μ') : Act.Co μ' μ := by grind
+theorem Co.symm (h : Co μ μ') : Co μ' μ := by grind
 
 /-- If two actions are one the coaction of the other, then they are both visible. -/
 @[grind]
-theorem Act.co_isVisible (h : Act.Co μ μ') : μ.IsVisible ∧ μ'.IsVisible := by grind
+theorem co_isVisible (h : Co μ μ') : μ.IsVisible ∧ μ'.IsVisible := by grind
+
+@[grind]
+def isCo [DecidableEq Name] (μ μ' : Act Name) : Bool := 
+  match μ, μ' with
+  | name a, coname b | coname a, name b => a = b
+  | _, _ => false
+
+theorem isCo_iff [DecidableEq Name] {μ μ' : Act Name} : isCo μ μ' ↔ Co μ μ' := by
+  grind [cases Act]
 
 /-- `Act.Co` is decidable if `Name` equality is decidable. -/
-instance {Name : Type u} [hdec : DecidableEq Name] {μ μ' : Act Name} :
-  Decidable (Act.Co μ μ') := by
-  cases μ
-  case name a =>
-    cases μ'
-    case name b =>
-      apply Decidable.isFalse
-      intro h'
-      cases h'
-    case coname b =>
-      by_cases hab : a = b
-      case pos =>
-        rw [hab]
-        apply Decidable.isTrue
-        constructor
-      case neg =>
-        apply Decidable.isFalse
-        intro h'
-        cases h'
-        contradiction
-    case τ =>
-      apply Decidable.isFalse
-      intro h'
-      cases h'
-  case coname a =>
-    cases μ'
-    case name b =>
-      by_cases hab : a = b
-      case pos =>
-        rw [hab]
-        apply Decidable.isTrue
-        constructor
-      case neg =>
-        apply Decidable.isFalse
-        intro h'
-        cases h'
-        contradiction
-    case coname b =>
-      apply Decidable.isFalse
-      intro h'
-      cases h'
-    case τ =>
-      apply Decidable.isFalse
-      intro h'
-      cases h'
-  case τ =>
-    apply Decidable.isFalse
-    intro h'
-    cases h'
+instance [DecidableEq Name] {μ μ' : Act Name} : Decidable (Co μ μ') := 
+  decidable_of_decidable_of_iff isCo_iff
+
+end Act
 
 /-- Contexts. -/
 @[grind]
-inductive Context (Name : Type u) (Constant : Type v): Type (max u v) where
+inductive Context (Name : Type u) (Constant : Type v) : Type (max u v) where
   | hole
   | pre (μ : Act Name) (c : Context Name Constant)
   | parL (c : Context Name Constant) (q : Process Name Constant)
@@ -136,7 +104,7 @@ deriving DecidableEq
 
 /-- Replaces the hole in a `Context` with a `Process`. -/
 @[grind]
-def Context.fill {Name : Type u} {Constant : Type v} (c : Context Name Constant) (p : Process Name Constant) : Process Name Constant :=
+def Context.fill (c : Context Name Constant) (p : Process Name Constant) : Process Name Constant :=
   match c with
   | hole => p
   | pre μ c => Process.pre μ (c.fill p)


### PR DESCRIPTION
This file did not depend on Mathlib, which given the use of `weak` in `lakefile.toml` meant that this was silently not linted. There are three other files for which this is true:
```
Cslib.Foundations.Syntax.HasAlphaEquiv
Cslib.Foundations.Syntax.HasSubstitution
Cslib.Foundations.Syntax.HasWellFormed
```
but they only define notation typeclasses and have no lint problems.

While here, I also took the opportunity to make a decidability proof easier to read.