### PR TITLE
chore: add Lint import to CslibTests.lean

### DIFF
--- a/CslibTests.lean
+++ b/CslibTests.lean
@@ -3,6 +3,7 @@ import CslibTests.CCS
 import CslibTests.DFA
 import CslibTests.FreeMonad
 import CslibTests.HasFresh
-import CslibTests.LTS
 import CslibTests.LambdaCalculus
+import CslibTests.Lint
+import CslibTests.LTS
 import CslibTests.ReductionSystem


### PR DESCRIPTION
This also places imports in alpha order.