### PR TITLE
chore: conform to header linter

### DIFF
--- a/Cslib/Algorithms/Lean/MergeSort/MergeSort.lean
+++ b/Cslib/Algorithms/Lean/MergeSort/MergeSort.lean
@@ -11,8 +11,6 @@ public import Mathlib.Data.Nat.Cast.Order.Ring
 public import Mathlib.Data.Nat.Lattice
 public import Mathlib.Data.Nat.Log
 
-@[expose] public section
-
 /-!
 # MergeSort on a list
 
@@ -26,6 +24,8 @@ over the list `TimeM ℕ (List α)`. The time complexity of `mergeSort` is the n
 - `mergeSort_time`:  The number of comparisons of `mergeSort` is at most `n*⌈log₂ n⌉`.
 
 -/
+
+@[expose] public section
 
 set_option autoImplicit false
 

--- a/Cslib/Algorithms/Lean/TimeM.lean
+++ b/Cslib/Algorithms/Lean/TimeM.lean
@@ -9,9 +9,6 @@ module
 public import Cslib.Init
 public import Mathlib.Algebra.Group.Defs
 
-
-@[expose] public section
-
 /-!
 
 # TimeM: Time Complexity Monad
@@ -40,6 +37,9 @@ actual wall time, or as more complex types in order to model more general costs.
 
 See [Danielsson2008] for the discussion.
 -/
+
+@[expose] public section
+
 namespace Cslib.Algorithms.Lean
 
 /-- A monad for tracking time complexity of computations.

--- a/Cslib/Computability/Automata/Acceptors/Acceptor.lean
+++ b/Cslib/Computability/Automata/Acceptors/Acceptor.lean
@@ -9,6 +9,8 @@ module
 public import Cslib.Init
 public import Mathlib.Computability.Language
 
+/-! -/
+
 @[expose] public section
 
 namespace Cslib.Automata

--- a/Cslib/Computability/Automata/Acceptors/OmegaAcceptor.lean
+++ b/Cslib/Computability/Automata/Acceptors/OmegaAcceptor.lean
@@ -8,6 +8,8 @@ module
 
 public import Cslib.Computability.Languages.OmegaLanguage
 
+/-! -/
+
 @[expose] public section
 
 namespace Cslib.Automata

--- a/Cslib/Computability/Automata/DA/Basic.lean
+++ b/Cslib/Computability/Automata/DA/Basic.lean
@@ -11,8 +11,6 @@ public import Cslib.Computability.Automata.Acceptors.OmegaAcceptor
 public import Cslib.Foundations.Data.OmegaSequence.InfOcc
 public import Cslib.Foundations.Semantics.FLTS.Basic
 
-@[expose] public section
-
 /-! # Deterministic Automata
 
 A Deterministic Automaton (`DA`) is an automaton defined by a transition function equipped with an
@@ -27,6 +25,8 @@ finiteness assumptions), deterministic Buchi automata, and deterministic Muller 
 * [J. E. Hopcroft, R. Motwani, J. D. Ullman,
   *Introduction to Automata Theory, Languages, and Computation*][Hopcroft2006]
 -/
+
+@[expose] public section
 
 open List Filter Cslib.ωSequence
 open scoped Cslib.FLTS

--- a/Cslib/Computability/Automata/DA/Buchi.lean
+++ b/Cslib/Computability/Automata/DA/Buchi.lean
@@ -8,12 +8,10 @@ module
 
 public import Cslib.Computability.Automata.DA.Basic
 
-public section
-
 /-! # Deterministic Buchi automata.
 -/
 
-open Filter
+public section
 
 namespace Cslib.Automata.DA
 

--- a/Cslib/Computability/Automata/DA/Congr.lean
+++ b/Cslib/Computability/Automata/DA/Congr.lean
@@ -9,9 +9,9 @@ module
 public import Cslib.Computability.Automata.DA.Basic
 public import Cslib.Computability.Languages.Congruences.RightCongruence
 
-@[expose] public section
-
 /-! # Deterministic automaton corresponding to a right congruence. -/
+
+@[expose] public section
 
 namespace Cslib
 

--- a/Cslib/Computability/Automata/DA/Prod.lean
+++ b/Cslib/Computability/Automata/DA/Prod.lean
@@ -9,9 +9,9 @@ module
 public import Cslib.Computability.Automata.DA.Basic
 public import Cslib.Foundations.Semantics.FLTS.Prod
 
-@[expose] public section
-
 /-! # Product of deterministic automata. -/
+
+@[expose] public section
 
 namespace Cslib.Automata
 

--- a/Cslib/Computability/Automata/DA/ToNA.lean
+++ b/Cslib/Computability/Automata/DA/ToNA.lean
@@ -10,11 +10,11 @@ public import Cslib.Computability.Automata.DA.Basic
 public import Cslib.Computability.Automata.NA.Basic
 public import Cslib.Foundations.Semantics.FLTS.FLTSToLTS
 
-@[expose] public section
-
 /-! # Translation of Deterministic Automata into Nonodeterministic Automata.
 
 This is the general version of the standard translation of DFAs into NFAs. -/
+
+@[expose] public section
 
 namespace Cslib.Automata.DA
 

--- a/Cslib/Computability/Automata/EpsilonNA/Basic.lean
+++ b/Cslib/Computability/Automata/EpsilonNA/Basic.lean
@@ -9,9 +9,9 @@ module
 public import Cslib.Computability.Automata.NA.Basic
 public import Cslib.Foundations.Semantics.LTS.HasTau
 
-@[expose] public section
-
 /-! # Nondeterministic automata with ε-transitions. -/
+
+@[expose] public section
 
 namespace Cslib.Automata
 

--- a/Cslib/Computability/Automata/EpsilonNA/ToNA.lean
+++ b/Cslib/Computability/Automata/EpsilonNA/ToNA.lean
@@ -8,9 +8,9 @@ module
 
 public import Cslib.Computability.Automata.EpsilonNA.Basic
 
-@[expose] public section
-
 /-! # Translation of εNA into NA -/
+
+@[expose] public section
 
 namespace Cslib
 

--- a/Cslib/Computability/Automata/NA/Basic.lean
+++ b/Cslib/Computability/Automata/NA/Basic.lean
@@ -1,7 +1,7 @@
 /-
 Copyright (c) 2025 Fabrizio Montesi. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
-Authors: Fabrizio Montesi, Ching-Tsun Chou, Chris Henson.
+Authors: Fabrizio Montesi, Ching-Tsun Chou, Chris Henson
 -/
 
 module
@@ -10,8 +10,6 @@ public import Cslib.Computability.Automata.Acceptors.Acceptor
 public import Cslib.Computability.Automata.Acceptors.OmegaAcceptor
 public import Cslib.Foundations.Data.OmegaSequence.InfOcc
 public import Cslib.Foundations.Semantics.LTS.OmegaExecution
-
-@[expose] public section
 
 /-! # Nondeterministic Automaton
 
@@ -30,6 +28,8 @@ type `State → Symbol → Set State`; it gets automatically expanded to the for
 * [J. E. Hopcroft, R. Motwani, J. D. Ullman,
   *Introduction to Automata Theory, Languages, and Computation*][Hopcroft2006]
 -/
+
+@[expose] public section
 
 open Filter
 

--- a/Cslib/Computability/Automata/NA/BuchiEquiv.lean
+++ b/Cslib/Computability/Automata/NA/BuchiEquiv.lean
@@ -1,6 +1,6 @@
 /-
 Copyright (c) 2025 Ching-Tsun Chou. All rights reserved.
-Relexsed under Apache 2.0 license xs described in the file LICENSE.
+Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Ching-Tsun Chou
 -/
 
@@ -8,9 +8,9 @@ module
 
 public import Cslib.Computability.Automata.NA.Basic
 
-@[expose] public section
-
 /-! # Equivalence of nondeterministic Buchi automata (NBAs). -/
+
+@[expose] public section
 
 universe u v w
 

--- a/Cslib/Computability/Automata/NA/BuchiInter.lean
+++ b/Cslib/Computability/Automata/NA/BuchiInter.lean
@@ -10,8 +10,6 @@ public import Cslib.Computability.Automata.NA.Hist
 public import Cslib.Computability.Automata.NA.Prod
 public import Cslib.Foundations.Data.OmegaSequence.Temporal
 
-@[expose] public section
-
 /-! # Intersection of nondeterministic Buchi automata.
 
 The intersection automaton consists of the product of the two automata to be intersected
@@ -23,6 +21,8 @@ The intersection automaton accepts iff the toggling happens infinitely many time
 The two automata to be intersected are indexed by the type `Bool`.  We choose `Bool`
 simply because toggling can be easily modeled by the boolean operation `not`.
 -/
+
+@[expose] public section
 
 namespace Cslib.Automata.NA.Buchi
 

--- a/Cslib/Computability/Automata/NA/Concat.lean
+++ b/Cslib/Computability/Automata/NA/Concat.lean
@@ -9,9 +9,9 @@ module
 public import Cslib.Computability.Automata.NA.Total
 public import Cslib.Foundations.Data.OmegaSequence.Temporal
 
-@[expose] public section
-
 /-! # Concatenation of nondeterministic automata. -/
+
+@[expose] public section
 
 namespace Cslib.Automata.NA
 

--- a/Cslib/Computability/Automata/NA/Hist.lean
+++ b/Cslib/Computability/Automata/NA/Hist.lean
@@ -8,13 +8,13 @@ module
 
 public import Cslib.Computability.Automata.NA.Basic
 
-@[expose] public section
-
 /-! # Adding a history states to a nondeterministic automaton.
 
 The evolution of the history state can depend on both the original state and the past history
 state. But the evolution of the original state is not constrained by the history state.
 -/
