### PR TITLE
doc: add a description of CI in `CONTRIBUTING.md`

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -59,7 +59,7 @@ You can run these locally with `lake test`.
 CSLib uses a number of linters, mostly inherited from Batteries and Mathlib. These come in three varieties:
 
 - *syntax linters*, which appear as you write your code and will give warnings in `lake build`
-- *environment linters*, which can be run using `lake lint`
+- *environment linters*, which can be run using `lake lint` or the `#lint` command
 - *text linters*, which can be run with `lake exe lint-style` and fixed automatically with the `--fix` option
 
 ## Imports


### PR DESCRIPTION
Add a description of continuous integration in `CONTRIBUTING.md`, with some instructions for running locally.