### PR TITLE
chore: deprecation of Sorted

### DIFF
--- a/Cslib/Algorithms/Lean/MergeSort/MergeSort.lean
+++ b/Cslib/Algorithms/Lean/MergeSort/MergeSort.lean
@@ -8,7 +8,6 @@ import Cslib.Algorithms.Lean.TimeM
 import Mathlib.Data.Nat.Cast.Order.Ring
 import Mathlib.Data.Nat.Lattice
 import Mathlib.Data.Nat.Log
-import Mathlib.Deprecated.Sort
 
 
 /-!


### PR DESCRIPTION
Fixes an accidental use of deprecated declarations that were unnoticed because of a release. A CI method of detecting this will be added soon.