### PR TITLE
chore: remove Cslib.Sum.{IsLeftP, IsRightP}

### DIFF
--- a/Cslib/Foundations/Semantics/LTS/Basic.lean
+++ b/Cslib/Foundations/Semantics/LTS/Basic.lean
@@ -195,61 +195,26 @@ def LTS.unionSubtype
       False
 
 /-- Lifting of an `LTS State Label` to `LTS (State ⊕ State') Label`. -/
-def LTS.inl {State'} (lts : LTS State Label) :
-  LTS (@Subtype (State ⊕ State') (Sum.isLeft ·)) (@Subtype Label (Function.const Label True)) where
-  Tr := fun s μ s' =>
-    let ⟨s, _⟩ := s
-    let ⟨s', _⟩ := s'
-    match s, μ, s' with
-    | Sum.inl s1, μ, Sum.inl s2 => lts.Tr s1 μ s2
-    | _, _, _ => False
+def LTS.inl (lts : LTS State Label) :
+    LTS { x : State ⊕ State' // x.isLeft } { _label : Label // True } where
+  Tr s μ s' := 
+    match s, s' with
+    | ⟨.inl s1, _⟩, ⟨.inl s2, _⟩ => lts.Tr s1 μ s2
+    | _, _ => False
 
 /-- Lifting of an `LTS State Label` to `LTS (State' ⊕ State) Label`. -/
-def LTS.inr {State'} (lts : LTS State Label) :
-  LTS (@Subtype (State' ⊕ State) (Sum.isRight ·)) (@Subtype Label (Function.const Label True)) where
-  Tr := fun s μ s' =>
-    let ⟨s, _⟩ := s
-    let ⟨s', _⟩ := s'
-    match s, μ, s' with
-    | Sum.inr s1, μ, Sum.inr s2 => lts.Tr s1 μ s2
-    | _, _, _ => False
+def LTS.inr (lts : LTS State Label) : 
+    LTS { x : State' ⊕ State // x.isRight } { _label : Label // True } where
+  Tr s μ s' :=
+    match s, s' with
+    | ⟨.inr s1, _⟩, ⟨.inr s2, _⟩ => lts.Tr s1 μ s2
+    | _, _ => False
 
 /-- Union of two LTSs with the same `Label` type. The result combines the original respective state
 types `State1` and `State2` into `(State1 ⊕ State2)`. -/
-def LTS.unionSum {State1} {State2} (lts1 : LTS State1 Label) (lts2 : LTS State2 Label) :
-  LTS (State1 ⊕ State2) Label :=
-  @LTS.unionSubtype
-    (State1 ⊕ State2) Label
-    (Sum.isLeft ·)
-    (Function.const Label True)
-    (Sum.isRight ·)
-    (Function.const Label True)
-    (by
-      intro s
-      cases h : s
-      · apply Decidable.isTrue
-        trivial
-      · simp only [Sum.isLeft, Bool.false_eq_true]
-        apply Decidable.isFalse
-        trivial)
-    (by
-      intro μ
-      apply Decidable.isTrue
-      trivial)
-    (by
-      intro s
-      cases h : s
-      · simp only [Sum.isRight, Bool.false_eq_true]
-        apply Decidable.isFalse
-        trivial
-      · apply Decidable.isTrue
-        trivial)
-    (by
-      intro μ
-      apply Decidable.isTrue
-      trivial)
-    lts1.inl
-    lts2.inr
+def LTS.unionSum (lts1 : LTS State1 Label) (lts2 : LTS State2 Label) :
+    LTS (State1 ⊕ State2) Label := 
+  LTS.unionSubtype lts1.inl lts2.inr
 
 end Union
 


### PR DESCRIPTION
These were unexpectedly creating the namespace `Cslib.Sum` which was confusing when working with the `Sum` in the global namespace. These can be removed and let us simplify the spelling of `LTS.unionSum`.