### PR TITLE
ci: disable just unicodeLinter from text-based linters

### DIFF
--- a/.github/workflows/lean_action_ci.yml
+++ b/.github/workflows/lean_action_ci.yml
@@ -34,6 +34,6 @@ jobs:
         run: |
           set -e
           lake exe checkInitImports
-      #- uses: leanprover-community/lint-style-action@main
-      #  with:
-      #    mode: check
+      - uses: leanprover-community/lint-style-action@main
+        with:
+          mode: check

--- a/lakefile.toml
+++ b/lakefile.toml
@@ -12,6 +12,8 @@ weak.linter.flexible = true
 weak.linter.pythonStyle = false
 weak.linter.checkInitImports = false
 weak.linter.allScriptsDocumented = false
+# this is currently not extensible for unicode not used in Mathlib
+weak.linter.unicodeLinter = false
 
 [[require]]
 name = "mathlib"


### PR DESCRIPTION
Unset just `linter.unicodeLinter` and re-enable the text-based linters. (I'd not realized these were individually configurable by lakefile option on the last toolchain bump.)

I'm hoping to make a Mathlib PR so that this can use our `.vscode/settings.json` automatically, see [this Zulip discussion](https://leanprover.zulipchat.com/#narrow/channel/287929-mathlib4/topic/Whitelist.20for.20Unicode.3F/near/586390499).