### PR TITLE
chore: restore closure properties of regular languages under boolean operations

### DIFF
--- a/Cslib/Computability/Languages/OmegaRegularLanguage.lean
+++ b/Cslib/Computability/Languages/OmegaRegularLanguage.lean
@@ -68,7 +68,7 @@ theorem IsRegular.not_da_buchi :
 @[simp]
 theorem IsRegular.regular_omegaLim {l : Language Symbol}
     (h : l.IsRegular) : (l↗ω).IsRegular := by
-  obtain ⟨State, _, ⟨da, acc⟩, rfl⟩ := Language.IsRegular.iff_cslib_dfa.mp h
+  obtain ⟨State, _, ⟨da, acc⟩, rfl⟩ := Language.IsRegular.iff_dfa.mp h
   grind [IsRegular.of_da_buchi, =_ DA.buchi_eq_finAcc_omegaLim]
 
 /-- The empty language is ω-regular. -/

--- a/Cslib/Computability/Languages/RegularLanguage.lean
+++ b/Cslib/Computability/Languages/RegularLanguage.lean
@@ -15,17 +15,16 @@ import Mathlib.Tactic.Common
 # Regular languages
 -/
 
-open Set Function List Prod
-open scoped Computability Cslib.FLTS Cslib.Automata.DA Cslib.Automata.NA Cslib.Automata.Acceptor
-  Cslib.Automata.DA.FinAcc Cslib.Automata.NA.FinAcc
+namespace Cslib.Language
 
-namespace Language
+open Set List Prod Automata Acceptor
+open scoped Computability FLTS DA NA DA.FinAcc NA.FinAcc
 
 variable {Symbol : Type*}
 
-open Cslib.Automata Acceptor in
-/-- A characterization of Language.IsRegular using Cslib.DA -/
-theorem IsRegular.iff_cslib_dfa {l : Language Symbol} :
+/-- A characterization of `Language.IsRegular` in terms of `DA`. This is the only theorem in Cslib
+in which Mathlib's definition of `Language.IsRegular` is used. -/
+theorem IsRegular.iff_dfa {l : Language Symbol} :
     l.IsRegular ↔ ∃ State : Type, ∃ _ : Finite State,
       ∃ dfa : DA.FinAcc State Symbol, language dfa = l := by
   constructor
@@ -38,12 +37,11 @@ theorem IsRegular.iff_cslib_dfa {l : Language Symbol} :
     use State, Fintype.ofFinite State, dfa
     rfl
 
-open Cslib.Automata Acceptor in
-/-- A characterization of Language.IsRegular using Cslib.NA -/
-theorem IsRegular.iff_cslib_nfa {l : Language Symbol} :
+/-- A characterization of Language.IsRegular in terms of NA. -/
+theorem IsRegular.iff_nfa {l : Language Symbol} :
     l.IsRegular ↔ ∃ State : Type, ∃ _ : Finite State,
       ∃ nfa : NA.FinAcc State Symbol, language nfa = l := by
-  rw [IsRegular.iff_cslib_dfa]; constructor
+  rw [IsRegular.iff_dfa]; constructor
   · rintro ⟨State, h_fin, ⟨da, acc⟩, rfl⟩
     use State, h_fin, ⟨da.toNA, acc⟩
     grind
@@ -51,27 +49,24 @@ theorem IsRegular.iff_cslib_nfa {l : Language Symbol} :
     use Set State, inferInstance, na.toDAFinAcc
     grind
 
--- From this point onward we will use only automata from Cslib in the proofs.
-open Cslib
-
-theorem IsRegular.compl_cslib {l : Language Symbol} (h : l.IsRegular) : (lᶜ).IsRegular := by
-  rw [IsRegular.iff_cslib_dfa] at h ⊢
+theorem IsRegular.compl {l : Language Symbol} (h : l.IsRegular) : (lᶜ).IsRegular := by
+  rw [IsRegular.iff_dfa] at h ⊢
   obtain ⟨State, _, ⟨da, acc⟩, rfl⟩ := h
   use State, inferInstance, ⟨da, accᶜ⟩
   grind
 
 @[simp]
 theorem IsRegular.zero : (0 : Language Symbol).IsRegular := by
-  rw [IsRegular.iff_cslib_dfa]
+  rw [IsRegular.iff_dfa]
   let flts := FLTS.mk (fun () (_ : Symbol) ↦ ())
-  use Unit, inferInstance, ⟨Cslib.Automata.DA.mk flts (), ∅⟩
+  use Unit, inferInstance, ⟨DA.mk flts (), ∅⟩
   grind
 
 @[simp]
 theorem IsRegular.one : (1 : Language Symbol).IsRegular := by
-  rw [IsRegular.iff_cslib_dfa]
+  rw [IsRegular.iff_dfa]
   let flts := FLTS.mk (fun (_ : Fin 2) (_ : Symbol) ↦ 1)
-  use Fin 2, inferInstance, ⟨Cslib.Automata.DA.mk flts 0, {0}⟩
+  use Fin 2, inferInstance, ⟨DA.mk flts 0, {0}⟩
   ext; constructor
   · intro h; by_contra h'
     have := dropLast_append_getLast h'
@@ -84,18 +79,18 @@ theorem IsRegular.top : (⊤ : Language Symbol).IsRegular := by
   rwa [← compl_bot]
 
 @[simp]
-theorem IsRegular.inf_cslib {l1 l2 : Language Symbol}
+theorem IsRegular.inf {l1 l2 : Language Symbol}
     (h1 : l1.IsRegular) (h2 : l2.IsRegular) : (l1 ⊓ l2).IsRegular := by
-  rw [IsRegular.iff_cslib_dfa] at h1 h2 ⊢
+  rw [IsRegular.iff_dfa] at h1 h2 ⊢
   obtain ⟨State1, h_fin1, ⟨da1, acc1⟩, rfl⟩ := h1
   obtain ⟨State2, h_fin1, ⟨da2, acc2⟩, rfl⟩ := h2
   use State1 × State2, inferInstance, ⟨da1.prod da2, fst ⁻¹' acc1 ∩ snd ⁻¹' acc2⟩
   ext; grind [Language.mem_inf]
 
 @[simp]
-theorem IsRegular.add_cslib {l1 l2 : Language Symbol}
+theorem IsRegular.add {l1 l2 : Language Symbol}
     (h1 : l1.IsRegular) (h2 : l2.IsRegular) : (l1 + l2).IsRegular := by
-  rw [IsRegular.iff_cslib_dfa] at h1 h2 ⊢
+  rw [IsRegular.iff_dfa] at h1 h2 ⊢
   obtain ⟨State1, h_fin1, ⟨da1, acc1⟩, rfl⟩ := h1
   obtain ⟨State2, h_fin1, ⟨da2, acc2⟩, rfl⟩ := h2
   use State1 × State2, inferInstance, ⟨da1.prod da2, fst ⁻¹' acc1 ∪ snd ⁻¹' acc2⟩
@@ -126,4 +121,4 @@ theorem IsRegular.iSup {I : Type*} [Finite I] {s : Set I} {l : I → Language Sy
     rw [iSup_insert]
     apply IsRegular.add <;> grind
 
-end Language
+end Cslib.Language


### PR DESCRIPTION
In view of the plan to develop a self-contained automata theory in cslib, the patch restores the closure properties of regular languages under boolean operations that were removed in https://github.com/leanprover/cslib/pull/209.

Note that in order to avoid conflicts with the equivalent theorems in mathlib, the `_cslib` suffix is added to theorem names.
