### PR TITLE
fix: prevent duplicate Zulip posts in nightly failure workflow

### DIFF
--- a/.github/workflows/report_failures_nightly-testing.yml
+++ b/.github/workflows/report_failures_nightly-testing.yml
@@ -316,6 +316,7 @@ jobs:
       shell: python
       run: |
         import os
+        import re
         import zulip
         client = zulip.Client(config_file="~/.zuliprc")
         current_version = os.getenv('NIGHTLY')
@@ -342,17 +343,27 @@ jobs:
             payload = f"🛠️: Automatic PR creation [failed]({failed_link}). Please create a new bump/nightly-{current_version} branch from nightly-testing (specifically {sha}), and then PR that to {bump_branch}. "
             payload += "To do so semi-automatically, run the following script from Cslib root:\n\n"
             payload += f"```bash\n./scripts/create-adaptation-pr.sh --bumpversion={bump_branch_suffix} --nightlydate={current_version} --nightlysha={sha}\n```\n"
-            # Only post if the message is different
-            # We compare the first 160 characters, since that includes the date and bump version
-            if not messages or messages[0]['content'][:160] != payload[:160]:
-                # Log messages, because the bot seems to repeat itself...
+            # Check if we already posted a message for this nightly date and bump branch.
+            # We extract these fields from the last message rather than comparing substrings,
+            # since the message also contains a run ID that differs between workflow runs.
+            should_post = True
+            if messages:
+                last_content = messages[0]['content']
+                # Extract nightly date and bump branch from last message
+                date_match = re.search(r'bump/nightly-(\d{4}-\d{2}-\d{2})', last_content)
+                branch_match = re.search(r'PR that to (bump/v[\d.]+)', last_content)
+                if date_match and branch_match:
+                    last_date = date_match.group(1)
+                    last_branch = branch_match.group(1)
+                    if last_date == current_version and last_branch == bump_branch:
+                        should_post = False
+                        print(f'Already posted for nightly {current_version} and {bump_branch}')
+            if should_post:
                 if messages:
                     print("###### Last message:")
                     print(messages[0]['content'])
                     print("###### Current message:")
                     print(payload)
-                else:
-                    print('The strings match!')
                 # Post the reminder message
                 request = {
                     'type': 'stream',


### PR DESCRIPTION
This PR fixes a bug in the `report_failures_nightly-testing.yml` workflow where duplicate messages were being posted to Zulip for the same nightly date.

The deduplication logic compared the first 160 characters of the message, but the GitHub Actions run ID appears within those characters. Different workflow runs have different IDs, so the comparison always failed and duplicates were posted.

Now we extract and compare the nightly date and bump branch explicitly using regex, which correctly identifies duplicate messages.

See https://leanprover.zulipchat.com/#narrow/channel/428973-nightly-testing/topic/Cslib.20bump.20branch.20reminders/near/569853848 for context.

🤖 Prepared with Claude Code