### PR TITLE
chore: restrict CI workflow to main and nightly-testing branches

### DIFF
--- a/.github/workflows/lean_action_ci.yml
+++ b/.github/workflows/lean_action_ci.yml
@@ -2,6 +2,9 @@ name: Lean Action CI
 
 on:
   push:
+    branches:
+      - main
+      - nightly-testing
   pull_request:
   workflow_dispatch:
 


### PR DESCRIPTION
Fixes #156. Restrict CI to run only on `main` and `nightly-testing` branch pushes.