### PR TITLE
chore: use authenticated gh api in nightly bump workflow

### DIFF
--- a/.github/workflows/bump_toolchain_nightly-testing.yml
+++ b/.github/workflows/bump_toolchain_nightly-testing.yml
@@ -28,12 +28,21 @@ jobs:
 
     - name: Get latest release tag from leanprover/lean4-nightly
       id: get-latest-release
+      env:
+        GH_TOKEN: ${{ steps.app-token.outputs.token }}
       run: |
-        RELEASE_TAG="$(curl -s "https://api.github.com/repos/leanprover/lean4-nightly/releases" | jq -r '.[0].tag_name')"
+        RELEASE_TAG=$(gh api repos/leanprover/lean4-nightly/releases \
+          -f per_page=1 --jq '.[0].tag_name')
+        if [ -z "$RELEASE_TAG" ] || [ "$RELEASE_TAG" = "null" ]; then
+          echo "::error::Could not determine latest lean4-nightly release"
+          exit 1
+        fi
         echo "RELEASE_TAG=$RELEASE_TAG" >> "${GITHUB_ENV}"
 
     - name: Check if nightly-testing tag exists in mathlib4-nightly-testing
       id: check-nightly-testing
+      env:
+        GH_TOKEN: ${{ steps.app-token.outputs.token }}
       run: |
         # Extract date from RELEASE_TAG (format: nightly-YYYY-MM-DD)
         DATE_PART=$(echo "$RELEASE_TAG" | sed 's/nightly-//')
@@ -41,7 +50,7 @@ jobs:
         echo "NIGHTLY_TESTING_TAG=$NIGHTLY_TESTING_TAG" >> "${GITHUB_ENV}"
 
         # Check if the tag exists in leanprover-community/mathlib4-nightly-testing
-        if curl -s -f "https://api.github.com/repos/leanprover-community/mathlib4-nightly-testing/git/ref/tags/${NIGHTLY_TESTING_TAG}" > /dev/null; then
+        if gh api "repos/leanprover-community/mathlib4-nightly-testing/git/ref/tags/${NIGHTLY_TESTING_TAG}" > /dev/null 2>&1; then
           echo "Tag ${NIGHTLY_TESTING_TAG} exists in mathlib4-nightly-testing"
           echo "tag_exists=true" >> "${GITHUB_OUTPUT}"
         else


### PR DESCRIPTION
This PR replaces unauthenticated `curl` calls to the GitHub API with `gh api` in the nightly bump workflow. The `gh api` command automatically uses the app token already generated in the workflow, avoiding transient failures from the unauthenticated rate limit (60 req/hour).

See [this mathlib4-nightly-testing failure](https://github.com/leanprover-community/mathlib4-nightly-testing/actions/runs/22084056453/job/63814863096) for an example of the problem: the API returned a rate-limit error object instead of the expected array, and `jq` crashed trying to index it.

Corresponding PRs:
- https://github.com/leanprover-community/mathlib4/pull/35427
- https://github.com/leanprover-community/batteries/pull/1678

🤖 Prepared with Claude Code