+
+@[expose] public section
 
 namespace Cslib.Automata.NA
 

--- a/Cslib/Computability/Automata/NA/Loop.lean
+++ b/Cslib/Computability/Automata/NA/Loop.lean
@@ -9,9 +9,9 @@ module
 public import Cslib.Computability.Automata.NA.Total
 public import Cslib.Foundations.Data.OmegaSequence.Temporal
 
-@[expose] public section
-
 /-! # Loop construction on nondeterministic automata. -/
+
+@[expose] public section
 
 namespace Cslib.Automata.NA
 

--- a/Cslib/Computability/Automata/NA/Pair.lean
+++ b/Cslib/Computability/Automata/NA/Pair.lean
@@ -8,10 +8,10 @@ module
 
 public import Cslib.Computability.Languages.RegularLanguage
 
-@[expose] public section
-
 /-! # Languages determined by pairs of states
 -/
+
+@[expose] public section
 
 namespace Cslib
 

--- a/Cslib/Computability/Automata/NA/Prod.lean
+++ b/Cslib/Computability/Automata/NA/Prod.lean
@@ -8,9 +8,9 @@ module
 
 public import Cslib.Computability.Automata.NA.Basic
 
-@[expose] public section
-
 /-! # Product of nondeterministic automata. -/
+
+@[expose] public section
 
 namespace Cslib.Automata.NA
 

--- a/Cslib/Computability/Automata/NA/Sum.lean
+++ b/Cslib/Computability/Automata/NA/Sum.lean
@@ -1,6 +1,6 @@
 /-
 Copyright (c) 2025 Ching-Tsun Chou. All rights reserved.
-Relexsed under Apache 2.0 license xs described in the file LICENSE.
+Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Ching-Tsun Chou
 -/
 
@@ -8,9 +8,9 @@ module
 
 public import Cslib.Computability.Automata.NA.Basic
 
-@[expose] public section
-
 /-! # Sum of nondeterministic automata. -/
+
+@[expose] public section
 
 namespace Cslib.Automata.NA
 

--- a/Cslib/Computability/Automata/NA/ToDA.lean
+++ b/Cslib/Computability/Automata/NA/ToDA.lean
@@ -10,12 +10,12 @@ public import Cslib.Computability.Automata.DA.Basic
 public import Cslib.Computability.Automata.NA.Basic
 public import Cslib.Foundations.Semantics.FLTS.LTSToFLTS
 
-@[expose] public section
-
 /-! # Translation of Nondeterministic Automata for finite strings into Deterministic Automata
 
 This file implements the standard subset construction.
 -/
+
+@[expose] public section
 
 namespace Cslib.Automata.NA
 

--- a/Cslib/Computability/Automata/NA/Total.lean
+++ b/Cslib/Computability/Automata/NA/Total.lean
@@ -9,10 +9,10 @@ module
 public import Cslib.Computability.Automata.NA.Basic
 public import Cslib.Foundations.Semantics.LTS.Total
 
-@[expose] public section
-
 /-! # Making a nondeterministic automaton total.
 -/
+
+@[expose] public section
 
 namespace Cslib.Automata.NA
 

--- a/Cslib/Computability/Languages/Congruences/BuchiCongruence.lean
+++ b/Cslib/Computability/Languages/Congruences/BuchiCongruence.lean
@@ -10,14 +10,14 @@ public import Cslib.Computability.Automata.NA.Pair
 public import Cslib.Foundations.Combinatorics.InfiniteGraphRamsey
 public import Cslib.Foundations.Data.Set.Saturation
 
-@[expose] public section
-
 /-!
 # Buchi Congruence
 
 A special type of right congruences used by J.R. Büchi to prove the closure
 of ω-regular languages under complementation.
 -/
+
+@[expose] public section
 
 namespace Cslib.Automata.NA.Buchi
 

--- a/Cslib/Computability/Languages/Congruences/RightCongruence.lean
+++ b/Cslib/Computability/Languages/Congruences/RightCongruence.lean
@@ -9,8 +9,6 @@ module
 public import Cslib.Init
 public import Mathlib.Computability.Language
 
-@[expose] public section
-
 /-!
 # Right Congruence
 
@@ -19,6 +17,8 @@ This file contains basic definitions about right congruences on finite sequences
 NOTE: Left congruences and two-sided congruences can be similarly defined.
 But they are left to future work because they are not needed for now.
 -/
+
+@[expose] public section
 
 namespace Cslib
 

--- a/Cslib/Computability/Languages/ExampleEventuallyZero.lean
+++ b/Cslib/Computability/Languages/ExampleEventuallyZero.lean
@@ -8,8 +8,6 @@ module
 
 public import Cslib.Computability.Automata.NA.Basic
 
-@[expose] public section
-
 /-!
 # An ω-regular language that is not accepted by any deterministic Buchi automaton
 
@@ -18,6 +16,8 @@ This example is adapted from Example 4.2 of [Thomas1990].
 ## References
 * [W. Thomas, "Automata on infinite objects"][Thomas1990]
 -/
+
+@[expose] public section
 
 open Set Function Filter Cslib.ωSequence Cslib.Automata ωAcceptor
 open scoped Computability

--- a/Cslib/Computability/Languages/Language.lean
+++ b/Cslib/Computability/Languages/Language.lean
@@ -9,14 +9,14 @@ module
 public import Cslib.Init
 public import Mathlib.Computability.Language
 
-@[expose] public section
-
 /-!
 # Language (additional definitions and theorems)
 
 This file contains additional definitions and theorems about `Language`
 as defined and developed in `Mathlib.Computability.Language`.
 -/
+
+@[expose] public section
 
 namespace Language
 

--- a/Cslib/Computability/Languages/OmegaLanguage.lean
+++ b/Cslib/Computability/Languages/OmegaLanguage.lean
@@ -12,8 +12,6 @@ public import Mathlib.Computability.Language
 public import Mathlib.Order.CompleteBooleanAlgebra
 public import Mathlib.Order.Filter.AtTopBot.Defs
 
-@[expose] public section
-
 /-!
 # ωLanguage
 
@@ -55,6 +53,8 @@ denote languages (namely, sets of finite sequences of type `List α`).
 
 * Prove more theorems about omegaLim and map.
 -/
+
+@[expose] public section
 
 variable {α β γ : Type*}
 

--- a/Cslib/Computability/Languages/OmegaRegularLanguage.lean
+++ b/Cslib/Computability/Languages/OmegaRegularLanguage.lean
@@ -16,13 +16,13 @@ public import Mathlib.Data.Finite.Card
 public import Mathlib.Data.Finite.Sigma
 public import Mathlib.Logic.Equiv.Fin.Basic
 
-@[expose] public section
-
 /-!
 # ω-Regular languages
 
 This file defines ω-regular languages and proves some properties of them.
 -/
+
+@[expose] public section
 
 namespace Cslib.ωLanguage
 

--- a/Cslib/Computability/Languages/RegularLanguage.lean
+++ b/Cslib/Computability/Languages/RegularLanguage.lean
@@ -16,11 +16,11 @@ public import Mathlib.Computability.DFA
 public import Mathlib.Data.Finite.Sum
 public import Mathlib.Data.Set.Card
 
-@[expose] public section
-
 /-!
 # Regular languages
 -/
+
+@[expose] public section
 
 namespace Cslib.Language
 

--- a/Cslib/Computability/Machines/SingleTapeTuring/Basic.lean
+++ b/Cslib/Computability/Machines/SingleTapeTuring/Basic.lean
@@ -10,8 +10,6 @@ public import Cslib.Foundations.Data.BiTape
 public import Cslib.Foundations.Data.RelatesInSteps
 public import Mathlib.Algebra.Polynomial.Eval.Defs
 
-@[expose] public section
-
 /-!
 # Single-Tape Turing Machines
 
@@ -61,6 +59,8 @@ We also provide ways of constructing polynomial-runtime TMs
 - Add `∘` notation for `compComputer`.
 
 -/
+
+@[expose] public section
 
 open Cslib Relation
 

--- a/Cslib/Crypto/Protocols/PerfectSecrecy/Basic.lean
+++ b/Cslib/Crypto/Protocols/PerfectSecrecy/Basic.lean
@@ -9,8 +9,6 @@ module
 public import Cslib.Crypto.Protocols.PerfectSecrecy.Defs
 public import Cslib.Crypto.Protocols.PerfectSecrecy.Internal.PerfectSecrecy
 
-@[expose] public section
-
 /-!
 # Perfect Secrecy
 
@@ -28,6 +26,8 @@ Characterisation theorems for perfect secrecy following
 
 * [J. Katz, Y. Lindell, *Introduction to Modern Cryptography*][KatzLindell2020]
 -/
+
+@[expose] public section
 
 namespace Cslib.Crypto.Protocols.PerfectSecrecy.EncScheme
 

--- a/Cslib/Crypto/Protocols/PerfectSecrecy/Defs.lean
+++ b/Cslib/Crypto/Protocols/PerfectSecrecy/Defs.lean
@@ -10,8 +10,6 @@ public import Cslib.Crypto.Protocols.PerfectSecrecy.Encryption
 public import Cslib.Crypto.Protocols.PerfectSecrecy.PMFUtilities
 public import Mathlib.Probability.ProbabilityMassFunction.Constructions
 
-@[expose] public section
-
 /-!
 # Perfect Secrecy: Definitions
 
@@ -32,6 +30,8 @@ Core definitions for perfect secrecy following [KatzLindell2020], Chapter 2.
 - `Cslib.Crypto.Protocols.PerfectSecrecy.EncScheme.CiphertextIndist`:
   ciphertext indistinguishability ([KatzLindell2020], Lemma 2.5)
 -/
