### PR TITLE
feat: Adding some `CompRel` lemmas to Relation for symmetric closure support

### DIFF
--- a/Cslib/Foundations/Data/Relation.lean
+++ b/Cslib/Foundations/Data/Relation.lean
@@ -45,6 +45,8 @@ theorem TransGen.to_eqvGen (h : TransGen r a b) : EqvGen r a b := by
 theorem ReflTransGen.to_eqvGen (h : ReflTransGen r a b) : EqvGen r a b := by
   induction h <;> grind
 
+-- TODO: topNamespace environment linter fails for CompRel.to_eqvGen
+@[nolint topNamespace]
 theorem _root_.CompRel.to_eqvGen (h : CompRel r a b) : EqvGen r a b := by
   induction h <;> grind
 

--- a/Cslib/Foundations/Lint/Basic.lean
+++ b/Cslib/Foundations/Lint/Basic.lean
@@ -15,7 +15,7 @@ open Lean Meta Std Batteries.Tactic.Lint
 
 /-- A linter for checking that new declarations fall under some preexisting namespace. -/
 @[env_linter]
-meta def topNamespace : Batteries.Tactic.Lint.Linter where
+public meta def topNamespace : Batteries.Tactic.Lint.Linter where
   noErrorsFound := "No declarations are outside a namespace."
   errorsFound := "TOP LEVEL DECLARATIONS:"
   test declName := do


### PR DESCRIPTION
This PR adds some preliminary support for [`CompRel`](https://leanprover-community.github.io/mathlib4_docs/Mathlib/Order/Comparable.html#CompRel) in `Relation.lean`, as it doesn't currently have a concrete notion of symmetric closure. In particular, we add:
-  Helper lemmas for symmetry relationships between `ReflGen`, `ReflTransGen`, and `CompRel`
- A theorem showing `EqvGen r = ReflTransGen (CompRel r)`, bridging the gap between `Gen` structures.

This should hopefully help with future development surrounding symmetric closures in `Relation.lean`.