### PR TITLE
chore: create GitHub releases from version tags

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,21 @@
+name: Release
+
+on:
+  push:
+    tags:
+      - "v[0-9]+.[0-9]+.[0-9]+"
+      - "v[0-9]+.[0-9]+.[0-9]+-rc[0-9]+"
+
+permissions:
+  contents: write
+
+jobs:
+  release:
+    runs-on: ubuntu-latest
+    if: github.repository == 'leanprover/cslib'
+    steps:
+      - name: Create GitHub Release
+        uses: softprops/action-gh-release@v2
+        with:
+          prerelease: ${{ contains(github.ref, 'rc') }}
+          make_latest: ${{ !contains(github.ref, 'rc') }}


### PR DESCRIPTION
## Summary

This PR adds a GitHub Actions workflow that automatically creates GitHub releases when version tags are pushed, mirroring the existing functionality in batteries.

See also https://github.com/leanprover-community/mathlib4/pull/35425

🤖 Prepared with Claude Code