### PR TITLE
chore: only build docs in leanprover/cslib repo

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -13,6 +13,7 @@ permissions:
 
 jobs:
   build:
+    if: github.repository == 'leanprover/cslib'
     runs-on: ubuntu-latest
     steps:
       - name: Checkout project


### PR DESCRIPTION
Adds a condition to `.github/workflows/docs.yml` to only run in the `leanprover/cslib` repo.