### PR TITLE
fix: specify `-X GET` in `gh api` call

### DIFF
--- a/.github/workflows/bump_toolchain_nightly-testing.yml
+++ b/.github/workflows/bump_toolchain_nightly-testing.yml
@@ -31,7 +31,8 @@ jobs:
       env:
         GH_TOKEN: ${{ steps.app-token.outputs.token }}
       run: |
-        RELEASE_TAG=$(gh api repos/leanprover/lean4-nightly/releases --jq '.[0].tag_name')
+        RELEASE_TAG=$(gh api -X GET repos/leanprover/lean4-nightly/releases \
+          -f per_page=1 --jq '.[0].tag_name')
         if [ -z "$RELEASE_TAG" ] || [ "$RELEASE_TAG" = "null" ]; then
           echo "::error::Could not determine latest lean4-nightly release"
           exit 1


### PR DESCRIPTION
This workflow has been failing since https://github.com/leanprover/cslib/pull/341, as the `-f per_page=1` is incorrectly interpreted without the `GET` HTTP verb. I have manually triggered a run from this branch to ensure this is working.