### PR TITLE
fix: look for last bot message when deduplicating Zulip posts

### DIFF
--- a/.github/workflows/report_failures_nightly-testing.yml
+++ b/.github/workflows/report_failures_nightly-testing.yml
@@ -328,28 +328,32 @@ jobs:
         print(f'Current version: {current_version}, Bump version: {bump_version}, SHA: {sha}')
         if current_version > bump_version:
             print('Lean toolchain in `nightly-testing` is ahead of the bump branch.')
-            # Get the last message in the 'Cslib bump branch reminders' topic
+            # Get recent messages in the 'Cslib bump branch reminders' topic
+            # We fetch multiple messages to find the last bot message, ignoring human replies.
             request = {
               'anchor': 'newest',
-              'num_before': 1,
+              'num_before': 20,
               'num_after': 0,
               'narrow': [{'operator': 'stream', 'operand': 'nightly-testing'}, {'operator': 'topic', 'operand': 'Cslib bump branch reminders'}],
               'apply_markdown': False    # Otherwise the content test below fails.
             }
             response = client.get_messages(request)
             messages = response['messages']
+            # Find the last message from the bot (ignoring human messages in between)
+            bot_email = 'github-mathlib4-bot@leanprover.zulipchat.com'
+            last_bot_message = next((m for m in messages if m['sender_email'] == bot_email), None)
             bump_branch_suffix = bump_branch.replace('bump/', '')
             failed_link = f"https://github.com/{repository}/actions/runs/{current_run_id}"
             payload = f"🛠️: Automatic PR creation [failed]({failed_link}). Please create a new bump/nightly-{current_version} branch from nightly-testing (specifically {sha}), and then PR that to {bump_branch}. "
             payload += "To do so semi-automatically, run the following script from Cslib root:\n\n"
             payload += f"```bash\n./scripts/create-adaptation-pr.sh --bumpversion={bump_branch_suffix} --nightlydate={current_version} --nightlysha={sha}\n```\n"
             # Check if we already posted a message for this nightly date and bump branch.
-            # We extract these fields from the last message rather than comparing substrings,
+            # We extract these fields from the last bot message rather than comparing substrings,
             # since the message also contains a run ID that differs between workflow runs.
             should_post = True
-            if messages:
-                last_content = messages[0]['content']
-                # Extract nightly date and bump branch from last message
+            if last_bot_message:
+                last_content = last_bot_message['content']
+                # Extract nightly date and bump branch from last bot message
                 date_match = re.search(r'bump/nightly-(\d{4}-\d{2}-\d{2})', last_content)
                 branch_match = re.search(r'PR that to (bump/v[\d.]+)', last_content)
                 if date_match and branch_match:
@@ -359,9 +363,9 @@ jobs:
                         should_post = False
                         print(f'Already posted for nightly {current_version} and {bump_branch}')
             if should_post:
-                if messages:
-                    print("###### Last message:")
-                    print(messages[0]['content'])
+                if last_bot_message:
+                    print("###### Last bot message:")
+                    print(last_bot_message['content'])
                     print("###### Current message:")
                     print(payload)
                 # Post the reminder message


### PR DESCRIPTION
This PR improves the Zulip deduplication logic by fetching the last 20 messages and finding the most recent one from the bot, rather than just checking the single most recent message.

This handles the case where human replies appear between bot messages, which would previously cause duplicates to be posted.

Suggested by Chris Henson: https://leanprover.zulipchat.com/#narrow/channel/428973-nightly-testing/topic/Cslib.20bump.20branch.20reminders/near/569945200

🤖 Prepared with Claude Code