### PR TITLE
ci: use `INFO=true` for weekly linting

### DIFF
--- a/.github/workflows/weekly-lints.yml
+++ b/.github/workflows/weekly-lints.yml
@@ -58,6 +58,7 @@ jobs:
         SHA=${{ github.sha }} \
         REPO=${{ github.repository }} \
         RUN_ID=${{ github.run_id }} \
+        INFO=true \
           "${CI_SCRIPTS_DIR}/reporting/zulip_build_report.sh" "${lean_outfile}" > "${GITHUB_OUTPUT}"
 
     - name: Post output to Zulip


### PR DESCRIPTION
This adds back `info` messages for the weekly linting report, see https://github.com/leanprover-community/mathlib-ci/pull/23 for more context.