### PR TITLE
feat: recipe for logical fragments and multiplicative linear logic

### DIFF
--- a/Cslib.lean
+++ b/Cslib.lean
@@ -125,5 +125,6 @@ public import Cslib.Logics.HML.LogicalEquivalence
 public import Cslib.Logics.LinearLogic.CLL.Basic
 public import Cslib.Logics.LinearLogic.CLL.CutElimination
 public import Cslib.Logics.LinearLogic.CLL.EtaExpansion
+public import Cslib.Logics.LinearLogic.CLL.MLL
 public import Cslib.Logics.LinearLogic.CLL.PhaseSemantics.Basic
 public import Cslib.Logics.Propositional.Defs

--- a/Cslib/Logics/LinearLogic/CLL/Basic.lean
+++ b/Cslib/Logics/LinearLogic/CLL/Basic.lean
@@ -81,7 +81,7 @@ inductive Proposition.Context (Atom : Type u) : Type u where
 deriving DecidableEq, BEq
 
 /-- Replaces the hole in a propositional context with a propositions. -/
-@[scoped grind =]
+@[simp]
 def Proposition.Context.fill (c : Context Atom) (a : Proposition Atom) : Proposition Atom :=
   match c with
   | hole => a
@@ -143,8 +143,8 @@ def Proposition.dual : Proposition Atom → Proposition Atom
 theorem Proposition.top_eq_zero_dual : ⊤ = (0⫠ : Proposition Atom) := rfl
 
 /-- Duality preserves size. -/
-@[scoped grind _=_]
-theorem Proposition.dual_sizeOf (a : Proposition Atom) : sizeOf a = sizeOf a⫠ := by
+@[scoped grind =, simp]
+theorem Proposition.dual_sizeOf (a : Proposition Atom) : sizeOf a⫠ = sizeOf a := by
   induction a <;> simp [dual] <;> grind
 
 /-- No proposition is equal to its dual. -/
@@ -153,7 +153,7 @@ theorem Proposition.dual_neq (a : Proposition Atom) : a ≠ a⫠ := by
   cases a <;> simp [Proposition.dual]
 
 /-- Two propositions are equal iff their respective duals are equal. -/
-@[scoped grind =, simp]
+@[simp]
 theorem Proposition.dual_inj (a b : Proposition Atom) : a⫠ = b⫠ ↔ a = b := by
   refine ⟨fun h ↦ ?_, congrArg dual⟩
   induction a generalizing b <;> cases b <;> grind
@@ -227,24 +227,20 @@ def Proof.cut' (p : ⇓(a⫠ ::ₘ Γ)) (q : ⇓(a ::ₘ Δ)) : ⇓(Γ + Δ) :=
   p.cut r
 
 /-- Inversion of the ⅋ rule. -/
-@[scoped grind =]
 def Proof.parr_inversion {Γ : Sequent Atom} (h : ⇓((a ⅋ b) ::ₘ Γ)) : ⇓(a ::ₘ b ::ₘ Γ) :=
   show a ::ₘ b ::ₘ Γ = {a, b} + Γ by simp ▸
     cut' (show ({a, b} : Sequent Atom) = {a} + {b} by simp ▸ tensor ax' ax') h
 
 /-- Inversion of the ⊥ rule. -/
-@[scoped grind =]
 def Proof.bot_inversion {Γ : Sequent Atom} (h : ⇓(⊥ ::ₘ Γ)) : ⇓Γ := by
   convert Proof.cut' (a := ⊥) (Γ := {}) (Δ := Γ) Proof.one h
   simp
 
 /-- Inversion of the & rule, first component. -/
-@[scoped grind =]
 def Proof.with_inversion₁ {Γ : Sequent Atom} (h : ⇓((a & b) ::ₘ Γ)) : ⇓(a ::ₘ Γ) :=
   cut' (a := a & b) (oplus₁ ax') h
 
 /-- Inversion of the & rule, second component. -/
-@[scoped grind =]
 def Proof.with_inversion₂ {Γ : Sequent Atom} (h : ⇓((a & b) ::ₘ Γ)) : ⇓(b ::ₘ Γ) :=
   cut' (a := a & b) (oplus₂ ax') h
 
@@ -283,31 +279,31 @@ namespace Proposition
 open Sequent
 
 /-- Proof-relevant equivalence is reflexive. -/
-@[scoped grind =]
+@[refl]
 def equiv.refl (a : Proposition Atom) : a ≡⇓ a := ⟨Proof.ax', Proof.ax'⟩
 
 /-- Proof-relevant equivalence is symmetric. -/