+
+@[expose] public section
 
 namespace Cslib.Crypto.Protocols.PerfectSecrecy.EncScheme
 

--- a/Cslib/Crypto/Protocols/PerfectSecrecy/Encryption.lean
+++ b/Cslib/Crypto/Protocols/PerfectSecrecy/Encryption.lean
@@ -9,8 +9,6 @@ module
 public import Cslib.Init
 public import Mathlib.Probability.ProbabilityMassFunction.Monad
 
-@[expose] public section
-
 /-!
 # Private-Key Encryption Schemes (Information-Theoretic)
 
@@ -28,6 +26,8 @@ constraints.
 
 * [J. Katz, Y. Lindell, *Introduction to Modern Cryptography*][KatzLindell2020]
 -/
+
+@[expose] public section
 
 namespace Cslib.Crypto.Protocols.PerfectSecrecy
 

--- a/Cslib/Crypto/Protocols/PerfectSecrecy/Internal/OneTimePad.lean
+++ b/Cslib/Crypto/Protocols/PerfectSecrecy/Internal/OneTimePad.lean
@@ -9,13 +9,13 @@ module
 public import Cslib.Init
 public import Mathlib.Probability.Distributions.Uniform
 
-@[expose] public section
-
 /-!
 # One-Time Pad: Internal proofs
 
 The OTP ciphertext distribution is uniform regardless of message.
 -/
+
+@[expose] public section
 
 namespace Cslib.Crypto.Protocols.PerfectSecrecy.OTP
 

--- a/Cslib/Crypto/Protocols/PerfectSecrecy/Internal/PerfectSecrecy.lean
+++ b/Cslib/Crypto/Protocols/PerfectSecrecy/Internal/PerfectSecrecy.lean
@@ -9,8 +9,6 @@ module
 public import Cslib.Crypto.Protocols.PerfectSecrecy.Defs
 public import Mathlib.Probability.Distributions.Uniform
 
-@[expose] public section
-
 /-!
 # Perfect Secrecy: Internal proofs
 
@@ -20,6 +18,8 @@ Auxiliary lemmas for perfect secrecy:
   ([KatzLindell2020], Lemma 2.5)
 - Shannon's key-space bound ([KatzLindell2020], Theorem 2.12)
 -/
+
+@[expose] public section
 
 namespace Cslib.Crypto.Protocols.PerfectSecrecy
 

--- a/Cslib/Crypto/Protocols/PerfectSecrecy/OneTimePad.lean
+++ b/Cslib/Crypto/Protocols/PerfectSecrecy/OneTimePad.lean
@@ -10,8 +10,6 @@ public import Cslib.Crypto.Protocols.PerfectSecrecy.Basic
 public import Cslib.Crypto.Protocols.PerfectSecrecy.Internal.OneTimePad
 public import Mathlib.Probability.Distributions.Uniform
 
-@[expose] public section
-
 /-!
 # One-Time Pad
 
@@ -31,6 +29,8 @@ The one-time pad (Vernam cipher) over `BitVec l`
 
 * [J. Katz, Y. Lindell, *Introduction to Modern Cryptography*][KatzLindell2020]
 -/
+
+@[expose] public section
 
 namespace Cslib.Crypto.Protocols.PerfectSecrecy
 

--- a/Cslib/Crypto/Protocols/PerfectSecrecy/PMFUtilities.lean
+++ b/Cslib/Crypto/Protocols/PerfectSecrecy/PMFUtilities.lean
@@ -9,8 +9,6 @@ module
 public import Cslib.Init
 public import Mathlib.Probability.ProbabilityMassFunction.Monad
 
-@[expose] public section
-
 /-!
 # PMF Utilities
 
@@ -30,6 +28,8 @@ the Mathlib module instead.
 - `PMFUtilities.posterior_hasSum`: posterior probabilities sum to 1
 - `PMFUtilities.posteriorDist`: the posterior as a `PMF`
 -/
+
+@[expose] public section
 
 namespace Cslib.Crypto.Protocols.PerfectSecrecy.PMFUtilities
 

--- a/Cslib/Foundations/Combinatorics/InfiniteGraphRamsey.lean
+++ b/Cslib/Foundations/Combinatorics/InfiniteGraphRamsey.lean
@@ -12,14 +12,14 @@ public import Mathlib.Data.Fintype.Pigeonhole
 public import Mathlib.Data.Set.Finite.Basic
 public import Mathlib.Data.Set.Lattice
 
-@[expose] public section
-
 /-! # Ramsey theorem for infinite graphs
 
 This result really should be in Mathlib, but currently it is not. We do expect
 the Ramsey theorem for infinite hypergraphs to appear in Mathlib eventually and
 this result to be derived as a corollary of the more general result.
 -/
+
+@[expose] public section
 
 namespace Cslib
 

--- a/Cslib/Foundations/Control/Monad/Free.lean
+++ b/Cslib/Foundations/Control/Monad/Free.lean
@@ -8,8 +8,6 @@ module
 
 public import Cslib.Init
 
-@[expose] public section
-
 /-!
 # Free Monad
 
@@ -68,6 +66,8 @@ The file `Free/Fold.lean` provides the theory of the fold operation for free mon
 
 Free monad, state monad
 -/
+
+@[expose] public section
 
 namespace Cslib
 

--- a/Cslib/Foundations/Control/Monad/Free/Effects.lean
+++ b/Cslib/Foundations/Control/Monad/Free/Effects.lean
@@ -9,8 +9,6 @@ module
 public import Cslib.Foundations.Control.Monad.Free
 public import Mathlib.Control.Monad.Cont
 
-@[expose] public section
-
 /-!
 # Free Monad
 
@@ -38,6 +36,8 @@ the universal property.
 
 Free monad, state monad, writer monad, continuation monad
 -/
+
+@[expose] public section
 
 namespace Cslib
 

--- a/Cslib/Foundations/Control/Monad/Free/Fold.lean
+++ b/Cslib/Foundations/Control/Monad/Free/Fold.lean
@@ -8,8 +8,6 @@ module
 
 public import Cslib.Foundations.Control.Monad.Free
 
-@[expose] public section
-
 /-!
 # Free Monad Catamorphism
 
@@ -39,6 +37,8 @@ An algebra of this functor consists of a type `β` and functions:
 For any such algebra, `foldFreeM onValue onEffect` is the unique algebra morphism
 from the initial algebra `FreeM F α` to `(β, onValue, onEffect)`.
 -/
+
+@[expose] public section
 
 namespace Cslib
 

--- a/Cslib/Foundations/Data/BiTape.lean
+++ b/Cslib/Foundations/Data/BiTape.lean
@@ -12,8 +12,6 @@ public import Mathlib.Data.Finset.Attr
 public import Mathlib.Tactic.SetLike
 public import Mathlib.Algebra.Order.Group.Nat
 
-@[expose] public section
-
 /-!
 # BiTape: Bidirectionally infinite TM tape representation using StackTape
 
@@ -37,6 +35,8 @@ will not collide.
 * `BiTape.write`: Write a symbol at the current head position
 * `BiTape.space_used`: The space used by the tape
 -/
+
+@[expose] public section
 
 namespace Turing
 

--- a/Cslib/Foundations/Data/DecidableEqZero.lean
+++ b/Cslib/Foundations/Data/DecidableEqZero.lean
@@ -8,6 +8,8 @@ module
 
 public import Cslib.Init
 
+/-! -/
+
 @[expose] public section
 
 namespace Cslib

--- a/Cslib/Foundations/Data/FinFun/Basic.lean
+++ b/Cslib/Foundations/Data/FinFun/Basic.lean
@@ -10,14 +10,14 @@ public import Cslib.Init
 public import Mathlib.Data.Finset.Filter
 public import Mathlib.Data.Finset.Lattice.Basic
 
-@[expose] public section
-
 /-! # Finite functions
 
 Given types `α` and `β`, and assuming that `β` has a `Zero` element,
 a `FinFun α β` is a function from `α` to `β` where only a finite number of elements
 in `α` are mapped to non-zero elements.
 -/
+
+@[expose] public section
 
 namespace Cslib
 

--- a/Cslib/Foundations/Data/FinFun/Update.lean
+++ b/Cslib/Foundations/Data/FinFun/Update.lean
@@ -10,13 +10,13 @@ public import Cslib.Foundations.Data.FinFun.Basic
 public import Cslib.Foundations.Data.DecidableEqZero
 public import Mathlib.Data.Finset.SDiff
 
-@[expose] public section
-
 /-! # Update for finite functions
 
 This module defines the update operation for finite functions, that is, the equivalent of
 `Function.update` for `FinFun`.
 -/
+
+@[expose] public section
 
 namespace Cslib.FinFun
 

--- a/Cslib/Foundations/Data/HasFresh.lean
+++ b/Cslib/Foundations/Data/HasFresh.lean
@@ -10,6 +10,8 @@ public import Cslib.Init
 public import Mathlib.Analysis.Normed.Field.Lemmas
 import Qq
 
+/-! Computable chacterization of infinite types. -/
+
 @[expose] public section
 
 universe u

--- a/Cslib/Foundations/Data/Nat/Segment.lean
+++ b/Cslib/Foundations/Data/Nat/Segment.lean
@@ -10,10 +10,6 @@ public import Cslib.Init
 public import Mathlib.Algebra.Order.Sub.Basic
 public import Mathlib.Data.Nat.Nth
 
-@[expose] public section
-
-open Function Set
-
 /-!
 # Segments defined by a strictly monotonic function on Nat
 
