### PR TITLE
chore: add .claude to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,3 +14,4 @@
 /docs/Std-manifest.json.hash
 /docs/Std-manifest.json.trace
 .DS_Store
+.claude


### PR DESCRIPTION
This one-line PR adds `.claude` to the `.gitignore`.

In the course of using tools from the Anthropic ecosystem, the user may want to add personalized permissions or scripts, which can appear in the `.claude` folder. Adding this to the `.gitignore` would make it easier to use these tools in this repository without accidentally committing a personalized setting.