-@[scoped grind =]
+@[symm]
 def equiv.symm (a : Proposition Atom) (h : a ≡⇓ b) : b ≡⇓ a := ⟨h.2, h.1⟩
 
 /-- Proof-relevant equivalence is transitive. -/
-@[scoped grind =]
 def equiv.trans {a b c : Proposition Atom} (hab : a ≡⇓ b) (hbc : b ≡⇓ c) : a ≡⇓ c :=
   ⟨(Multiset.pair_comm b (a⫠) ▸ hab.fst).cut hbc.fst,
    (Multiset.pair_comm b (c⫠) ▸ hbc.snd).cut hab.snd⟩
 
 /-- Proof-irrelevant equivalence is reflexive. -/
-@[refl, scoped grind .]
+@[refl]
 theorem Equiv.refl (a : Proposition Atom) : a ≡ a := equiv.refl a
 
 /-- Proof-irrelevant equivalence is symmetric. -/
-@[symm, scoped grind →]
+@[symm]
 theorem Equiv.symm {a b : Proposition Atom} (h : a ≡ b) : b ≡ a := ⟨h.2, h.1⟩
 
 /-- Proof-irrelevant equivalence is transitive. -/
-@[scoped grind →]
 theorem Equiv.trans {a b c : Proposition Atom} (hab : a ≡ b) (hbc : b ≡ c) : a ≡ c :=
   equiv.trans (chooseEquiv hab) (chooseEquiv hbc)
+
+scoped grind_pattern Equiv.trans => a ≡ b, b ≡ c
 
 /-- The canonical equivalence relation for propositions. -/
 def propositionSetoid : Setoid (Proposition Atom) :=
@@ -348,8 +344,7 @@ attribute [local grind =] Multiset.add_assoc
 attribute [local grind =] Multiset.insert_eq_cons
 
 open scoped Multiset in
-/-- ⊗ distributed over ⊕. -/
-@[scoped grind =]
+/-- ⊗ distributes over ⊕. -/
 def tensor_distrib_oplus (a b c : Proposition Atom) : a ⊗ (b ⊕ c) ≡⇓ (a ⊗ b) ⊕ (a ⊗ c) :=
   ⟨.parr <|
     .rwConclusion (Multiset.cons_swap ..) <|
@@ -655,7 +650,7 @@ instance : Congruence (Proposition Atom) Proposition.Equiv where
       Covariant (Proposition.Context Atom) (Proposition Atom) (Proposition.Context.fill)
       Proposition.Equiv := by
     intro ctx a b hab
-    induction ctx <;> grind
+    induction ctx <;> grind [= Context.fill]
 
 noncomputable instance : LogicalEquivalence (Proposition Atom) (Sequent Atom) Proof where
   eqv := Proposition.Equiv
@@ -665,7 +660,7 @@ noncomputable instance : LogicalEquivalence (Proposition Atom) (Sequent Atom) Pr
     apply subst_eqv_head (chooseEquiv heqv) h
 
 /-- Tensor is commutative. -/
-@[scoped grind =]
+@[scoped grind ←]
 def tensor_symm {a b : Proposition Atom} : a ⊗ b ≡⇓ b ⊗ a :=
   ⟨.parr <| show a⫠ ::ₘ b⫠ ::ₘ {b ⊗ a} = (b ⊗ a) ::ₘ {b⫠} + {a⫠} by grind ▸ .tensor .ax .ax,
    .parr <| show b⫠ ::ₘ a⫠ ::ₘ {a ⊗ b} = (a ⊗ b) ::ₘ {a⫠} + {b⫠} by grind ▸ .tensor .ax .ax⟩
@@ -673,7 +668,7 @@ def tensor_symm {a b : Proposition Atom} : a ⊗ b ≡⇓ b ⊗ a :=
 -- TODO: the precedence on ⊗ notation is wrong
 open scoped Multiset in
 /-- ⊗ is associative. -/
-@[scoped grind =]
+@[scoped grind ←]
 def tensor_assoc {a b c : Proposition Atom} : a ⊗ (b ⊗ c) ≡⇓ (a ⊗ b) ⊗ c :=
   ⟨.parr <|
      Multiset.cons_swap .. ▸