@@ -22,6 +18,10 @@ Given a strictly monotonic function `f : ℕ → ℕ` and `k : ℕ` with `k ≥ 
 `Nat.segment f k` is defined to be 0 for `k < f 0`.
 This file defines `Nat.segment` and proves various properties aboout it.
 -/
+
+@[expose] public section
+
+open Function Set
 
 /-- The `f`-segment of `k`, where `f : ℕ → ℕ` will be assumed to be at least StrictMono. -/
 @[scoped grind]

--- a/Cslib/Foundations/Data/OmegaSequence/Defs.lean
+++ b/Cslib/Foundations/Data/OmegaSequence/Defs.lean
@@ -10,8 +10,6 @@ public import Cslib.Init
 public import Mathlib.Data.FunLike.Basic
 public import Mathlib.Logic.Function.Iterate
 
-@[expose] public section
-
 /-!
 # Definition of `ωSequence` and functions on infinite sequences
 
@@ -24,6 +22,8 @@ function application notation `s n`.
 In this file we define `ωSequence` and its API functions.
 Most code below is adapted from Mathlib.Data.Stream.Defs.
 -/
+
+@[expose] public section
 
 namespace Cslib
 

--- a/Cslib/Foundations/Data/OmegaSequence/Flatten.lean
+++ b/Cslib/Foundations/Data/OmegaSequence/Flatten.lean
@@ -9,8 +9,6 @@ module
 public import Cslib.Foundations.Data.Nat.Segment
 public import Cslib.Foundations.Data.OmegaSequence.Init
 
-@[expose] public section
-
 /-!
 # Flattening an infinite sequence of lists
 
@@ -19,6 +17,8 @@ concatenating all members of `ls`.  For this definition to make proper sense,
 we will consistently assume that all lists in `ls` are nonempty.  Furthermore,
 in order to simplify the definition, we will also assume [Inhabited α].
 -/
+
+@[expose] public section
 
 namespace Cslib
 

--- a/Cslib/Foundations/Data/OmegaSequence/InfOcc.lean
+++ b/Cslib/Foundations/Data/OmegaSequence/InfOcc.lean
@@ -11,11 +11,11 @@ public import Cslib.Foundations.Data.OmegaSequence.Defs
 public import Mathlib.Data.Fintype.Pigeonhole
 public import Mathlib.Order.Filter.Cofinite
 
-@[expose] public section
-
 /-!
 # Infinite occurrences
 -/
+
+@[expose] public section
 
 namespace Cslib
 

--- a/Cslib/Foundations/Data/OmegaSequence/Init.lean
+++ b/Cslib/Foundations/Data/OmegaSequence/Init.lean
@@ -11,13 +11,13 @@ public import Mathlib.Algebra.Order.Group.Nat
 public import Mathlib.Algebra.Order.Sub.Basic
 public import Mathlib.Data.Nat.Lattice
 
-@[expose] public section
-
 /-!
 # ω-sequences a.k.a. infinite sequences
 
 Most code below is adapted from Mathlib.Data.Stream.Init.
 -/
+
+@[expose] public section
 
 namespace Cslib
 

--- a/Cslib/Foundations/Data/OmegaSequence/Temporal.lean
+++ b/Cslib/Foundations/Data/OmegaSequence/Temporal.lean
@@ -9,11 +9,11 @@ module
 public import Cslib.Foundations.Data.OmegaSequence.Init
 public import Mathlib.Order.Filter.AtTopBot.Basic
 
-@[expose] public section
-
 /-!
 # Temporal reasoning over infinite sequences.
 -/
+
+@[expose] public section
 
 open Function Set Filter
 

--- a/Cslib/Foundations/Data/RelatesInSteps.lean
+++ b/Cslib/Foundations/Data/RelatesInSteps.lean
@@ -9,16 +9,16 @@ module
 public import Cslib.Init
 public import Mathlib.Logic.Relation
 
-@[expose] public section
-
-variable {α : Type*} {r : α → α → Prop} {a b c : α}
-
 /-! # Relations Across Steps
 
 This file defines `Relation.RelatesInSteps` (and `Relation.RelatesWithinSteps`).
 These are inductively defines propositions that communicate whether a relation forms a
 chain of length `n` (or at most `n`) between two elements.
 -/
+
+@[expose] public section
+
+variable {α : Type*} {r : α → α → Prop} {a b c : α}
 
 namespace Relation
 

--- a/Cslib/Foundations/Data/Relation.lean
+++ b/Cslib/Foundations/Data/Relation.lean
@@ -12,6 +12,14 @@ public import Mathlib.Order.Comparable
 public import Mathlib.Order.WellFounded
 public import Mathlib.Order.BooleanAlgebra.Basic
 
+/-! # Relations
+
+## References
+
+* [*Term Rewriting and All That*][Baader1998]
+
+-/
+
 @[expose] public section
 
 variable {α : Type*} {r : α → α → Prop}
@@ -22,14 +30,6 @@ theorem WellFounded.ofTransGen (trans_wf : WellFounded (Relation.TransGen r)) : 
 @[simp, grind =]
 theorem WellFounded.iff_transGen : WellFounded (Relation.TransGen r) ↔ WellFounded r :=
   ⟨ofTransGen, transGen⟩
-
-/-! # Relations
-
-## References
-
-* [*Term Rewriting and All That*][Baader1998]
-
--/
 
 namespace Relation
 

--- a/Cslib/Foundations/Data/Set/Saturation.lean
+++ b/Cslib/Foundations/Data/Set/Saturation.lean
@@ -10,11 +10,11 @@ public import Cslib.Init
 public import Mathlib.Order.SetNotation
 public import Mathlib.Data.Set.Basic
 
-@[expose] public section
-
 /-!
 # Saturation
 -/
+
+@[expose] public section
 
 namespace Set
 

--- a/Cslib/Foundations/Data/StackTape.lean
+++ b/Cslib/Foundations/Data/StackTape.lean
@@ -8,8 +8,6 @@ module
 
 public import Cslib.Init
 
-@[expose] public section
-
 /-!
 # StackTape: Infinite, eventually-`none` lists of `Option`s
 
@@ -37,6 +35,8 @@ advantages and disadvantages.
 - Make a `::`-like notation.
 
 -/
+
+@[expose] public section
 
 namespace Turing
 

--- a/Cslib/Foundations/Logic/InferenceSystem.lean
+++ b/Cslib/Foundations/Logic/InferenceSystem.lean
@@ -8,6 +8,8 @@ module
 
 public import Cslib.Init
 
+/-! -/
+
 @[expose] public section
 
 namespace Cslib.Logic

--- a/Cslib/Foundations/Logic/LogicalEquivalence.lean
+++ b/Cslib/Foundations/Logic/LogicalEquivalence.lean
@@ -9,6 +9,8 @@ module
 public import Cslib.Foundations.Syntax.Context
 public import Cslib.Foundations.Syntax.Congruence
 
+/-! Typeclass and notation for logical equivalence. -/
+
 @[expose] public section
 
 namespace Cslib.Logic

--- a/Cslib/Foundations/Semantics/FLTS/Basic.lean
+++ b/Cslib/Foundations/Semantics/FLTS/Basic.lean
@@ -8,8 +8,6 @@ module
 
 public import Cslib.Init
 
-@[expose] public section
-
 /-! # Functional Labelled Transition System (FLTS)
 
 A Functional Labelled Transition System is a special case of an `LTS` where transitions are
@@ -22,6 +20,8 @@ This is a generalisation of deterministic finite-state machines.
 * [J. E. Hopcroft, R. Motwani, J. D. Ullman,
   *Introduction to Automata Theory, Languages, and Computation*][Hopcroft2006]
 -/
+
+@[expose] public section
 
 namespace Cslib
 

--- a/Cslib/Foundations/Semantics/FLTS/FLTSToLTS.lean
+++ b/Cslib/Foundations/Semantics/FLTS/FLTSToLTS.lean
@@ -9,6 +9,8 @@ module
 public import Cslib.Foundations.Semantics.FLTS.Basic
 public import Cslib.Foundations.Semantics.LTS.Basic
 
+/-! Converting from `FLTS` to `LTS` -/
+
 @[expose] public section
 
 variable {State Label : Type*}

--- a/Cslib/Foundations/Semantics/FLTS/LTSToFLTS.lean
+++ b/Cslib/Foundations/Semantics/FLTS/LTSToFLTS.lean
@@ -9,6 +9,8 @@ module
 public import Cslib.Foundations.Semantics.FLTS.Basic
 public import Cslib.Foundations.Semantics.LTS.Basic
 
+/-! Converting from `LTS` to `FLTS` -/
+
 @[expose] public section
 
 variable {State Label : Type*}

--- a/Cslib/Foundations/Semantics/FLTS/Prod.lean
+++ b/Cslib/Foundations/Semantics/FLTS/Prod.lean
@@ -8,9 +8,9 @@ module
 
 public import Cslib.Foundations.Semantics.FLTS.Basic
 
-@[expose] public section
-
 /-! # Product of functional labelled transition systems -/
+
+@[expose] public section
 
 namespace Cslib.FLTS
 

--- a/Cslib/Foundations/Semantics/LTS/Basic.lean
+++ b/Cslib/Foundations/Semantics/LTS/Basic.lean
@@ -10,8 +10,6 @@ public import Cslib.Init
 public import Mathlib.Data.Set.Finite.Basic
 public import Mathlib.Order.SetNotation
 
-@[expose] public section
-
 /-!
 # Labelled Transition System (LTS)
 
@@ -47,6 +45,8 @@ type of labels is finite.
 * [F. Montesi, *Introduction to Choreographies*][Montesi2023]
 * [D. Sangiorgi, *Introduction to Bisimulation and Coinduction*][Sangiorgi2011]
 -/
+
+@[expose] public section
 
 namespace Cslib
 

--- a/Cslib/Foundations/Semantics/LTS/Bisimulation.lean
+++ b/Cslib/Foundations/Semantics/LTS/Bisimulation.lean
@@ -11,8 +11,6 @@ public import Cslib.Foundations.Semantics.LTS.HasTau
 public import Cslib.Foundations.Semantics.LTS.Simulation
 public import Cslib.Foundations.Semantics.LTS.TraceEq
 
-@[expose] public section
-
 /-! # Bisimulation and Bisimilarity
 
 A bisimulation is a binary relation on the states of two `LTS`s, which establishes a tight semantic
@@ -65,6 +63,8 @@ equivalence coincide.
 - `WeakBisimilarity.eqv`: weak bisimilarity is an equivalence relation.
 
 -/
+
+@[expose] public section
 
 namespace Cslib.LTS
 

--- a/Cslib/Foundations/Semantics/LTS/Divergence.lean
+++ b/Cslib/Foundations/Semantics/LTS/Divergence.lean
@@ -9,11 +9,11 @@ module
 public import Cslib.Foundations.Semantics.LTS.HasTau
 public import Cslib.Foundations.Semantics.LTS.OmegaExecution
 
-@[expose] public section
-
 /-!
 # Divergence of LTS
 -/
+
+@[expose] public section
 
 namespace Cslib.LTS
 

--- a/Cslib/Foundations/Semantics/LTS/Execution.lean
+++ b/Cslib/Foundations/Semantics/LTS/Execution.lean
@@ -8,11 +8,11 @@ module
 
 public import Cslib.Foundations.Semantics.LTS.Basic
 
-@[expose] public section
-
 /-!
 # Finite executions of LTS
 -/
+
+@[expose] public section
 
 namespace Cslib.LTS
 

--- a/Cslib/Foundations/Semantics/LTS/HasTau.lean
+++ b/Cslib/Foundations/Semantics/LTS/HasTau.lean
@@ -8,11 +8,11 @@ module
 
 public import Cslib.Foundations.Semantics.LTS.Relation
 
-@[expose] public section
-
 /-!
 # LTS with a special "internal" transition `τ`.
 -/
+
+@[expose] public section
 
 namespace Cslib
 

--- a/Cslib/Foundations/Semantics/LTS/LTSCat/Basic.lean
+++ b/Cslib/Foundations/Semantics/LTS/LTSCat/Basic.lean
@@ -10,12 +10,6 @@ public import Mathlib.CategoryTheory.Category.Basic
 public import Cslib.Foundations.Semantics.LTS.Basic
 public import Mathlib.Control.Basic
 
-@[expose] public section
-
-namespace Cslib
-
-variable {State Label : Type*}
-
 /-! # Category of Labelled Transition Systems
 
 This file contains the definition of the category of labelled transition systems
@@ -25,6 +19,12 @@ as defined in Winskel and Nielsen's handbook chapter [WinskelNielsen1995].
 
 * [N. Winskel and M. Nielsen, *Models for concurrency*][WinskelNielsen1995]
 -/
+
+@[expose] public section
+
+namespace Cslib
+
+variable {State Label : Type*}
 
 /--
 We first define what is denoted Tran* in [WinskelNielsen1995]: the extension of

--- a/Cslib/Foundations/Semantics/LTS/OmegaExecution.lean
+++ b/Cslib/Foundations/Semantics/LTS/OmegaExecution.lean
@@ -9,11 +9,11 @@ module
 public import Cslib.Foundations.Data.OmegaSequence.Flatten
 public import Cslib.Foundations.Semantics.LTS.Execution
 
-@[expose] public section
-
 /-!
 # Infinite executions of LTS
 -/
+
+@[expose] public section
 
 namespace Cslib.LTS
 

--- a/Cslib/Foundations/Semantics/LTS/Relation.lean
+++ b/Cslib/Foundations/Semantics/LTS/Relation.lean
@@ -8,11 +8,11 @@ module
 
 public import Cslib.Foundations.Semantics.LTS.Basic
 
-@[expose] public section
-
 /-!
 # Conversions between `LTS` and `Relation`.
 -/
+
+@[expose] public section
 
 namespace Cslib.LTS
 

--- a/Cslib/Foundations/Semantics/LTS/Simulation.lean
+++ b/Cslib/Foundations/Semantics/LTS/Simulation.lean
@@ -8,8 +8,6 @@ module
 
 public import Cslib.Foundations.Semantics.LTS.Basic
 
-@[expose] public section
-
 /-! # IsSimulation and Similarity
 
 A simulation is a binary relation on the states of two `LTS`s: if two states `s₁` and `s2` are
@@ -42,6 +40,8 @@ any two states similar to each other.
 - `HomSimulationEquiv.eqv`: homogeneous simulation equivalence is an equivalence relation.
 
 -/
+
+@[expose] public section
 
 namespace Cslib.LTS
 

--- a/Cslib/Foundations/Semantics/LTS/Termination.lean
+++ b/Cslib/Foundations/Semantics/LTS/Termination.lean
@@ -8,11 +8,11 @@ module
 
 public import Cslib.Foundations.Semantics.LTS.Basic
 
-@[expose] public section
-
 /-!
 # Termination of LTS
 -/
+
+@[expose] public section
 
 namespace Cslib.LTS
 

--- a/Cslib/Foundations/Semantics/LTS/Total.lean
+++ b/Cslib/Foundations/Semantics/LTS/Total.lean
@@ -9,14 +9,14 @@ module
 public import Cslib.Foundations.Semantics.FLTS.Basic
 public import Cslib.Foundations.Semantics.LTS.OmegaExecution
 
-@[expose] public section
-
 /-!
 # Total LTS
 
 This file defines, and proves some theorems about, the notion of an LTS being "total"
 and a "totalize" construction that converts any LTS into a total LTS.
 -/
+
+@[expose] public section
 
 namespace Cslib.LTS
 

--- a/Cslib/Foundations/Semantics/LTS/TraceEq.lean
+++ b/Cslib/Foundations/Semantics/LTS/TraceEq.lean
@@ -9,8 +9,6 @@ module
 public import Cslib.Foundations.Semantics.LTS.Basic
 public import Cslib.Foundations.Semantics.LTS.Simulation
 
-@[expose] public section
-
 /-!
 # Trace Equivalence
 
@@ -31,6 +29,8 @@ Definitions and results on trace equivalence for `LTS`s.
 - `TraceEq.deterministic_sim`: in any deterministic `LTS`, trace equivalence is a simulation.
 
 -/
+
+@[expose] public section
 
 namespace Cslib.LTS
 

--- a/Cslib/Foundations/Semantics/LTS/Union.lean
+++ b/Cslib/Foundations/Semantics/LTS/Union.lean
@@ -8,14 +8,14 @@ module
 
 public import Cslib.Foundations.Semantics.LTS.Basic
 
-@[expose] public section
-
 /-!
 # Union of LTSs
 
 Note: there is a nontrivial balance between ergonomics and generality here. These definitions might
 change in the future.
 -/
+
+@[expose] public section
 
 namespace Cslib.LTS
 

--- a/Cslib/Foundations/Syntax/Congruence.lean
+++ b/Cslib/Foundations/Syntax/Congruence.lean
@@ -9,6 +9,8 @@ module
 public import Cslib.Foundations.Syntax.Context
 public import Mathlib.Algebra.Order.Monoid.Unbundled.Defs
 
+/-! Typeclass for congruence over a context. -/
+
 @[expose] public section
 
 namespace Cslib

--- a/Cslib/Foundations/Syntax/Context.lean
+++ b/Cslib/Foundations/Syntax/Context.lean
@@ -8,6 +8,8 @@ module
 
 public import Cslib.Init
 
+/-! Typeclasses for contexts, with heterogeneous and homogeneous variants. -/
+
 @[expose] public section
 
 namespace Cslib

--- a/Cslib/Foundations/Syntax/HasAlphaEquiv.lean
+++ b/Cslib/Foundations/Syntax/HasAlphaEquiv.lean
@@ -8,6 +8,8 @@ module
 
 public import Cslib.Init
 
+/-! Notation typeclass for α-equivalence. -/
+
 public section
 
 namespace Cslib

--- a/Cslib/Foundations/Syntax/HasSubstitution.lean
+++ b/Cslib/Foundations/Syntax/HasSubstitution.lean
@@ -8,6 +8,8 @@ module
 
 public import Cslib.Init
 
+/-! Notation typeclass for substitution. -/
+
 public section
 
 namespace Cslib

--- a/Cslib/Foundations/Syntax/HasWellFormed.lean
+++ b/Cslib/Foundations/Syntax/HasWellFormed.lean
@@ -8,6 +8,8 @@ module
 
 public import Cslib.Init
 
+/-! Notation typeclass for well-formedness. -/
+
 public section
 
 namespace Cslib

--- a/Cslib/Languages/CCS/Basic.lean
+++ b/Cslib/Languages/CCS/Basic.lean
@@ -10,8 +10,6 @@ public import Cslib.Foundations.Syntax.Context
 public import Mathlib.Tactic.ToAdditive
 public import Mathlib.Tactic.ToDual
 
-@[expose] public section
-
 /-! # Calculus of Communicating Systems (CCS)
 
 CCS [Milner80], as presented in [Sangiorgi2011]. In the semantics (see `CCS.lts`), we adopt the
@@ -30,6 +28,8 @@ option of constant definitions (K = P).
 * [R. Milner, *A Calculus of Communicating Systems*][Milner80]
 * [D. Sangiorgi, *Introduction to Bisimulation and Coinduction*][Sangiorgi2011]
 -/
+
+@[expose] public section
 
 namespace Cslib.CCS
 

--- a/Cslib/Languages/CCS/BehaviouralTheory.lean
+++ b/Cslib/Languages/CCS/BehaviouralTheory.lean
@@ -10,8 +10,6 @@ public import Cslib.Foundations.Semantics.LTS.Bisimulation
 public import Cslib.Foundations.Syntax.Congruence
 public import Cslib.Languages.CCS.Semantics
 
-@[expose] public section
-
 /-! # Behavioural theory of CCS
 
 ## Main results
@@ -23,6 +21,8 @@ Additionally, some standard laws of bisimilarity for CCS, including:
 - `CCS.bisimilarity_par_comm`: P | Q ~ Q | P
 - `CCS.bisimilarity_choice_comm`: P + Q ~ Q + P
 -/
+
+@[expose] public section
 
 namespace Cslib
 

--- a/Cslib/Languages/CCS/Semantics.lean
+++ b/Cslib/Languages/CCS/Semantics.lean
@@ -10,8 +10,6 @@ public import Cslib.Foundations.Semantics.LTS.HasTau
 public meta import Cslib.Foundations.Semantics.LTS.Notation
 public import Cslib.Languages.CCS.Basic
 
-@[expose] public section
-
 /-! # Semantics of CCS
 
 ## Main definitions
@@ -19,6 +17,8 @@ public import Cslib.Languages.CCS.Basic
 - `CCS.lts`: the `LTS` of CCS.
 
 -/
+
+@[expose] public section
 
 namespace Cslib
 

--- a/Cslib/Languages/CombinatoryLogic/Basic.lean
+++ b/Cslib/Languages/CombinatoryLogic/Basic.lean
@@ -8,8 +8,6 @@ module
 
 public import Cslib.Languages.CombinatoryLogic.Defs
 
-@[expose] public section
-
 /-!
 # Basic results for the SKI calculus
 
@@ -33,6 +31,8 @@ $Γ(x_0, ..., x_{n-1})$ into a term such that (`Polynomial.toSKI_correct`)
 For a presentation of the bracket abstraction algorithm see:
 <https://web.archive.org/web/19970727171324/http://www.cs.oberlin.edu/classes/cs280/labs/lab4/lab43.html#@l13>
 -/
+
+@[expose] public section
 
 namespace Cslib
 

--- a/Cslib/Languages/CombinatoryLogic/Confluence.lean
+++ b/Cslib/Languages/CombinatoryLogic/Confluence.lean
@@ -8,8 +8,6 @@ module
 
 public import Cslib.Languages.CombinatoryLogic.Defs
 
-@[expose] public section
-
 /-!
 # SKI reduction is confluent
 
@@ -38,6 +36,8 @@ confluent in a single step.
 for its reflexive-transitive closure. This closure is exactly `↠`, which implies the
 **Church-Rosser** theorem as sketched above.
 -/
+
+@[expose] public section
 
 namespace Cslib
 

--- a/Cslib/Languages/CombinatoryLogic/Defs.lean
+++ b/Cslib/Languages/CombinatoryLogic/Defs.lean
@@ -9,8 +9,6 @@ module
 public import Cslib.Foundations.Data.Relation
 public meta import Mathlib.Tactic.ToDual
 
-@[expose] public section
-
 /-!
 # SKI Combinatory Logic
 
@@ -35,6 +33,8 @@ The setup of SKI combinatory logic is standard, see for example:
 - <https://en.m.wikipedia.org/wiki/SKI_combinator_calculus>
 - <https://en.m.wikipedia.org/wiki/Combinatory_logic>
 -/
+
+@[expose] public section
 
 namespace Cslib
 

--- a/Cslib/Languages/CombinatoryLogic/Evaluation.lean
+++ b/Cslib/Languages/CombinatoryLogic/Evaluation.lean
@@ -9,8 +9,6 @@ module
 public import Cslib.Languages.CombinatoryLogic.Confluence
 public import Cslib.Languages.CombinatoryLogic.Recursion
 
-@[expose] public section
-
 /-!
 # Evaluation results
 
@@ -34,6 +32,8 @@ form, then they are equal.
 
 This file draws heavily from <https://gist.github.com/b-mehta/e412c837818223b8f16ca0b4aa19b166>.
 -/
+
+@[expose] public section
 
 namespace Cslib
 

--- a/Cslib/Languages/CombinatoryLogic/List.lean
+++ b/Cslib/Languages/CombinatoryLogic/List.lean
@@ -8,14 +8,14 @@ module
 
 public import Cslib.Languages.CombinatoryLogic.Recursion
 
-@[expose] public section
-
 /-!
 # Church-Encoded Lists in SKI Combinatory Logic
 
 Church-encoded lists for proving SKI ≃ TM equivalence. A list is encoded as
 `λ c n. c a₀ (c a₁ (... (c aₖ n)...))` where each `aᵢ` is a Church numeral.
 -/
+
+@[expose] public section
 
 namespace Cslib
 

--- a/Cslib/Languages/CombinatoryLogic/Recursion.lean
+++ b/Cslib/Languages/CombinatoryLogic/Recursion.lean
@@ -9,8 +9,6 @@ module
 public import Cslib.Languages.CombinatoryLogic.Basic
 public import Mathlib.Data.Nat.Pairing
 
-@[expose] public section
-
 /-!
 # General recursion in the SKI calculus
 
@@ -58,6 +56,8 @@ by defining reduction on polynomials.
 sense of `Mathlib.Data.Part` (as used in `Mathlib.Computability.Partrec`).
 - The results of this file should define a surjection `SKI → Nat.Partrec`.
 -/
+
+@[expose] public section
 
 namespace Cslib
 

--- a/Cslib/Languages/LambdaCalculus/LocallyNameless/Context.lean
+++ b/Cslib/Languages/LambdaCalculus/LocallyNameless/Context.lean
@@ -10,13 +10,14 @@ public import Cslib.Foundations.Syntax.HasWellFormed
 public import Mathlib.Data.Finset.Dedup
 public import Mathlib.Data.List.Sigma
 
-@[expose] public section
 
 /-! # λ-calculus
 
 Contexts as pairs of free variables and types.
 
 -/
+
+@[expose] public section
 
 namespace Cslib
 

--- a/Cslib/Languages/LambdaCalculus/LocallyNameless/Fsub/Basic.lean
+++ b/Cslib/Languages/LambdaCalculus/LocallyNameless/Fsub/Basic.lean
@@ -9,8 +9,6 @@ module
 public import Cslib.Foundations.Data.HasFresh
 public import Cslib.Languages.LambdaCalculus.LocallyNameless.Context
 
-@[expose] public section
-
 /-! # λ-calculus
 
 The λ-calculus with polymorphism and subtyping, with a locally nameless representation of syntax.
@@ -22,6 +20,8 @@ The λ-calculus with polymorphism and subtyping, with a locally nameless represe
   this is adapted
 
 -/
+
+@[expose] public section
 
 namespace Cslib
 

--- a/Cslib/Languages/LambdaCalculus/LocallyNameless/Fsub/Opening.lean
+++ b/Cslib/Languages/LambdaCalculus/LocallyNameless/Fsub/Opening.lean
@@ -9,10 +9,6 @@ module
 public import Cslib.Foundations.Syntax.HasSubstitution
 public import Cslib.Languages.LambdaCalculus.LocallyNameless.Fsub.Basic
 
-@[expose] public section
-
-set_option linter.unusedDecidableInType false
-
 /-! # λ-calculus
 
 The λ-calculus with polymorphism and subtyping, with a locally nameless representation of syntax.
@@ -25,6 +21,10 @@ This file defines opening, local closure, and substitution.
   this is adapted
 
 -/
+
+@[expose] public section
+
+set_option linter.unusedDecidableInType false
 
 namespace Cslib
 

--- a/Cslib/Languages/LambdaCalculus/LocallyNameless/Fsub/Reduction.lean
+++ b/Cslib/Languages/LambdaCalculus/LocallyNameless/Fsub/Reduction.lean
@@ -9,10 +9,6 @@ module
 public import Cslib.Foundations.Data.Relation
 public import Cslib.Languages.LambdaCalculus.LocallyNameless.Fsub.Opening
 
-@[expose] public section
-
-set_option linter.unusedDecidableInType false
-
 /-! # λ-calculus
 
 The λ-calculus with polymorphism and subtyping, with a locally nameless representation of syntax.
@@ -25,6 +21,10 @@ This file defines a call-by-value reduction.
   this is adapted
 
 -/
+
+@[expose] public section
+
+set_option linter.unusedDecidableInType false
 
 namespace Cslib
 

--- a/Cslib/Languages/LambdaCalculus/LocallyNameless/Fsub/Safety.lean
+++ b/Cslib/Languages/LambdaCalculus/LocallyNameless/Fsub/Safety.lean
@@ -8,8 +8,6 @@ module
 
 public import Cslib.Languages.LambdaCalculus.LocallyNameless.Fsub.Typing
 
-public section
-
 /-! # λ-calculus
 
 The λ-calculus with polymorphism and subtyping, with a locally nameless representation of syntax.
@@ -22,6 +20,8 @@ This file proves type safety.
   this is adapted
 
 -/
+
+public section
 
 namespace Cslib
 

--- a/Cslib/Languages/LambdaCalculus/LocallyNameless/Fsub/Subtype.lean
+++ b/Cslib/Languages/LambdaCalculus/LocallyNameless/Fsub/Subtype.lean
@@ -8,8 +8,6 @@ module
 
 public import Cslib.Languages.LambdaCalculus.LocallyNameless.Fsub.WellFormed
 
-@[expose] public section
-
 /-! # λ-calculus
 
 The λ-calculus with polymorphism and subtyping, with a locally nameless representation of syntax.
@@ -22,6 +20,8 @@ This file defines the subtyping relation.
   this is adapted
 
 -/
+
+@[expose] public section
 
 namespace Cslib
 

--- a/Cslib/Languages/LambdaCalculus/LocallyNameless/Fsub/Typing.lean
+++ b/Cslib/Languages/LambdaCalculus/LocallyNameless/Fsub/Typing.lean
@@ -9,8 +9,6 @@ module
 public import Cslib.Languages.LambdaCalculus.LocallyNameless.Fsub.Reduction
 public import Cslib.Languages.LambdaCalculus.LocallyNameless.Fsub.Subtype
 
-@[expose] public section
-
 /-! # λ-calculus
 
 The λ-calculus with polymorphism and subtyping, with a locally nameless representation of syntax.
@@ -23,6 +21,8 @@ This file defines the typing relation.
   this is adapted
 
 -/
+
+@[expose] public section
 
 namespace Cslib
 

--- a/Cslib/Languages/LambdaCalculus/LocallyNameless/Fsub/WellFormed.lean
+++ b/Cslib/Languages/LambdaCalculus/LocallyNameless/Fsub/WellFormed.lean
@@ -8,8 +8,6 @@ module
 
 public import Cslib.Languages.LambdaCalculus.LocallyNameless.Fsub.Opening
 
-@[expose] public section
-
 /-! # λ-calculus
 
 The λ-calculus with polymorphism and subtyping, with a locally nameless representation of syntax.
@@ -22,6 +20,8 @@ This file defines the well-formedness condition for types and contexts.
   this is adapted
 
 -/
+
+@[expose] public section
 
 namespace Cslib
 

--- a/Cslib/Languages/LambdaCalculus/LocallyNameless/Stlc/Basic.lean
+++ b/Cslib/Languages/LambdaCalculus/LocallyNameless/Stlc/Basic.lean
@@ -9,10 +9,6 @@ module
 public import Cslib.Languages.LambdaCalculus.LocallyNameless.Context
 public import Cslib.Languages.LambdaCalculus.LocallyNameless.Untyped.Properties
 
-@[expose] public section
-
-set_option linter.unusedDecidableInType false
-
 /-! # λ-calculus
 
 The simply typed λ-calculus, with a locally nameless representation of syntax.
@@ -24,6 +20,10 @@ The simply typed λ-calculus, with a locally nameless representation of syntax.
   this is partially adapted
 
 -/
+
+@[expose] public section
+
+set_option linter.unusedDecidableInType false
 
 namespace Cslib
 

--- a/Cslib/Languages/LambdaCalculus/LocallyNameless/Stlc/Safety.lean
+++ b/Cslib/Languages/LambdaCalculus/LocallyNameless/Stlc/Safety.lean
@@ -9,8 +9,6 @@ module
 public import Cslib.Languages.LambdaCalculus.LocallyNameless.Stlc.Basic
 public import Cslib.Languages.LambdaCalculus.LocallyNameless.Untyped.FullBeta
 
-@[expose] public section
-
 /-! # λ-calculus
 
 Type safety of the simply typed λ-calculus, with a locally nameless representation of syntax.
@@ -23,6 +21,8 @@ Theorems in this file are namespaced by their respective reductions.
   this is partially adapted
 
 -/
+
+@[expose] public section
 
 namespace Cslib
 

--- a/Cslib/Languages/LambdaCalculus/LocallyNameless/Stlc/StrongNorm.lean
+++ b/Cslib/Languages/LambdaCalculus/LocallyNameless/Stlc/StrongNorm.lean
@@ -14,6 +14,8 @@ public import Cslib.Languages.LambdaCalculus.LocallyNameless.Untyped.StrongNorm
 public import Cslib.Languages.LambdaCalculus.LocallyNameless.Untyped.LcAt
 public import Cslib.Languages.LambdaCalculus.LocallyNameless.Untyped.MultiSubst
 
+/-! Strong normalization (termination) for full beta-reduction of simply typed lamba calulus. -/
+
 @[expose] public section
 
 set_option linter.unusedDecidableInType false

--- a/Cslib/Languages/LambdaCalculus/LocallyNameless/Untyped/Basic.lean
+++ b/Cslib/Languages/LambdaCalculus/LocallyNameless/Untyped/Basic.lean
@@ -9,8 +9,6 @@ module
 public import Cslib.Foundations.Data.HasFresh
 public import Cslib.Foundations.Syntax.HasSubstitution
 
-@[expose] public section
-
 /-! # λ-calculus
 
 The untyped λ-calculus, with a locally nameless representation of syntax.
@@ -22,6 +20,8 @@ The untyped λ-calculus, with a locally nameless representation of syntax.
   this is partially adapted
 
 -/
+
+@[expose] public section
 
 namespace Cslib
 

--- a/Cslib/Languages/LambdaCalculus/LocallyNameless/Untyped/Congruence.lean
+++ b/Cslib/Languages/LambdaCalculus/LocallyNameless/Untyped/Congruence.lean
@@ -8,9 +8,9 @@ module
 
 public import Cslib.Languages.LambdaCalculus.LocallyNameless.Untyped.Properties
 
-public section
-
 /-! # Congruence for the λ-calculus -/
+
+public section
 
 namespace Cslib
 

--- a/Cslib/Languages/LambdaCalculus/LocallyNameless/Untyped/FullBeta.lean
+++ b/Cslib/Languages/LambdaCalculus/LocallyNameless/Untyped/FullBeta.lean
@@ -10,10 +10,6 @@ public import Cslib.Foundations.Data.Relation
 public import Cslib.Languages.LambdaCalculus.LocallyNameless.Untyped.Properties
 public import Cslib.Languages.LambdaCalculus.LocallyNameless.Untyped.Congruence
 
-public section
-
-set_option linter.unusedDecidableInType false
-
 /-! # β-reduction for the λ-calculus
 
 ## References
@@ -23,6 +19,10 @@ set_option linter.unusedDecidableInType false
   this is partially adapted
 
 -/
+
+public section
+
+set_option linter.unusedDecidableInType false
 
 namespace Cslib
 

--- a/Cslib/Languages/LambdaCalculus/LocallyNameless/Untyped/FullBetaConfluence.lean
+++ b/Cslib/Languages/LambdaCalculus/LocallyNameless/Untyped/FullBetaConfluence.lean
@@ -8,11 +8,11 @@ module
 
 public import Cslib.Languages.LambdaCalculus.LocallyNameless.Untyped.FullBeta
 
+/-! # β-confluence for the λ-calculus -/
+
 @[expose] public section
 
 set_option linter.unusedDecidableInType false
-
-/-! # β-confluence for the λ-calculus -/
 
 namespace Cslib
 

--- a/Cslib/Languages/LambdaCalculus/LocallyNameless/Untyped/FullBetaEtaConfluence.lean
+++ b/Cslib/Languages/LambdaCalculus/LocallyNameless/Untyped/FullBetaEtaConfluence.lean
@@ -9,10 +9,6 @@ module
 public import Cslib.Languages.LambdaCalculus.LocallyNameless.Untyped.FullBetaConfluence
 public import Cslib.Languages.LambdaCalculus.LocallyNameless.Untyped.FullEtaConfluence
 
-@[expose] public section
-
-set_option linter.unusedDecidableInType false
-
 /-! # βη-Confluence for the λ-calculus
 
 ## Reference
@@ -20,6 +16,10 @@ set_option linter.unusedDecidableInType false
 * [T. Nipkow, *More Church-Rosser Proofs (in Isabelle/HOL)*][Nipkow2001]
 
 -/
+
+@[expose] public section
+
+set_option linter.unusedDecidableInType false
 
 namespace Cslib
 

--- a/Cslib/Languages/LambdaCalculus/LocallyNameless/Untyped/FullEta.lean
+++ b/Cslib/Languages/LambdaCalculus/LocallyNameless/Untyped/FullEta.lean
@@ -10,11 +10,11 @@ public import Cslib.Foundations.Data.Relation
 public import Cslib.Languages.LambdaCalculus.LocallyNameless.Untyped.Properties
 public import Cslib.Languages.LambdaCalculus.LocallyNameless.Untyped.Congruence
 
+/-! # η-reduction for the λ-calculus -/
+
 public section
 
 set_option linter.unusedDecidableInType false
-
-/-! # η-reduction for the λ-calculus -/
 
 namespace Cslib
 

--- a/Cslib/Languages/LambdaCalculus/LocallyNameless/Untyped/FullEtaConfluence.lean
+++ b/Cslib/Languages/LambdaCalculus/LocallyNameless/Untyped/FullEtaConfluence.lean
@@ -8,10 +8,6 @@ module
 
 public import Cslib.Languages.LambdaCalculus.LocallyNameless.Untyped.FullEta
 
-@[expose] public section
-
-set_option linter.unusedDecidableInType false
-
 /-! # η-confluence for the λ-calculus
 
 ## Reference
@@ -19,6 +15,10 @@ set_option linter.unusedDecidableInType false
 * [T. Nipkow, *More Church-Rosser Proofs (in Isabelle/HOL)*][Nipkow2001]
 
 -/
+
+@[expose] public section
+
+set_option linter.unusedDecidableInType false
 
 namespace Cslib
 

--- a/Cslib/Languages/LambdaCalculus/LocallyNameless/Untyped/LcAt.lean
+++ b/Cslib/Languages/LambdaCalculus/LocallyNameless/Untyped/LcAt.lean
@@ -8,8 +8,6 @@ module
 
 public import Cslib.Languages.LambdaCalculus.LocallyNameless.Untyped.Basic
 
-@[expose] public section
-
 /-!
 
 Alternative Definitions for LC:
@@ -18,6 +16,8 @@ This module defines `LcAt k M`, a more general definition of local closure. When
 equivalent to `LC`, as shown in `lcAt_iff_LC`.
 
 -/
+
+@[expose] public section
 
 namespace Cslib.LambdaCalculus.LocallyNameless.Untyped.Term
 

--- a/Cslib/Languages/LambdaCalculus/LocallyNameless/Untyped/MultiApp.lean
+++ b/Cslib/Languages/LambdaCalculus/LocallyNameless/Untyped/MultiApp.lean
@@ -7,8 +7,9 @@ Authors: David Wegmann
 
 module
 
-
 public import Cslib.Languages.LambdaCalculus.LocallyNameless.Untyped.FullBeta
+
+/-! Multiple application for untyped lambda calculus. -/
 
 set_option linter.unusedDecidableInType false
 

--- a/Cslib/Languages/LambdaCalculus/LocallyNameless/Untyped/MultiSubst.lean
+++ b/Cslib/Languages/LambdaCalculus/LocallyNameless/Untyped/MultiSubst.lean
@@ -13,6 +13,8 @@ public import Cslib.Foundations.Syntax.HasSubstitution
 public import Cslib.Languages.LambdaCalculus.LocallyNameless.Stlc.Basic
 public import Cslib.Languages.LambdaCalculus.LocallyNameless.Untyped.FullBeta
 
+/-! Multiple substitution for untyped lambda calculus. -/
+
 @[expose] public section
 
 namespace Cslib

--- a/Cslib/Languages/LambdaCalculus/LocallyNameless/Untyped/Properties.lean
+++ b/Cslib/Languages/LambdaCalculus/LocallyNameless/Untyped/Properties.lean
@@ -8,6 +8,8 @@ module
 
 public import Cslib.Languages.LambdaCalculus.LocallyNameless.Untyped.Basic
 
+/-! General properties of opening and substitution in untyped lambda calculus terms. -/
+
 public section
 
 namespace Cslib

--- a/Cslib/Languages/LambdaCalculus/LocallyNameless/Untyped/StrongNorm.lean
+++ b/Cslib/Languages/LambdaCalculus/LocallyNameless/Untyped/StrongNorm.lean
@@ -10,6 +10,8 @@ public import Cslib.Languages.LambdaCalculus.LocallyNameless.Untyped.FullBeta
 public import Cslib.Languages.LambdaCalculus.LocallyNameless.Untyped.MultiApp
 public import Cslib.Languages.LambdaCalculus.LocallyNameless.Untyped.LcAt
 
+/-! Strong normalization (termination) for full beta-reduction of untyped lamba calulus. -/
+
 @[expose] public section
 
 set_option linter.unusedDecidableInType false

--- a/Cslib/Languages/LambdaCalculus/Named/Untyped/Basic.lean
+++ b/Cslib/Languages/LambdaCalculus/Named/Untyped/Basic.lean
@@ -10,8 +10,6 @@ public import Cslib.Foundations.Data.HasFresh
 public import Cslib.Foundations.Syntax.HasAlphaEquiv
 public import Cslib.Foundations.Syntax.HasSubstitution
 
-@[expose] public section
-
 /-! # λ-calculus
 
 The untyped λ-calculus.
@@ -21,6 +19,8 @@ The untyped λ-calculus.
 * [H. Barendregt, *Introduction to Lambda Calculus*][Barendregt1984]
 
 -/
+
+@[expose] public section
 
 namespace Cslib
 

--- a/Cslib/Logics/HML/Basic.lean
+++ b/Cslib/Logics/HML/Basic.lean
@@ -8,8 +8,6 @@ module
 
 public import Cslib.Foundations.Semantics.LTS.Bisimulation
 
-@[expose] public section
-
 /-! # Hennessy-Milner Logic (HML)
 
 Hennessy-Milner Logic (HML) is a logic for reasoning about the behaviour of nondeterministic and
@@ -45,6 +43,8 @@ distinguishing proposition that one state satisfies and the other does not.
 * [L. Aceto, A. Ingólfsdóttir, *Testing Hennessy-Milner Logic with Recursion*][Aceto1999]
 
 -/
+
+@[expose] public section
 
 namespace Cslib.Logic.HML
 

--- a/Cslib/Logics/HML/LogicalEquivalence.lean
+++ b/Cslib/Logics/HML/LogicalEquivalence.lean
@@ -9,12 +9,12 @@ module
 public import Cslib.Logics.HML.Basic
 public import Cslib.Foundations.Logic.LogicalEquivalence
 
-@[expose] public section
-
 /-! # Logical Equivalence in HML
 
 This module defines logical equivalence for HML propositions and instantiates `LogicalEquivalence`.
 -/
+
+@[expose] public section
 
 namespace Cslib.Logic.HML
 

--- a/Cslib/Logics/LinearLogic/CLL/Basic.lean
+++ b/Cslib/Logics/LinearLogic/CLL/Basic.lean
@@ -12,8 +12,6 @@ public import Cslib.Foundations.Logic.InferenceSystem
 public import Cslib.Foundations.Logic.LogicalEquivalence
 public import Mathlib.Data.Multiset.Fold
 
-@[expose] public section
-
 /-! # Classical Linear Logic
 
 ## TODO
@@ -25,6 +23,8 @@ public import Mathlib.Data.Multiset.Fold
 * [J.-Y. Girard, *Linear Logic: its syntax and semantics*][Girard1995]
 
 -/
+
+@[expose] public section
 
 namespace Cslib.Logic.CLL
 

--- a/Cslib/Logics/LinearLogic/CLL/CutElimination.lean
+++ b/Cslib/Logics/LinearLogic/CLL/CutElimination.lean
@@ -8,6 +8,8 @@ module
 
 public import Cslib.Logics.LinearLogic.CLL.Basic
 
+/-! -/
+
 @[expose] public section
 
 namespace Cslib.Logic.CLL

--- a/Cslib/Logics/LinearLogic/CLL/EtaExpansion.lean
+++ b/Cslib/Logics/LinearLogic/CLL/EtaExpansion.lean
@@ -8,9 +8,9 @@ module
 
 public import Cslib.Logics.LinearLogic.CLL.Basic
 
-@[expose] public section
-
 /-! # η-expansion for Classical Linear Logic (CLL) -/
+
+@[expose] public section
 
 namespace Cslib.Logic.CLL
 

--- a/Cslib/Logics/LinearLogic/CLL/MLL.lean
+++ b/Cslib/Logics/LinearLogic/CLL/MLL.lean
@@ -9,8 +9,6 @@ module
 public import Cslib.Logics.LinearLogic.CLL.Basic
 public import Cslib.Foundations.Logic.InferenceSystem
 
-@[expose] public section
-
 /-! # Multiplicative Classical Linear Logic (MLL)
 
 Multiplicative classical linear logic, defined as a fragment of classical linear logic by means of
@@ -50,6 +48,8 @@ where go {Γ : CLL.Sequent Atom} (p : ⇓Γ) (hp : p.IsMLL) : Bool :=
   | .tensor p q, hp => go p hp.left && go q hp.right
 ```
 -/