@@ -689,13 +684,13 @@ instance {Γ : Sequent Atom} : Std.Symm (fun a b => Derivable ((a ⊗ b) ::ₘ �
   symm _ _ h := Derivable.fromDerivation (subst_eqv_head tensor_symm (Derivable.toDerivation h))
 
 /-- ⊕ is idempotent. -/
-@[scoped grind =]
+@[scoped grind ←]
 def oplus_idem {a : Proposition Atom} : a ⊕ a ≡⇓ a :=
   ⟨.with .ax' .ax',
    show ({a⫠, a ⊕ a} : Sequent Atom) = {a ⊕ a, a⫠} by grind ▸ .oplus₁ .ax⟩
 
 /-- & is idempotent. -/
-@[scoped grind =]
+@[scoped grind ←]
 def with_idem {a : Proposition Atom} : a & a ≡⇓ a :=
   ⟨.oplus₁ .ax',
    show ({a⫠, a & a} : Sequent Atom) = {a & a, a⫠} by grind ▸ .with .ax .ax⟩

--- a/Cslib/Logics/LinearLogic/CLL/Basic.lean
+++ b/Cslib/Logics/LinearLogic/CLL/Basic.lean
@@ -26,13 +26,7 @@ public import Mathlib.Data.Multiset.Fold
 
 -/
 
-namespace Cslib
-
-universe u
-
-variable {Atom : Type u}
-
-namespace CLL
+namespace Cslib.Logic.CLL
 
 /-- Propositions. -/
 inductive Proposition (Atom : Type u) : Type u where
@@ -111,22 +105,12 @@ theorem Proposition.context_fill_def (c : Context Atom) (a : Proposition Atom) :
 
 /-- Positive propositions. -/
 def Proposition.positive : Proposition Atom → Bool
-  | atom _ => true
-  | one => true
-  | zero => true
-  | tensor _ _ => true
-  | oplus _ _ => true
-  | bang _ => true
+  | atom _ | one | zero | tensor _ _ | oplus _ _ | bang _ => true
   | _ => false
 
 /-- Negative propositions. -/
 def Proposition.negative : Proposition Atom → Bool
-  | atomDual _ => true
-  | bot => true
-  | top => true
-  | parr _ _ => true
-  | .with _ _ => true
-  | quest _ => true
+  | atomDual _ | bot | top | parr _ _ | .with _ _ | quest _ => true
   | _ => false
 
 /-- Whether a `Proposition` is positive is decidable. -/
@@ -720,6 +704,4 @@ end Proposition
 
 end LogicalEquiv
 
-end CLL
-
-end Cslib
+end Cslib.Logic.CLL

--- a/Cslib/Logics/LinearLogic/CLL/CutElimination.lean
+++ b/Cslib/Logics/LinearLogic/CLL/CutElimination.lean
@@ -10,13 +10,7 @@ public import Cslib.Logics.LinearLogic.CLL.Basic
 
 @[expose] public section
 
-namespace Cslib
-
-namespace CLL
-
-universe u
-
-variable {Atom : Type u}
+namespace Cslib.Logic.CLL
 
 open Cslib.Logic.InferenceSystem
 
@@ -53,6 +47,4 @@ cut. -/
 -/
 -- def Proof.cut_elim (p : ⇓Γ) : CutFreeProof Γ
 
-end CLL
-
-end Cslib
+end Cslib.Logic.CLL

--- a/Cslib/Logics/LinearLogic/CLL/EtaExpansion.lean
+++ b/Cslib/Logics/LinearLogic/CLL/EtaExpansion.lean
@@ -12,11 +12,7 @@ public import Cslib.Logics.LinearLogic.CLL.Basic
 
 /-! # η-expansion for Classical Linear Logic (CLL) -/
 
-namespace Cslib.CLL
-
-universe u
-
-variable {Atom : Type u}
+namespace Cslib.Logic.CLL
 
 attribute [local grind _=_] Multiset.coe_eq_coe
 attribute [local grind _=_] Multiset.cons_coe
@@ -137,4 +133,4 @@ theorem Proof.expand_onlyAtomicAxioms (a : Proposition Atom) : a.expand.onlyAtom
   | top | bot => simp [expand, onlyAtomicAxioms]
   | _ => grind
 
-end Cslib.CLL
+end Cslib.Logic.CLL

--- a/Cslib/Logics/LinearLogic/CLL/EtaExpansion.lean
+++ b/Cslib/Logics/LinearLogic/CLL/EtaExpansion.lean
@@ -25,7 +25,7 @@ open Cslib.Logic.InferenceSystem
 
 /-- The η-expansion of a proposition `a` is a `Proof` of `{a, a⫠}` that applies the axiom
 only to atomic propositions. -/
-@[scoped grind =]
+@[simp]
 def Proposition.expand (a : Proposition Atom) : ⇓({a, a⫠} : Sequent Atom):=
   match a with
   | atom x
@@ -114,7 +114,7 @@ private lemma Proof.expand_onlyAtomicAxioms_dual {a : Proposition Atom} :
     congr 1
     · grind
     · simp [dual, expand, rwConclusion, Logic.InferenceSystem.rwConclusion]
-  | _ => grind
+  | _ => grind [Proposition.expand, Proposition.dual_inj]
 
 open Proposition Proof in
 /-- η-expansion is correct: the proof returned by η-expansion contains only atomic axioms. -/
@@ -131,6 +131,6 @@ theorem Proof.expand_onlyAtomicAxioms (a : Proposition Atom) : a.expand.onlyAtom
     apply expand_onlyAtomicAxioms_dual
     simp [expand, onlyAtomicAxioms, dual]
   | top | bot => simp [expand, onlyAtomicAxioms]
-  | _ => grind
+  | _ => grind [Proposition.expand]
 
 end Cslib.Logic.CLL

--- a/Cslib/Logics/LinearLogic/CLL/MLL.lean
+++ b/Cslib/Logics/LinearLogic/CLL/MLL.lean
@@ -76,7 +76,6 @@ def Proposition.Context.IsMLL : Context Atom → Prop
 
 /-- Filling a multiplicative propositional context with a multiplicative proposition stays in MLL.
 -/
-@[scoped grind .]
 theorem Proposition.Context.isMLL_fill {c : CLL.Proposition.Context Atom} {a : CLL.Proposition Atom}
     (hc : c.IsMLL) : (c.fill a).IsMLL ↔ a.IsMLL := by induction c <;>
       grind only [Context.fill, Proposition.IsMLL, Proposition.Context.IsMLL]

--- a/Cslib/Logics/LinearLogic/CLL/MLL.lean
+++ b/Cslib/Logics/LinearLogic/CLL/MLL.lean
@@ -57,10 +57,8 @@ namespace Cslib.Logic.CLL
 @[simp]
 def Proposition.IsMLL : Proposition Atom → Prop
   | atom _ | atomDual _ | one | bot => True
-  | top | zero => False
   | tensor a b | parr a b => a.IsMLL ∧ b.IsMLL
-  | oplus _ _ | .with _ _ => False
-  | bang _ | quest _ => False
+  | _ => False
 
 /-- Duality in MLL stays in MLL. -/
 @[scoped grind →]

--- a/Cslib/Logics/LinearLogic/CLL/MLL.lean
+++ b/Cslib/Logics/LinearLogic/CLL/MLL.lean
@@ -124,9 +124,10 @@ abbrev Proposition.Context (Atom : Type u) := {c : CLL.Proposition.Context Atom 
 
 open scoped CLL.Proposition CLL.Proposition.Context in
 /-- Filling of an MLL propositional context. -/
-def Proposition.Context.fill (c : MLL.Proposition.Context Atom) (a : MLL.Proposition Atom) :
-    MLL.Proposition Atom :=
-  ⟨CLL.Proposition.Context.fill c a, (CLL.Proposition.Context.isMLL_fill c.property).2 a.property⟩
+def Proposition.Context.fill (c : Proposition.Context Atom) (a : Proposition Atom) :
+    Proposition Atom where
+  val := CLL.Proposition.Context.fill c a
+  property := (CLL.Proposition.Context.isMLL_fill c.property).mpr a.property
 
 /-- MLL sequents. -/
 abbrev Sequent (Atom : Type u) := {Γ : CLL.Sequent Atom // Γ.IsMLL}

--- a/Cslib/Logics/LinearLogic/CLL/MLL.lean
+++ b/Cslib/Logics/LinearLogic/CLL/MLL.lean
@@ -108,11 +108,8 @@ theorem Proof.isMLL_sequent {Γ : Sequent Atom} (p : ⇓Γ) (hp : p.IsMLL) : Γ.
     simp [Sequent.IsMLL, Proposition.IsMLL]
   case parr | tensor | cut => grind [Proposition.IsMLL, Proof.IsMLL]
   case bot Γ p ih =>
-    simp only [Proof.IsMLL] at hp
-    simp only [Sequent.IsMLL, Multiset.mem_cons, forall_eq_or_imp]
-    apply And.intro
-    · simp only [Proposition.IsMLL]
-    · grind only [Sequent.IsMLL]
+    simp
+    grind [Proof.IsMLL]
   case oplus₁ | oplus₂ | «with» | top | quest | weaken | contract | bang => contradiction
 
 end Cslib.Logic.CLL

--- a/Cslib/Logics/LinearLogic/CLL/MLL.lean
+++ b/Cslib/Logics/LinearLogic/CLL/MLL.lean
@@ -1,0 +1,89 @@
+/-
+Copyright (c) 2026 Fabrizio Montesi. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Fabrizio Montesi
+-/
+
+module
+
+public import Cslib.Logics.LinearLogic.CLL.Basic
+public import Cslib.Foundations.Logic.InferenceSystem
+
+@[expose] public section
+
+/-! # Multiplicative Classical Linear Logic -/
+
+namespace Cslib.CLL
+
+@[scoped grind =]
+def Proposition.IsMLL : Proposition Atom → Prop
+  | atom _ | atomDual _ | one | bot => True
+  | top | zero => False
+  | tensor a b | parr a b => a.IsMLL ∧ b.IsMLL
+  | oplus _ _ | .with _ _ => False
+  | bang _ | quest _ => False
+
+@[scoped grind →]
+theorem Proposition.isMLL_dual {a : Proposition Atom} (ha : a.IsMLL) : a⫠.IsMLL := by
+  induction a <;> grind
+
+@[scoped grind =]
+def Proposition.Context.IsMLL : Context Atom → Prop
+  | hole => True
+  | tensorL a b | tensorR a b | parrL a b | parrR a b => a.IsMLL ∧ b.IsMLL
+  | _ => False
+
+@[scoped grind .]
+theorem Proposition.Context.isMLL_fill {c : CLL.Proposition.Context Atom} {a : CLL.Proposition Atom}
+    (hc : c.IsMLL) : (c.fill a).IsMLL ↔ a.IsMLL := by induction c <;> grind
+
+@[scoped grind =]
+def Sequent.IsMLL (Γ : Sequent Atom) := ∀ a ∈ Γ, a.IsMLL
+
+open scoped Logic.InferenceSystem
+
+@[scoped grind =]
+def Proof.IsMLL {Γ : Sequent Atom} : ⇓Γ → Prop
+  | ax (a := a) => a.IsMLL
+  | cut p q | tensor p q => p.IsMLL ∧ q.IsMLL
+  | one => True
+  | bot p | parr p => p.IsMLL
+  | _ => False
+
+open scoped Sequent Proposition in
+theorem Proof.isMLL_sequent {Γ : Sequent Atom} (p : ⇓Γ) (hp : p.IsMLL) : Γ.IsMLL := by
+  -- This should be much simpler, gotta figure out how to make grind work.
+  induction p
+  case ax => grind [Multiset.insert_eq_cons, Multiset.mem_singleton]
+  case one =>
+    simp [Sequent.IsMLL]
+    simp [Proposition.IsMLL]
+  case parr | tensor | cut => grind
+  case bot Γ p ih =>
+    simp only [Proof.IsMLL] at hp
+    simp only [Sequent.IsMLL, Multiset.mem_cons, forall_eq_or_imp]
+    apply And.intro
+    · simp [Proposition.IsMLL]
+    · grind
+  case oplus₁ | oplus₂ | «with» | top | quest | weaken | contract | bang => contradiction
+
+end Cslib.CLL
+
+namespace Cslib.CLL.MLL
+
+abbrev Proposition (Atom : Type u) := {a : CLL.Proposition Atom // a.IsMLL}
+
+abbrev Proposition.Context (Atom : Type u) := {c : CLL.Proposition.Context Atom // c.IsMLL}
+
+open scoped CLL.Proposition CLL.Proposition.Context in
+def Proposition.Context.fill (c : MLL.Proposition.Context Atom) (a : MLL.Proposition Atom) :
+    MLL.Proposition Atom :=
+  ⟨CLL.Proposition.Context.fill c a, (CLL.Proposition.Context.isMLL_fill c.property).2 a.property⟩
+
+abbrev Sequent (Atom : Type u) := {Γ : CLL.Sequent Atom // Γ.IsMLL}
+
+abbrev Proof {Atom : Type u} (Γ : Sequent Atom) := {p : CLL.Proof (Atom := Atom) Γ // p.IsMLL}
+
+instance : Logic.InferenceSystem (Sequent Atom) := ⟨Proof⟩
+
+end Cslib.CLL.MLL

--- a/Cslib/Logics/LinearLogic/CLL/MLL.lean
+++ b/Cslib/Logics/LinearLogic/CLL/MLL.lean
@@ -63,7 +63,9 @@ def Proposition.IsMLL : Proposition Atom → Prop
 /-- Duality in MLL stays in MLL. -/
 @[scoped grind →]
 theorem Proposition.isMLL_dual {a : Proposition Atom} (ha : a.IsMLL) : a⫠.IsMLL := by
-  induction a <;> grind only [Proposition.dual, IsMLL]
+  induction a with
+  | atom | atomDual | one | bot | tensor | parr => grind [dual, IsMLL]
+  | _ => grind [IsMLL]
 
 /-- A multiplicative propositional context. -/
 @[simp]

--- a/Cslib/Logics/LinearLogic/CLL/MLL.lean
+++ b/Cslib/Logics/LinearLogic/CLL/MLL.lean
@@ -122,7 +122,6 @@ abbrev Proposition (Atom : Type u) := {a : CLL.Proposition Atom // a.IsMLL}
 /-- MLL propositional contexts. -/
 abbrev Proposition.Context (Atom : Type u) := {c : CLL.Proposition.Context Atom // c.IsMLL}
 
-open scoped CLL.Proposition CLL.Proposition.Context in
 /-- Filling of an MLL propositional context. -/
 def Proposition.Context.fill (c : Proposition.Context Atom) (a : Proposition Atom) :
     Proposition Atom where

--- a/Cslib/Logics/LinearLogic/CLL/MLL.lean
+++ b/Cslib/Logics/LinearLogic/CLL/MLL.lean
@@ -11,11 +11,50 @@ public import Cslib.Foundations.Logic.InferenceSystem
 
 @[expose] public section
 
-/-! # Multiplicative Classical Linear Logic -/
+/-! # Multiplicative Classical Linear Logic (MLL)
 
-namespace Cslib.CLL
+Multiplicative classical linear logic, defined as a fragment of classical linear logic by means of
+`Subtype`.
 
-@[scoped grind =]
+This file also serves as the reference example of how to define a fragment of an inference system
+through `Subtype`, following the next recipe.
+
+1. Define predicates for restricting relevant types to the fragment, here `IsMLL` for propositions
+(`CLL.Proposition`) and proofs (`CLL.Proof`). This part lives under the namespace of the original
+system (here `Cslib.Logic.CLL`).
+2. Define the types in the fragment -- here `MLL.Proposition` and `MLL.Proof` -- as abbreviations of
+subtypes. This part lives under the namespace of the fragment (here `Cslib.Logic.MLL`).
+
+We also call the first part the 'unbundled part' and the second the 'bundled part'.
+
+This recipe has the advantage that any value (propositions, proofs, etc.) in the fragment is
+coerciable into the original system for free through `Subtype`.
+
+The main disadvantage is that the fragment does not have its own inductives, so case analysis
+requires carrying around the restricting predicate(s) as parameters to discharge irrelevant cases
+from the original system.
+This can be elegantly managed by unbundling the predicate right away, so that `match` (or similar)
+can automatically eliminate irrelevant cases.
+For example, the following definition checks that an MLL proof is cut-free:
+
+```
+/-- A proof is cut-free if it does not contain any applications of rule cut. -/
+def Proof.cutFree {Γ : Sequent Atom} (p : ⇓Γ) : Bool :=
+  go p.val p.property
+where go {Γ : CLL.Sequent Atom} (p : ⇓Γ) (hp : p.IsMLL) : Bool :=
+  match p, hp with
+  | .ax, _ => true
+  | .bot p, hp | .parr p, hp => go p hp
+  | .one, _ => true
+  | .cut _ _, _ => false
+  | .tensor p q, hp => go p hp.left && go q hp.right
+```
+-/
+
+namespace Cslib.Logic.CLL
+
+/-- A proposition is in the multiplicative fragment of CLL. -/
+@[simp]
 def Proposition.IsMLL : Proposition Atom → Prop
   | atom _ | atomDual _ | one | bot => True
   | top | zero => False
@@ -23,26 +62,33 @@ def Proposition.IsMLL : Proposition Atom → Prop
   | oplus _ _ | .with _ _ => False
   | bang _ | quest _ => False
 
+/-- Duality in MLL stays in MLL. -/
 @[scoped grind →]
 theorem Proposition.isMLL_dual {a : Proposition Atom} (ha : a.IsMLL) : a⫠.IsMLL := by
-  induction a <;> grind
+  induction a <;> grind only [Proposition.dual, IsMLL]
 
-@[scoped grind =]
+/-- A multiplicative propositional context. -/
+@[simp]
 def Proposition.Context.IsMLL : Context Atom → Prop
   | hole => True
   | tensorL a b | tensorR a b | parrL a b | parrR a b => a.IsMLL ∧ b.IsMLL
   | _ => False
 
+/-- Filling a multiplicative propositional context with a multiplicative proposition stays in MLL.
+-/
 @[scoped grind .]
 theorem Proposition.Context.isMLL_fill {c : CLL.Proposition.Context Atom} {a : CLL.Proposition Atom}
-    (hc : c.IsMLL) : (c.fill a).IsMLL ↔ a.IsMLL := by induction c <;> grind
+    (hc : c.IsMLL) : (c.fill a).IsMLL ↔ a.IsMLL := by induction c <;>
+      grind only [Context.fill, Proposition.IsMLL, Proposition.Context.IsMLL]
 
-@[scoped grind =]
+/-- A multiplicative sequent. -/
+@[scoped grind =, simp]
 def Sequent.IsMLL (Γ : Sequent Atom) := ∀ a ∈ Γ, a.IsMLL
 
 open scoped Logic.InferenceSystem
 
-@[scoped grind =]
+/-- A proof is in MLL. -/
+@[simp]
 def Proof.IsMLL {Γ : Sequent Atom} : ⇓Γ → Prop
   | ax (a := a) => a.IsMLL
   | cut p q | tensor p q => p.IsMLL ∧ q.IsMLL
@@ -51,39 +97,48 @@ def Proof.IsMLL {Γ : Sequent Atom} : ⇓Γ → Prop
   | _ => False
 
 open scoped Sequent Proposition in
+/-- An MLL proof can only prove MLL sequents. -/
 theorem Proof.isMLL_sequent {Γ : Sequent Atom} (p : ⇓Γ) (hp : p.IsMLL) : Γ.IsMLL := by
-  -- This should be much simpler, gotta figure out how to make grind work.
+  -- This should be simpler, grind seems to have some trouble.
   induction p
-  case ax => grind [Multiset.insert_eq_cons, Multiset.mem_singleton]
+  case ax =>
+    grind [Proof.IsMLL, Multiset.insert_eq_cons, Multiset.mem_singleton]
   case one =>
-    simp [Sequent.IsMLL]
-    simp [Proposition.IsMLL]
-  case parr | tensor | cut => grind
+    simp [Sequent.IsMLL, Proposition.IsMLL]
+  case parr | tensor | cut => grind [Proposition.IsMLL, Proof.IsMLL]
   case bot Γ p ih =>
     simp only [Proof.IsMLL] at hp
     simp only [Sequent.IsMLL, Multiset.mem_cons, forall_eq_or_imp]
     apply And.intro
-    · simp [Proposition.IsMLL]
-    · grind
+    · simp only [Proposition.IsMLL]
+    · grind only [Sequent.IsMLL]
   case oplus₁ | oplus₂ | «with» | top | quest | weaken | contract | bang => contradiction
 
-end Cslib.CLL
+end Cslib.Logic.CLL
 
-namespace Cslib.CLL.MLL
+namespace Cslib.Logic.MLL
 
+/-- MLL propositions. -/
 abbrev Proposition (Atom : Type u) := {a : CLL.Proposition Atom // a.IsMLL}
 
+/-- MLL propositional contexts. -/
 abbrev Proposition.Context (Atom : Type u) := {c : CLL.Proposition.Context Atom // c.IsMLL}
 
 open scoped CLL.Proposition CLL.Proposition.Context in
+/-- Filling of an MLL propositional context. -/
 def Proposition.Context.fill (c : MLL.Proposition.Context Atom) (a : MLL.Proposition Atom) :
     MLL.Proposition Atom :=
   ⟨CLL.Proposition.Context.fill c a, (CLL.Proposition.Context.isMLL_fill c.property).2 a.property⟩
 
+/-- MLL sequents. -/
 abbrev Sequent (Atom : Type u) := {Γ : CLL.Sequent Atom // Γ.IsMLL}
 
+/-- MLL derivations. -/
 abbrev Proof {Atom : Type u} (Γ : Sequent Atom) := {p : CLL.Proof (Atom := Atom) Γ // p.IsMLL}
 
+/-- The sequent calculus of MLL. -/
 instance : Logic.InferenceSystem (Sequent Atom) := ⟨Proof⟩
 
-end Cslib.CLL.MLL
+open scoped Logic.InferenceSystem
+
+end Cslib.Logic.MLL

--- a/Cslib/Logics/LinearLogic/CLL/MLL.lean
+++ b/Cslib/Logics/LinearLogic/CLL/MLL.lean
@@ -138,6 +138,4 @@ abbrev Proof {Atom : Type u} (Γ : Sequent Atom) := {p : CLL.Proof (Atom := Atom
 /-- The sequent calculus of MLL. -/
 instance : Logic.InferenceSystem (Sequent Atom) := ⟨Proof⟩
 
-open scoped Logic.InferenceSystem
-
 end Cslib.Logic.MLL

--- a/Cslib/Logics/LinearLogic/CLL/MLL.lean
+++ b/Cslib/Logics/LinearLogic/CLL/MLL.lean
@@ -77,8 +77,11 @@ def Proposition.Context.IsMLL : Context Atom → Prop
 /-- Filling a multiplicative propositional context with a multiplicative proposition stays in MLL.
 -/
 theorem Proposition.Context.isMLL_fill {c : CLL.Proposition.Context Atom} {a : CLL.Proposition Atom}
-    (hc : c.IsMLL) : (c.fill a).IsMLL ↔ a.IsMLL := by induction c <;>
-      grind only [Context.fill, Proposition.IsMLL, Proposition.Context.IsMLL]
+    (hc : c.IsMLL) : (c.fill a).IsMLL ↔ a.IsMLL := by
+  induction c with
+  | hole => grind [fill]
+  | tensorL | tensorR | parrL | parrR => grind [fill, IsMLL, Proposition.IsMLL]
+  | _ => grind [IsMLL]
 
 /-- A multiplicative sequent. -/
 @[scoped grind =, simp]

--- a/Cslib/Logics/LinearLogic/CLL/MLL.lean
+++ b/Cslib/Logics/LinearLogic/CLL/MLL.lean
@@ -92,10 +92,9 @@ open scoped Logic.InferenceSystem
 /-- A proof is in MLL. -/
 @[simp]
 def Proof.IsMLL {Γ : Sequent Atom} : ⇓Γ → Prop
-  | ax (a := a) => a.IsMLL
+  | ax (a := a) | bot a | parr a => a.IsMLL
   | cut p q | tensor p q => p.IsMLL ∧ q.IsMLL
   | one => True
-  | bot p | parr p => p.IsMLL
   | _ => False
 
 open scoped Sequent Proposition in

--- a/Cslib/Logics/LinearLogic/CLL/PhaseSemantics/Basic.lean
+++ b/Cslib/Logics/LinearLogic/CLL/PhaseSemantics/Basic.lean
@@ -54,11 +54,9 @@ Several lemmas about facts and orthogonality useful in the proof of soundness ar
 * [J.-Y. Girard, *Linear Logic: its syntax and semantics*][Girard1995]
 -/
 
-namespace Cslib
+namespace Cslib.Logic.CLL
 
 universe u v
-
-namespace CLL
 
 open scoped Pointwise
 open Set
@@ -705,6 +703,4 @@ def interpProp [PhaseSpace M] (v : Atom → Fact M) : Proposition Atom → Fact 
 
 end PhaseSpace
 
-end CLL
-
-end Cslib
+end Cslib.Logic.CLL

--- a/CslibTests/CLL.lean
+++ b/CslibTests/CLL.lean
@@ -13,7 +13,7 @@ namespace CslibTests
 I use `Proposition Nat` as the concrete instantiation for atoms.
 -/
 
-open Cslib.CLL
+open Cslib.Logic.CLL
 
 /-! ## Proposition construction tests -/
 

--- a/CslibTests/GrindLint.lean
+++ b/CslibTests/GrindLint.lean
@@ -47,16 +47,6 @@ open_scoped_all Cslib
 #grind_lint skip Cslib.Automata.NA.Buchi.reindex_language_eq
 #grind_lint skip Cslib.Automata.NA.FinAcc.toDAFinAcc_language_eq
 #grind_lint skip Cslib.Automata.εNA.FinAcc.toNAFinAcc_language_eq
-#grind_lint skip Cslib.CLL.Proof.parr_inversion.eq_1
-#grind_lint skip Cslib.CLL.Proof.with_inversion₁.eq_1
-#grind_lint skip Cslib.CLL.Proof.with_inversion₂.eq_1
-#grind_lint skip Cslib.CLL.Proposition.Equiv.trans
-#grind_lint skip Cslib.CLL.Proposition.bang_top_eqv_one.eq_1
-#grind_lint skip Cslib.CLL.Proposition.expand.eq_10
-#grind_lint skip Cslib.CLL.Proposition.parr_top_eqv_top.eq_1
-#grind_lint skip Cslib.CLL.Proposition.tensor_assoc.eq_1
-#grind_lint skip Cslib.CLL.Proposition.tensor_distrib_oplus.eq_1
-#grind_lint skip Cslib.CLL.Proposition.tensor_symm.eq_1
 #grind_lint skip Cslib.LambdaCalculus.LocallyNameless.Fsub.Sub.arrow
 #grind_lint skip Cslib.LambdaCalculus.LocallyNameless.Fsub.Sub.sum
 #grind_lint skip Cslib.LambdaCalculus.LocallyNameless.Fsub.Sub.trans_tvar


### PR DESCRIPTION
This PR:
- Adds multiplicative linear logic (MLL) as an example of how a fragment can be derived from a larger inference system (CLL), using Subtype and local recursive functions to eliminate irrelevant cases (see the example in the docstring).
- Puts CLL under the right `Cslib.Logic` namespace.
- Shortens a few simple definitions for CLL in the expected way.