+
+@[expose] public section
 
 namespace Cslib.Logic.CLL
 

--- a/Cslib/Logics/LinearLogic/CLL/PhaseSemantics/Basic.lean
+++ b/Cslib/Logics/LinearLogic/CLL/PhaseSemantics/Basic.lean
@@ -11,8 +11,6 @@ public import Mathlib.Algebra.Group.Idempotent
 public import Mathlib.Order.Closure
 public import Cslib.Logics.LinearLogic.CLL.Basic
 
-@[expose] public section
-
 /-!
 # Phase semantics for Classical Linear Logic
 
@@ -53,6 +51,8 @@ Several lemmas about facts and orthogonality useful in the proof of soundness ar
 * [J.-Y. Girard, *Linear logic*][Girard1987]
 * [J.-Y. Girard, *Linear Logic: its syntax and semantics*][Girard1995]
 -/
+
+@[expose] public section
 
 namespace Cslib.Logic.CLL
 

--- a/Cslib/Logics/Propositional/Defs.lean
+++ b/Cslib/Logics/Propositional/Defs.lean
@@ -11,8 +11,6 @@ public import Mathlib.Data.FunLike.Basic
 public import Mathlib.Data.Set.Image
 public import Mathlib.Order.TypeTags
 
-@[expose] public section
-
 /-! # Propositions and theories
 
 ## Main definitions
@@ -33,6 +31,8 @@ theory.
 We introduce notation for the logical connectives: `⊥ ⊤ ⋏ ⋎ ⟶ ~` for, respectively, falsum, verum,
 conjunction, disjunction, implication and negation.
 -/
+
+@[expose] public section
 
 universe u
 


### PR DESCRIPTION
I recently discovered that while the header linter is included as part of the weekly linting set that CSLib enables, its implementation was such that it only worked in Mathlib. Kim has kindly fixed this in https://github.com/leanprover-community/mathlib4/pull/38396, which should be merged soon.

Unfortunately, when I did the port to the module system, I accidentally placed some of the `public section` incorrectly above the module docstring, getting no warning from the header linter, and subsequently others followed my lead. Most of the changes here are just this, plus just a few missing module docstrings and typos.