### PR TITLE
feat(data structures): simple functional queue from Okasaki

### DIFF
--- a/Cslib.lean
+++ b/Cslib.lean
@@ -3,6 +3,7 @@ module  -- shake: keep-all --deprecated_module: ignore
 public import Cslib.Algorithms.Lean.FunctionalQueue.FunctionalQueue
 public import Cslib.Algorithms.Lean.MergeSort.MergeSort
 public import Cslib.Algorithms.Lean.TimeM
+public import Cslib.Algorithms.Lean.Amortized
 public import Cslib.Computability.Automata.Acceptors.Acceptor
 public import Cslib.Computability.Automata.Acceptors.OmegaAcceptor
 public import Cslib.Computability.Automata.DA.Basic

--- a/Cslib.lean
+++ b/Cslib.lean
@@ -1,5 +1,6 @@
 module  -- shake: keep-all --deprecated_module: ignore
 
+public import Cslib.Algorithms.Lean.FunctionalQueue.FunctionalQueue
 public import Cslib.Algorithms.Lean.MergeSort.MergeSort
 public import Cslib.Algorithms.Lean.TimeM
 public import Cslib.Computability.Automata.Acceptors.Acceptor

--- a/Cslib.lean
+++ b/Cslib.lean
@@ -1,9 +1,9 @@
 module  -- shake: keep-all --deprecated_module: ignore
 
+public import Cslib.Algorithms.Lean.Amortized
 public import Cslib.Algorithms.Lean.FunctionalQueue.FunctionalQueue
 public import Cslib.Algorithms.Lean.MergeSort.MergeSort
 public import Cslib.Algorithms.Lean.TimeM
-public import Cslib.Algorithms.Lean.Amortized
 public import Cslib.Computability.Automata.Acceptors.Acceptor
 public import Cslib.Computability.Automata.Acceptors.OmegaAcceptor
 public import Cslib.Computability.Automata.DA.Basic

--- a/Cslib/Algorithms/Lean/Amortized.lean
+++ b/Cslib/Algorithms/Lean/Amortized.lean
@@ -29,8 +29,6 @@ class Potential φ α extends CommRing φ, LinearOrder φ, IsStrictOrderedRing �
   /-- [Okasaki, *Purely Functional Data Structures*, 1996][okasaki1996] -/
   potential : α → φ
 
-  potentialNonNegative : forall (x : α), (potential x : φ) ≥ 0
-
 class Op α o where
   applyOp : α → o → TimeM ℕ α
 
@@ -77,7 +75,7 @@ theorem constantAmortizedCostL {α o φ : Type*}
     set potX := (Potential.potential x : φ)
     set potOpX := (Potential.potential applyOpX.ret : φ)
     set potOps2 := (Potential.potential applyOps2.ret : φ)
-    have potOpXPos := (Potential.potentialNonNegative (φ := φ) applyOpX.ret)
+    /- have potOpXPos := (Potential.potentialNonNegative (φ := φ) applyOpX.ret) -/
     ring_nf
     have jfdoit := add_le_add bound1 bound2
     ring_nf at jfdoit

--- a/Cslib/Algorithms/Lean/Amortized.lean
+++ b/Cslib/Algorithms/Lean/Amortized.lean
@@ -26,9 +26,13 @@ This complements `TimeM` in the cases where amortized costs are necessary.
 namespace Cslib.Algorithms.Lean.Amortized
 
 /-- Physicist method: a potential (lower bound on savings) defined on a
-    data structure -/
-class Potential φ α [CommRing φ] [LinearOrder φ] [IsStrictOrderedRing φ] where
-  /-- [Okasaki, *Purely Functional Data Structures*, 1996][okasaki1996] -/
+    data structure.
+    [Okasaki, *Purely Functional Data Structures*, 1996][okasaki1996] -/
+class Potential (φ α : Type*) [CommRing φ] [LinearOrder φ] [IsStrictOrderedRing φ] where
+  /-- The potential, a representation of savings accumulated (just like
+      potential energy), to be released later. In some functional data
+      structures, amortized costs allow some operations to be more expensive
+      by "using" potential previously accumulated in cheaper operations. -/
   potential : α → φ
 
 class Op α o where

--- a/Cslib/Algorithms/Lean/Amortized.lean
+++ b/Cslib/Algorithms/Lean/Amortized.lean
@@ -23,8 +23,7 @@ namespace Cslib.Algorithms.Lean.Amortized
 /-- Physicist method: a potential (lower bound on savings) defined on a
     data structure -/
 class Potential α where
-  /-- Initial potential should be 0.
-      [Okasaki, *Purely Functional Data Structures*, 1996][okasaki1996] -/
+  /-- [Okasaki, *Purely Functional Data Structures*, 1996][okasaki1996] -/
   potential : α → Nat
 
 class Op α o where
@@ -33,14 +32,6 @@ class Op α o where
 @[simp] def applyOps {α o : Type*} [Op α o] (x : α) (ops : List o)
     : TimeM ℕ α :=
   List.foldlM (fun x op => Op.applyOp x op) x ops
-
-def triples {α o : Type*} [Op α o] (x : α) (ops : List o) : List (α × o) × α :=
-  match ops with
-  | [] => ([], x)
-  | o :: ops2 =>
-    let ⟨ x2, _cost ⟩ := Op.applyOp x o
-    let ⟨ pairs, final ⟩ := triples x2 ops2
-    ((x2, o) :: pairs, final)
 
 /-- Amortized cost with the physicist's method,
     following Okasaki, chapter 5 -/

--- a/Cslib/Algorithms/Lean/Amortized.lean
+++ b/Cslib/Algorithms/Lean/Amortized.lean
@@ -25,7 +25,7 @@ namespace Cslib.Algorithms.Lean.Amortized
 
 /-- Physicist method: a potential (lower bound on savings) defined on a
     data structure -/
-class Potential φ α extends CommRing φ, PartialOrder φ, IsStrictOrderedRing φ where
+class Potential φ α extends CommRing φ, LinearOrder φ, IsStrictOrderedRing φ where
   /-- [Okasaki, *Purely Functional Data Structures*, 1996][okasaki1996] -/
   potential : α → φ
 
@@ -51,7 +51,7 @@ def amortizedCost {α o φ : Type*}
   cost over a series of operations is bounded by `k * ops.length`. -/
 theorem constantAmortizedCostL {α o φ : Type*}
     [h_op : Op α o] [h_pot : Potential φ α]
-    (k : φ) (h_k_pos : k > 0) (h_bounded : ∀ (x : α) (op : o), amortizedCost x op ≤ k)
+    (k : φ) (h_bounded : ∀ (x : α) (op : o), amortizedCost x op ≤ k)
     (x : α) (ops : List o)
     : (applyOps x ops).time
         + Potential.potential (applyOps x ops).ret - Potential.potential x
@@ -81,7 +81,6 @@ theorem constantAmortizedCostL {α o φ : Type*}
     ring_nf
     have jfdoit := add_le_add bound1 bound2
     ring_nf at jfdoit
-    exact jfdoit
     linarith
 
 end Cslib.Algorithms.Lean.Amortized

--- a/Cslib/Algorithms/Lean/Amortized.lean
+++ b/Cslib/Algorithms/Lean/Amortized.lean
@@ -35,29 +35,28 @@ class Potential (φ α : Type*) [CommRing φ] [LinearOrder φ] [IsStrictOrderedR
       by "using" potential previously accumulated in cheaper operations. -/
   potential : α → φ
 
-class Op α o where
-  applyOp : α → o → TimeM ℕ α
+abbrev Op α := α → TimeM ℕ α
 
-@[simp] def applyOps {α o : Type*} [Op α o] (x : α) (ops : List o)
+@[simp] def applyOps {α : Type*} (x : α) (ops : List (Op α))
     : TimeM ℕ α :=
-  List.foldlM (fun x op => Op.applyOp x op) x ops
+  List.foldlM (fun x op => op x) x ops
 
 /-- Amortized cost with the physicist's method,
     following Okasaki, chapter 5 -/
-def amortizedCost {α o φ : Type*}
-    [Op α o] [CommRing φ] [LinearOrder φ] [IsStrictOrderedRing φ] [Potential φ α]
-    (x : α) (op : o) : φ :=
-  Nat.cast (Op.applyOp x op).time
-    + Potential.potential (Op.applyOp x op).ret
+def amortizedCost {α φ : Type*}
+    [CommRing φ] [LinearOrder φ] [IsStrictOrderedRing φ] [Potential φ α]
+    (x : α) (op : Op α) : φ :=
+  Nat.cast (op x).time
+    + Potential.potential (op x).ret
     - Potential.potential x
 
 /-- If each operation's cost is bounded by `k`, then the amortized
   cost over a series of operations is bounded by `k * ops.length`. -/
-theorem constantAmortizedCostL {α o φ : Type*}
+theorem constantAmortizedCostL {α φ : Type*}
     [CommRing φ] [LinearOrder φ] [IsStrictOrderedRing φ]
-    [h_op : Op α o] [h_pot : Potential φ α]
-    (k : φ) (h_bounded : ∀ (x : α) (op : o), amortizedCost x op ≤ k)
-    (x : α) (ops : List o)
+    [h_pot : Potential φ α]
+    (k : φ) (h_bounded : ∀ (x : α) (op : Op α), amortizedCost x op ≤ k)
+    (x : α) (ops : List (Op α))
     : (applyOps x ops).time
         + Potential.potential (applyOps x ops).ret - Potential.potential x
       ≤ k * Nat.cast ops.length
@@ -76,15 +75,15 @@ theorem constantAmortizedCostL {α o φ : Type*}
     simp only [List.foldlM, TimeM.time_bind, Nat.cast_add, TimeM.ret_bind, List.length_cons,
       Nat.cast_one]
     have bound1 := h_bounded x op
-    have bound2 := h_ind (Op.applyOp x op).ret
-    set applyOpX := (Op.applyOp x op : TimeM ℕ α)
-    set applyOps2 := (List.foldlM (fun x op => Op.applyOp x op) (Op.applyOp x op).ret ops2)
+    have bound2 := h_ind (op x).ret
+    set applyOpX := (op x : TimeM ℕ α)
+    set applyOps2 := (List.foldlM (fun x op => op x) (op x).ret ops2)
     set potX := (Potential.potential x : φ)
     set potOpX := (Potential.potential applyOpX.ret : φ)
     set potOps2 := (Potential.potential applyOps2.ret : φ)
     /- have potOpXPos := (Potential.potentialNonNegative (φ := φ) applyOpX.ret) -/
-    ring_nf
     have jfdoit := add_le_add bound1 bound2
+    ring_nf
     ring_nf at jfdoit
     linarith
 

--- a/Cslib/Algorithms/Lean/Amortized.lean
+++ b/Cslib/Algorithms/Lean/Amortized.lean
@@ -9,6 +9,9 @@ module
 import Cslib.Init
 import Mathlib
 public import Cslib.Algorithms.Lean.TimeM
+public import Mathlib.Algebra.Ring.Defs
+public import Mathlib.Order.Defs.PartialOrder
+public import Mathlib.Algebra.Order.Ring.Defs
 
 /-!
 # Amortized cost analysis
@@ -22,9 +25,11 @@ namespace Cslib.Algorithms.Lean.Amortized
 
 /-- Physicist method: a potential (lower bound on savings) defined on a
     data structure -/
-class Potential α where
+class Potential φ α extends CommRing φ, PartialOrder φ, IsStrictOrderedRing φ where
   /-- [Okasaki, *Purely Functional Data Structures*, 1996][okasaki1996] -/
-  potential : α → Nat
+  potential : α → φ
+
+  potentialNonNegative : forall (x : α), (potential x : φ) ≥ 0
 
 class Op α o where
   applyOp : α → o → TimeM ℕ α
@@ -35,36 +40,48 @@ class Op α o where
 
 /-- Amortized cost with the physicist's method,
     following Okasaki, chapter 5 -/
-def amortizedCost {α o : Type*} [Op α o] [Potential α]
-    (x : α) (op : o) : ℕ :=
-  (Op.applyOp x op).time
+def amortizedCost {α o φ : Type*}
+    [Op α o] [Add φ] [Sub φ] [NatCast φ] [Potential φ α]
+    (x : α) (op : o) : φ :=
+  Nat.cast (Op.applyOp x op).time
     + Potential.potential (Op.applyOp x op).ret
-    - Potential.potential x
-
-def amortizedCostL {α o : Type*} [Op α o] [Potential α]
-    (x : α) (ops : List o) : ℕ :=
-  (applyOps x ops).time
-    + Potential.potential (applyOps x ops).ret
     - Potential.potential x
 
 /-- If each operation's cost is bounded by `k`, then the amortized
   cost over a series of operations is bounded by `k * ops.length`. -/
-theorem constantAmortizedCostL {α o : Type*}
-    [h_op : Op α o] [h_pot : Potential α]
-    (k : ℕ) (h_bounded : ∀ (x : α) (op : o), amortizedCost x op ≤ k)
+theorem constantAmortizedCostL {α o φ : Type*}
+    [h_op : Op α o] [h_pot : Potential φ α]
+    (k : φ) (h_k_pos : k > 0) (h_bounded : ∀ (x : α) (op : o), amortizedCost x op ≤ k)
     (x : α) (ops : List o)
-    : amortizedCostL x ops ≤ k * ops.length
+    : (applyOps x ops).time
+        + Potential.potential (applyOps x ops).ret - Potential.potential x
+      ≤ k * Nat.cast ops.length
     := by
-  simp only [amortizedCostL, applyOps, tsub_le_iff_right]
+  simp only [applyOps]
   revert x
   induction ops with
-  | nil => simp [List.foldlM]
+  | nil =>
+    intro x
+    simp only [List.foldlM, TimeM.time_pure, CharP.cast_eq_zero,
+      TimeM.ret_pure, zero_add, sub_self,
+      List.length_nil, mul_zero, Std.le_refl]
   | cons op ops2 h_ind =>
     intro x
-    simp only [amortizedCost, tsub_le_iff_right] at h_bounded
-    simp [List.foldlM, List.length_cons]
+    simp only [amortizedCost] at h_bounded
+    simp only [List.foldlM, TimeM.time_bind, Nat.cast_add, TimeM.ret_bind, List.length_cons,
+      Nat.cast_one]
     have bound1 := h_bounded x op
     have bound2 := h_ind (Op.applyOp x op).ret
+    set applyOpX := (Op.applyOp x op : TimeM ℕ α)
+    set applyOps2 := (List.foldlM (fun x op => Op.applyOp x op) (Op.applyOp x op).ret ops2)
+    set potX := (Potential.potential x : φ)
+    set potOpX := (Potential.potential applyOpX.ret : φ)
+    set potOps2 := (Potential.potential applyOps2.ret : φ)
+    have potOpXPos := (Potential.potentialNonNegative (φ := φ) applyOpX.ret)
+    ring_nf
+    have jfdoit := add_le_add bound1 bound2
+    ring_nf at jfdoit
+    exact jfdoit
     linarith
 
 end Cslib.Algorithms.Lean.Amortized

--- a/Cslib/Algorithms/Lean/Amortized.lean
+++ b/Cslib/Algorithms/Lean/Amortized.lean
@@ -1,4 +1,3 @@
-
 /-
 Copyright (c) 2026 Simon Cruanes. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
@@ -8,6 +7,7 @@ Authors: Simon Cruanes
 module
 
 import Cslib.Init
+public import Cslib.Algorithms.Lean.TimeM
 
 /-!
 # Amortized cost analysis
@@ -25,6 +25,18 @@ class Potential α where
   /-- non-negative potential. Initial potential should be 0.
       [Okasaki, *Purely Functional Data Structures*, 1996][okasaki1996] -/
   potential : α → Nat
+
+class Op α o where
+  applyOp : α → o → TimeM ℕ α
+
+@[simp] def applyOps {α o : Type u} [Op α o] (ops : List o) (x : α)
+    : TimeM ℕ α :=
+  List.foldlM (fun x op => Op.applyOp x op) x ops
+
+/-- Amortized cost with the physicist's method,
+    following Okasaki, chapter 5 -/
+def amortizedCost {α o : Type*} [Op α o] [Potential α] (x : α) (op : o) : ℕ :=
+  (Op.applyOp x op).time + Potential.potential (Op.applyOp x op).ret - Potential.potential x
 
 end Cslib.Algorithms.Lean.Amortized
 

--- a/Cslib/Algorithms/Lean/Amortized.lean
+++ b/Cslib/Algorithms/Lean/Amortized.lean
@@ -7,6 +7,7 @@ Authors: Simon Cruanes
 module
 
 import Cslib.Init
+import Mathlib
 public import Cslib.Algorithms.Lean.TimeM
 
 /-!
@@ -22,21 +23,58 @@ namespace Cslib.Algorithms.Lean.Amortized
 /-- Physicist method: a potential (lower bound on savings) defined on a
     data structure -/
 class Potential α where
-  /-- non-negative potential. Initial potential should be 0.
+  /-- Initial potential should be 0.
       [Okasaki, *Purely Functional Data Structures*, 1996][okasaki1996] -/
   potential : α → Nat
 
 class Op α o where
   applyOp : α → o → TimeM ℕ α
 
-@[simp] def applyOps {α o : Type u} [Op α o] (ops : List o) (x : α)
+@[simp] def applyOps {α o : Type*} [Op α o] (x : α) (ops : List o)
     : TimeM ℕ α :=
   List.foldlM (fun x op => Op.applyOp x op) x ops
 
+def triples {α o : Type*} [Op α o] (x : α) (ops : List o) : List (α × o) × α :=
+  match ops with
+  | [] => ([], x)
+  | o :: ops2 =>
+    let ⟨ x2, _cost ⟩ := Op.applyOp x o
+    let ⟨ pairs, final ⟩ := triples x2 ops2
+    ((x2, o) :: pairs, final)
+
 /-- Amortized cost with the physicist's method,
     following Okasaki, chapter 5 -/
-def amortizedCost {α o : Type*} [Op α o] [Potential α] (x : α) (op : o) : ℕ :=
-  (Op.applyOp x op).time + Potential.potential (Op.applyOp x op).ret - Potential.potential x
+def amortizedCost {α o : Type*} [Op α o] [Potential α]
+    (x : α) (op : o) : ℕ :=
+  (Op.applyOp x op).time
+    + Potential.potential (Op.applyOp x op).ret
+    - Potential.potential x
+
+def amortizedCostL {α o : Type*} [Op α o] [Potential α]
+    (x : α) (ops : List o) : ℕ :=
+  (applyOps x ops).time
+    + Potential.potential (applyOps x ops).ret
+    - Potential.potential x
+
+/-- If each operation's cost is bounded by `k`, then the amortized
+  cost over a series of operations is bounded by `k * ops.length`. -/
+theorem constantAmortizedCostL {α o : Type*}
+    [h_op : Op α o] [h_pot : Potential α]
+    (k : ℕ) (h_bounded : ∀ (x : α) (op : o), amortizedCost x op ≤ k)
+    (x : α) (ops : List o)
+    : amortizedCostL x ops ≤ k * ops.length
+    := by
+  simp only [amortizedCostL, applyOps, tsub_le_iff_right]
+  revert x
+  induction ops with
+  | nil => simp [List.foldlM]
+  | cons op ops2 h_ind =>
+    intro x
+    simp only [amortizedCost, tsub_le_iff_right] at h_bounded
+    simp [List.foldlM, List.length_cons]
+    have bound1 := h_bounded x op
+    have bound2 := h_ind (Op.applyOp x op).ret
+    linarith
 
 end Cslib.Algorithms.Lean.Amortized
 

--- a/Cslib/Algorithms/Lean/Amortized.lean
+++ b/Cslib/Algorithms/Lean/Amortized.lean
@@ -12,6 +12,8 @@ public import Cslib.Algorithms.Lean.TimeM
 public import Mathlib.Algebra.Ring.Defs
 public import Mathlib.Order.Defs.PartialOrder
 public import Mathlib.Algebra.Order.Ring.Defs
+public import Mathlib.Algebra.Ring.Int.Defs
+public import Mathlib.Algebra.Order.Ring.Int
 
 /-!
 # Amortized cost analysis
@@ -25,7 +27,7 @@ namespace Cslib.Algorithms.Lean.Amortized
 
 /-- Physicist method: a potential (lower bound on savings) defined on a
     data structure -/
-class Potential φ α extends CommRing φ, LinearOrder φ, IsStrictOrderedRing φ where
+class Potential φ α [CommRing φ] [LinearOrder φ] [IsStrictOrderedRing φ] where
   /-- [Okasaki, *Purely Functional Data Structures*, 1996][okasaki1996] -/
   potential : α → φ
 
@@ -39,7 +41,7 @@ class Op α o where
 /-- Amortized cost with the physicist's method,
     following Okasaki, chapter 5 -/
 def amortizedCost {α o φ : Type*}
-    [Op α o] [Add φ] [Sub φ] [NatCast φ] [Potential φ α]
+    [Op α o] [CommRing φ] [LinearOrder φ] [IsStrictOrderedRing φ] [Potential φ α]
     (x : α) (op : o) : φ :=
   Nat.cast (Op.applyOp x op).time
     + Potential.potential (Op.applyOp x op).ret
@@ -48,6 +50,7 @@ def amortizedCost {α o φ : Type*}
 /-- If each operation's cost is bounded by `k`, then the amortized
   cost over a series of operations is bounded by `k * ops.length`. -/
 theorem constantAmortizedCostL {α o φ : Type*}
+    [CommRing φ] [LinearOrder φ] [IsStrictOrderedRing φ]
     [h_op : Op α o] [h_pot : Potential φ α]
     (k : φ) (h_bounded : ∀ (x : α) (op : o), amortizedCost x op ≤ k)
     (x : α) (ops : List o)

--- a/Cslib/Algorithms/Lean/Amortized.lean
+++ b/Cslib/Algorithms/Lean/Amortized.lean
@@ -1,0 +1,31 @@
+
+/-
+Copyright (c) 2026 Simon Cruanes. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Simon Cruanes
+-/
+
+module
+
+import Cslib.Init
+
+/-!
+# Amortized cost analysis
+
+This complements `TimeM` in the cases where amortized costs are necessary.
+-/
+
+@[expose] public section
+
+namespace Cslib.Algorithms.Lean.Amortized
+
+/-- Physicist method: a potential (lower bound on savings) defined on a
+    data structure -/
+class Potential α where
+  /-- non-negative potential. Initial potential should be 0.
+      [Okasaki, *Purely Functional Data Structures*, 1996][okasaki1996] -/
+  potential : α → Nat
+
+end Cslib.Algorithms.Lean.Amortized
+
+end

--- a/Cslib/Algorithms/Lean/Amortized.lean
+++ b/Cslib/Algorithms/Lean/Amortized.lean
@@ -38,6 +38,7 @@ class Potential (φ α : Type*) [CommRing φ] [LinearOrder φ] [IsStrictOrderedR
 /-- An operation that takes a state and returns a new state with its execution time. -/
 abbrev Op α := α → TimeM ℕ α
 
+/-- Apply a list of operations sequentially, threading the state through. -/
 @[simp] def applyOps {α : Type*} (x : α) (ops : List (Op α))
     : TimeM ℕ α :=
   List.foldlM (fun x op => op x) x ops

--- a/Cslib/Algorithms/Lean/Amortized.lean
+++ b/Cslib/Algorithms/Lean/Amortized.lean
@@ -35,6 +35,7 @@ class Potential (φ α : Type*) [CommRing φ] [LinearOrder φ] [IsStrictOrderedR
       by "using" potential previously accumulated in cheaper operations. -/
   potential : α → φ
 
+/-- An operation on a data structure that takes a state and returns a new state with its execution time. -/
 abbrev Op α := α → TimeM ℕ α
 
 @[simp] def applyOps {α : Type*} (x : α) (ops : List (Op α))

--- a/Cslib/Algorithms/Lean/Amortized.lean
+++ b/Cslib/Algorithms/Lean/Amortized.lean
@@ -35,7 +35,7 @@ class Potential (φ α : Type*) [CommRing φ] [LinearOrder φ] [IsStrictOrderedR
       by "using" potential previously accumulated in cheaper operations. -/
   potential : α → φ
 
-/-- An operation on a data structure that takes a state and returns a new state with its execution time. -/
+/-- An operation that takes a state and returns a new state with its execution time. -/
 abbrev Op α := α → TimeM ℕ α
 
 @[simp] def applyOps {α : Type*} (x : α) (ops : List (Op α))

--- a/Cslib/Algorithms/Lean/FunctionalQueue/FunctionalQueue.lean
+++ b/Cslib/Algorithms/Lean/FunctionalQueue/FunctionalQueue.lean
@@ -8,6 +8,7 @@ module
 
 import Cslib.Init
 public import Cslib.Algorithms.Lean.Amortized
+public import Cslib.Algorithms.Lean.TimeM
 
 /-!
 # Functional Queue
@@ -31,78 +32,89 @@ namespace Cslib.Algorithms.Lean
 
 universe u
 
-structure RawFunctionalQueue (α : Type u) where
+namespace Raw
+
+structure FunctionalQueue (α : Type u) where
   front : List α
   back : List α
 
-namespace Raw
-
 /-- Well-formedness: if front is empty, back must be empty too. -/
-def invariant {α : Type u} (q : RawFunctionalQueue α) : Prop :=
+def invariant {α : Type u} (q : Raw.FunctionalQueue α) : Prop :=
   q.front = [] → q.back = []
 
 /-- The logical contents of the queue: `front ++ back.reverse`. -/
-def ghostList {α : Type u} (q : RawFunctionalQueue α) : List α :=
+def ghostList {α : Type u} (q : FunctionalQueue α) : List α :=
   List.append q.front q.back.reverse
 
 /-- The empty queue. -/
-def empty {α : Type u} : RawFunctionalQueue α := ⟨ [], [] ⟩
+def empty {α : Type u} : FunctionalQueue α := ⟨ [], [] ⟩
 
 /-- Internal: rebalance by moving `back.reverse` to `front` when `front` is empty. -/
-def rebalance {α : Type u} (q : RawFunctionalQueue α) : RawFunctionalQueue α :=
+def rebalance {α : Type u} (q : FunctionalQueue α)
+    : TimeM ℕ (FunctionalQueue α) :=
   match q.front with
-  | [] => ⟨ (q.back).reverse, [] ⟩
-  | _ => q
+  | [] => do
+    TimeM.tick q.back.length
+    pure ⟨ (q.back).reverse, [] ⟩
+  | _ => pure q
 
-theorem rebalanceInvert {α : Type u} (q : RawFunctionalQueue α) :
-    (rebalance q).front = [] → q = Raw.empty := by
+theorem rebalanceInvert {α : Type u} (q : FunctionalQueue α) :
+    (rebalance q).ret.front = [] → q = empty := by
   intro h
   obtain ⟨f, b⟩ := q
   simp only [rebalance, Raw.empty] at h ⊢
   split at h <;> simp_all
 
-theorem rebalanceInvariant {α : Type u} {q : RawFunctionalQueue α} :
-    invariant (rebalance q) := by
+theorem rebalanceInvariant {α : Type u} {q : FunctionalQueue α} :
+    invariant (rebalance q).ret := by
   obtain ⟨f, b⟩ := q
   simp [rebalance, invariant]
   split <;> grind
 
-@[simp] theorem rebalanceIdempotent {α : Type u} (q : RawFunctionalQueue α) :
-    rebalance (rebalance q) = rebalance q := by
+@[simp] theorem rebalanceIdempotent {α : Type u} (q : FunctionalQueue α) :
+    (rebalance (rebalance q).ret).ret = (rebalance q).ret := by
   obtain ⟨f, b⟩ := q
   simp [rebalance]
   split <;> grind
 
-@[simp] theorem rebalancePreserveGhost {α : Type u} (q : RawFunctionalQueue α) :
-    ghostList (rebalance q) = ghostList q := by
+@[simp] theorem rebalancePreserveGhost {α : Type u} (q : FunctionalQueue α) :
+    ghostList (rebalance q).ret = ghostList q := by
   obtain ⟨f, b⟩ := q
   simp [rebalance, ghostList]
   split <;> grind [List.reverse_append]
 
 /-- Enqueue an element. -/
-def push {α : Type u} (x : α) (q : RawFunctionalQueue α) : RawFunctionalQueue α :=
+def push {α : Type u} (x : α) (q : FunctionalQueue α)
+    : TimeM ℕ (FunctionalQueue α) := do
+  TimeM.tick 1
   rebalance ⟨ q.front, x :: q.back ⟩
 
-theorem pushInvariant {α : Type u} (x : α) (q : RawFunctionalQueue α) :
-    invariant q → invariant (push x q) := by
+theorem pushInvariant {α : Type u} (x : α) (q : FunctionalQueue α)
+    : invariant q → invariant (push x q).ret := by
   intro h
   rw [push]
   apply rebalanceInvariant
 
-theorem pushGhost {α : Type u} (x : α) (q : RawFunctionalQueue α) :
-    ghostList (push x q) = ghostList q ++ [x] := by
-  rw [push, rebalancePreserveGhost, ghostList]
+theorem pushGhost {α : Type u} (x : α) (q : Raw.FunctionalQueue α)
+    : ghostList (push x q).ret = ghostList q ++ [x] := by
+  rw [push]
+  simp only [TimeM.ret_bind, rebalancePreserveGhost]
+  rw [ghostList]
   simp [ghostList, List.append_assoc]
 
 /-- Dequeue: returns `some (head, remaining)` or `none` if empty. -/
-def pop {α : Type u} (q : RawFunctionalQueue α) : Option (α × RawFunctionalQueue α) :=
+def pop {α : Type u} (q : Raw.FunctionalQueue α)
+    : TimeM ℕ (Option (α × Raw.FunctionalQueue α)) :=
   match q.front with
-  | [] => none
-  | x :: tl =>
-    some (x, rebalance ⟨ tl, q.back ⟩)
+  | [] => pure none
+  | x :: tl => do
+    let q2 ← rebalance ⟨ tl, q.back ⟩
+    pure (some (x, q2))
 
-theorem popInvariant {α : Type u} (x : α) (q q2 : RawFunctionalQueue α) :
-    invariant q → pop q = some (x, q2) → invariant q2 := by
+theorem popInvariant {α : Type u} (x : α) (q q2 : FunctionalQueue α)
+    : invariant q →
+      (pop q).ret = some (x, q2) →
+      invariant q2 := by
   intro hq hpop
   obtain ⟨f, b⟩ := q
   simp [invariant] at hq
@@ -120,8 +132,10 @@ theorem popInvariant {α : Type u} (x : α) (q q2 : RawFunctionalQueue α) :
 @[simp] theorem emptyGhost {α : Type u} : ghostList (@Raw.empty α) = [] := by
   simp [ghostList, Raw.empty]
 
-theorem popGhost {α : Type u} {x : α} {q q2 : RawFunctionalQueue α} :
-    invariant q → pop q = some (x, q2) → ghostList q = x :: ghostList q2 := by
+theorem popGhost {α : Type u} {x : α} {q q2 : Raw.FunctionalQueue α}
+    : invariant q →
+      (pop q).ret = some (x, q2) →
+      ghostList q = x :: ghostList q2 := by
   intro hq hpop
   obtain ⟨f, b⟩ := q
   simp [invariant] at hq
@@ -138,65 +152,106 @@ end Raw
 
 namespace Complexity
 
-def potential {α : Type u} (q : RawFunctionalQueue α) : Nat :=
+def potential {α : Type u} (q : Raw.FunctionalQueue α) : Nat :=
   q.back.length
 
 instance functionalQueuePotential {α : Type u}
-    : Amortized.Potential (RawFunctionalQueue α) :=
+    : Amortized.Potential (Raw.FunctionalQueue α) :=
   ⟨ potential ⟩
 
 inductive queueOp (α : Type u) where
   | push : α → queueOp α
   | pop
 
-def applyOp {α : Type u} (op : queueOp α) (q : RawFunctionalQueue α) : RawFunctionalQueue α :=
+def applyOp {α : Type u} (q : Raw.FunctionalQueue α) (op : queueOp α)
+    : TimeM ℕ (Raw.FunctionalQueue α) :=
   match op with
   | .push x => Raw.push x q
-  | .pop =>
-    match Raw.pop q with
-    | none => q
-    | some (_, q2) => q2
+  | .pop => do
+    match (← Raw.pop q) with
+    | none => pure q
+    | some (_, q2) => pure q2
 
-def applyOps {α : Type u} (ops : List (queueOp α)) (q : RawFunctionalQueue α)
-    : RawFunctionalQueue α :=
-  ops.foldl (fun q op => applyOp op q) q
+instance functionalQueueApplyOp {α : Type u}
+    : Amortized.Op (Raw.FunctionalQueue α) (queueOp α) :=
+  ⟨ applyOp ⟩
+
+theorem costRebalanceEmpty {α : Type u} (q : Raw.FunctionalQueue α)
+    : q.front = [] → (Raw.rebalance q).time = potential q := by
+  intro h
+  simp only [Raw.rebalance]; rw [h]; simp [potential]
+
+grind_pattern costRebalanceEmpty => (Raw.rebalance q).time
+
+theorem costRebalanceNonEmpty {α : Type u} (q : Raw.FunctionalQueue α)
+    : q.front ≠ [] → (Raw.rebalance q).time = 0 := by
+  intro h
+  simp [Raw.rebalance]
+
+grind_pattern costRebalanceNonEmpty => (Raw.rebalance q).time
+
+theorem costPush {α : Type u} (x : α) (q : Raw.FunctionalQueue α)
+    : (Raw.push x q).time ≤ potential q := by
+  simp [Raw.push]
+  sorry
+  /- cases q.front <;> grind -/
+  /-     grind [Raw.push] -/
+
+theorem costApplyOp {α : Type u} (op : queueOp α) (q : Raw.FunctionalQueue α)
+    : (applyOp q op).time ≤ 1 + potential q := by
+  sorry
+  /- cases op with -/
+  /- | .pu -/
+  /- simp [applyOp] -/
+  /- grind -/
 
 theorem constantTimeAmortized {α : Type u} :
-    ∀ (q : RawFunctionalQueue α) (ops:List (queueOp α)),
-    false
- := by
-   sorry
+    ∀ (q : Raw.FunctionalQueue α) (ops : List (queueOp α)),
+    (Amortized.applyOps ops q).time ≤ 2 * potential (Amortized.applyOps ops q).ret
+    := by
+  intro q ops
+  induction ops generalizing q with
+  | nil => simp
+  | cons op otherOps hOps =>
+    simp
+    sorry
 
 end Complexity
 
 /-- A functional queue with invariant. -/
 @[ext]
 structure FunctionalQueue (α : Type u) where
-  raw : RawFunctionalQueue α
+  raw : Raw.FunctionalQueue α
   inv : Raw.invariant raw
 
 def empty {α : Type u} : FunctionalQueue α := ⟨ @Raw.empty α, Raw.emptyInvariant ⟩
 
-def push {α : Type u} (x : α) (q : FunctionalQueue α) : FunctionalQueue α :=
-  ⟨ Raw.push x q.raw, Raw.pushInvariant x q.raw q.inv ⟩
+def push {α : Type u} (x : α) (q : FunctionalQueue α)
+    : TimeM ℕ (FunctionalQueue α) :=
+  let r := Raw.push x q.raw
+  ⟨ ⟨ r.ret, Raw.pushInvariant x q.raw q.inv ⟩, r.time ⟩
 
-def pop {α : Type u} (q : FunctionalQueue α) : Option (α × FunctionalQueue α) :=
-  match h : Raw.pop q.raw with
-  | none => none
+def pop {α : Type u} (q : FunctionalQueue α)
+    : TimeM ℕ (Option (α × FunctionalQueue α)) :=
+  let r := Raw.pop q.raw
+  match h : r.ret with
+  | none => ⟨ none, r.time ⟩
   | some (x, q2) =>
-    some (x, ⟨ q2, Raw.popInvariant x q.raw q2 q.inv h ⟩)
+    ⟨ some (x, ⟨ q2, Raw.popInvariant x q.raw q2 q.inv h ⟩), r.time ⟩
 
 /-- project to a list view, an ordered sequence of elements -/
 def ghostList {α : Type u} (q : FunctionalQueue α) : List α := Raw.ghostList q.raw
 
 theorem pushGhost {α : Type u} (x : α) (q : FunctionalQueue α) :
-    ghostList (push x q) = ghostList q ++ [x] :=
+    ghostList (push x q).ret = ghostList q ++ [x] :=
   Raw.pushGhost x q.raw
 
-theorem popGhost {α : Type u} {x : α} {q q2 : FunctionalQueue α} :
-    pop q = some (x, q2) → ghostList q = x :: ghostList q2 := by
-  intro h
+theorem popGhost {α : Type u} {x : α} {q2 : FunctionalQueue α} :
+    ∀ {q : FunctionalQueue α},
+    (pop q).ret = some (x, q2) → ghostList q = x :: ghostList q2 := by
+  intro q h
   simp only [pop, ghostList] at h ⊢
+  simp only [TimeM.ret] at h
   split at h
   · simp only [reduceCtorEq] at h
   · rename_i x2 q2' heq

--- a/Cslib/Algorithms/Lean/FunctionalQueue/FunctionalQueue.lean
+++ b/Cslib/Algorithms/Lean/FunctionalQueue/FunctionalQueue.lean
@@ -26,6 +26,8 @@ universe u
   front : List α
   back : List α
 
+namespace Raw
+
 /-- Well-formedness: if front is empty, back must be empty too. -/
 def invariant {α : Type u} (q : RawFunctionalQueue α) : Prop :=
   q.front = [] → q.back = []
@@ -35,7 +37,7 @@ def ghostList {α : Type u} (q : RawFunctionalQueue α) : List α :=
   List.append q.front q.back.reverse
 
 /-- The empty queue. -/
-def empty {α : Type u} : RawFunctionalQueue α := ⟨ [], [] ⟩
+def emptyRaw {α : Type u} : RawFunctionalQueue α := ⟨ [], [] ⟩
 
 /-- Internal: rebalance by moving `back.reverse` to `front` when `front` is empty. -/
 def rebalance {α : Type u} (q : RawFunctionalQueue α) : RawFunctionalQueue α :=
@@ -44,10 +46,10 @@ def rebalance {α : Type u} (q : RawFunctionalQueue α) : RawFunctionalQueue α 
   | _ => q
 
 theorem rebalanceInvert {α : Type u} (q : RawFunctionalQueue α) :
-    (rebalance q).front = [] → q = empty := by
+    (rebalance q).front = [] → q = emptyRaw := by
   intro h
   obtain ⟨f, b⟩ := q
-  simp only [rebalance, empty] at h ⊢
+  simp only [rebalance, emptyRaw] at h ⊢
   split at h <;> simp_all
 
 theorem rebalanceInvariant {α : Type u} {q : RawFunctionalQueue α} :
@@ -69,33 +71,33 @@ theorem rebalanceInvariant {α : Type u} {q : RawFunctionalQueue α} :
   split <;> grind [List.reverse_append]
 
 /-- Enqueue an element. -/
-def push {α : Type u} (x : α) (q : RawFunctionalQueue α) : RawFunctionalQueue α :=
+def pushRaw {α : Type u} (x : α) (q : RawFunctionalQueue α) : RawFunctionalQueue α :=
   rebalance ⟨ q.front, x :: q.back ⟩
 
 theorem pushInvariant {α : Type u} (x : α) (q : RawFunctionalQueue α) :
-    invariant q → invariant (push x q) := by
+    invariant q → invariant (pushRaw x q) := by
   intro h
-  rw [push]
+  rw [pushRaw]
   apply rebalanceInvariant
 
 theorem pushGhost {α : Type u} (x : α) (q : RawFunctionalQueue α) :
-    ghostList (push x q) = ghostList q ++ [x] := by
-  rw [push, rebalancePreserveGhost, ghostList]
+    ghostList (pushRaw x q) = ghostList q ++ [x] := by
+  rw [pushRaw, rebalancePreserveGhost, ghostList]
   simp [ghostList, List.append_assoc]
 
 /-- Dequeue: returns `some (head, remaining)` or `none` if empty. -/
-def pop {α : Type u} (q : RawFunctionalQueue α) : Option (α × RawFunctionalQueue α) :=
+def popRaw {α : Type u} (q : RawFunctionalQueue α) : Option (α × RawFunctionalQueue α) :=
   match q.front with
   | [] => none
   | x :: tl =>
     some (x, rebalance ⟨ tl, q.back ⟩)
 
-theorem pop_invariant {α : Type u} (x : α) (q q2 : RawFunctionalQueue α) :
-    invariant q → pop q = some (x, q2) → invariant q2 := by
+theorem popInvariant {α : Type u} (x : α) (q q2 : RawFunctionalQueue α) :
+    invariant q → popRaw q = some (x, q2) → invariant q2 := by
   intro hq hpop
   obtain ⟨f, b⟩ := q
   simp [invariant] at hq
-  unfold pop at hpop
+  unfold popRaw at hpop
   cases f with
   | nil => simp at hpop
   | cons y tl =>
@@ -103,18 +105,18 @@ theorem pop_invariant {α : Type u} (x : α) (q q2 : RawFunctionalQueue α) :
     obtain ⟨rfl, rfl⟩ := hpop
     exact rebalanceInvariant
 
-@[simp] theorem emptyInvariant {α : Type u} : invariant (@empty α) := by
-  simp [invariant, empty]
+@[simp] theorem emptyInvariant {α : Type u} : invariant (@emptyRaw α) := by
+  simp [invariant, emptyRaw]
 
-@[simp] theorem emptyGhost {α : Type u} : ghostList (@empty α) = [] := by
-  simp [ghostList, empty]
+@[simp] theorem emptyGhost {α : Type u} : ghostList (@emptyRaw α) = [] := by
+  simp [ghostList, emptyRaw]
 
-theorem pop_ghost {α : Type u} {x : α} {q q2 : RawFunctionalQueue α} :
-    invariant q → pop q = some (x, q2) → ghostList q = x :: ghostList q2 := by
+theorem popGhost {α : Type u} {x : α} {q q2 : RawFunctionalQueue α} :
+    invariant q → popRaw q = some (x, q2) → ghostList q = x :: ghostList q2 := by
   intro hq hpop
   obtain ⟨f, b⟩ := q
   simp [invariant] at hq
-  unfold pop at hpop
+  unfold popRaw at hpop
   cases f with
   | nil => simp at hpop
   | cons y tl =>
@@ -122,5 +124,39 @@ theorem pop_ghost {α : Type u} {x : α} {q q2 : RawFunctionalQueue α} :
     obtain ⟨rfl, rfl⟩ := hpop
     simp only [rebalancePreserveGhost]
     simp [ghostList]
+
+end Raw
+
+/-- A functional queue with invariant. -/
+structure FunctionalQueue (α : Type u) where
+  q : RawFunctionalQueue α
+  inv : Raw.invariant q
+
+def empty {α : Type u} : FunctionalQueue α := ⟨ @Raw.emptyRaw α, Raw.emptyInvariant ⟩
+
+def push {α : Type u} (x : α) (q : FunctionalQueue α) : FunctionalQueue α :=
+  ⟨ Raw.pushRaw x q.q, Raw.pushInvariant x q.q q.inv ⟩
+
+def pop {α : Type u} (q : FunctionalQueue α) : Option (α × FunctionalQueue α) :=
+  match h : Raw.popRaw q.q with
+  | none => none
+  | some (x, q2) =>
+    some (x, ⟨ q2, Raw.popInvariant x q.q q2 q.inv h ⟩)
+
+@[simp] def ghostList {α : Type u} (q : FunctionalQueue α) : List α := Raw.ghostList q.q
+
+theorem pushGhost {α : Type u} (x : α) (q : FunctionalQueue α) :
+    ghostList (push x q) = ghostList q ++ [x] :=
+  Raw.pushGhost x q.q
+
+theorem popGhost {α : Type u} {x : α} {q q2 : FunctionalQueue α} :
+    pop q = some (x, q2) → ghostList q = x :: ghostList q2 := by
+  intro h
+  simp only [pop, ghostList] at h ⊢
+  split at h
+  · simp only [reduceCtorEq] at h
+  · rename_i x2 q2' heq
+    obtain ⟨ h1, h2 ⟩ := h
+    apply @Raw.popGhost α x q.q q2' q.inv; grind
 
 end Cslib.Algorithms.Lean

--- a/Cslib/Algorithms/Lean/FunctionalQueue/FunctionalQueue.lean
+++ b/Cslib/Algorithms/Lean/FunctionalQueue/FunctionalQueue.lean
@@ -7,18 +7,27 @@ Authors: Simon Cruanes
 module
 
 import Cslib.Init
+public import Cslib.Algorithms.Lean.Amortized
 
 /-!
 # Functional Queue
 
 A classic two-list queue with amortized O(1) `push` and `pop`.
--/
 
-@[expose] public section
+The representation uses two lists: a front list (for dequeue) and a back list
+(for enqueue). When the front list becomes empty, the back list is reversed
+and becomes the new front. This yields amortized O(1) operations.
+
+## References
+
+* [Okasaki, *Purely Functional Data Structures*, 1996][okasaki1996]
+-/
 
 set_option autoImplicit false
 
 namespace Cslib.Algorithms.Lean
+
+@[expose] public section
 
 universe u
 
@@ -127,6 +136,39 @@ theorem popGhost {α : Type u} {x : α} {q q2 : RawFunctionalQueue α} :
 
 end Raw
 
+namespace Complexity
+
+def potential {α : Type u} (q : RawFunctionalQueue α) : Nat :=
+  q.back.length
+
+instance functionalQueuePotential {α : Type u}
+    : Amortized.Potential (RawFunctionalQueue α) :=
+  ⟨ potential ⟩
+
+inductive queueOp (α : Type u) where
+  | push : α → queueOp α
+  | pop
+
+def applyOp {α : Type u} (op : queueOp α) (q : RawFunctionalQueue α) : RawFunctionalQueue α :=
+  match op with
+  | .push x => Raw.push x q
+  | .pop =>
+    match Raw.pop q with
+    | none => q
+    | some (_, q2) => q2
+
+def applyOps {α : Type u} (ops : List (queueOp α)) (q : RawFunctionalQueue α)
+    : RawFunctionalQueue α :=
+  ops.foldl (fun q op => applyOp op q) q
+
+theorem constantTimeAmortized {α : Type u} :
+    ∀ (q : RawFunctionalQueue α) (ops:List (queueOp α)),
+    false
+ := by
+   sorry
+
+end Complexity
+
 /-- A functional queue with invariant. -/
 @[ext]
 structure FunctionalQueue (α : Type u) where
@@ -160,5 +202,7 @@ theorem popGhost {α : Type u} {x : α} {q q2 : FunctionalQueue α} :
   · rename_i x2 q2' heq
     obtain ⟨h1, h2⟩ := h
     exact @Raw.popGhost α x q.raw q2' q.inv heq
+
+end
 
 end Cslib.Algorithms.Lean

--- a/Cslib/Algorithms/Lean/FunctionalQueue/FunctionalQueue.lean
+++ b/Cslib/Algorithms/Lean/FunctionalQueue/FunctionalQueue.lean
@@ -177,38 +177,42 @@ def applyOp {α : Type u} (q : Raw.FunctionalQueue α) (op : queueOp α)
     | none => pure q
     | some (_, q2) => pure q2
 
-instance functionalQueueApplyOp {α : Type u}
-    : Amortized.Op (Raw.FunctionalQueue α) (queueOp α) :=
-  ⟨ applyOp ⟩
-
 theorem potentialEmptyIsZero {α : Type u}
     : potential (@Raw.empty α) = 0 := by
   simp [potential, Raw.empty]
 
 theorem amortizedCostQueueOp {α : Type u} (q : Raw.FunctionalQueue α) (op : queueOp α)
-    : Amortized.amortizedCost q op ≤ (2 : ℤ) := by
+    : Amortized.amortizedCost q (fun q => applyOp q op) ≤ (2 : ℤ) := by
   simp only [Amortized.amortizedCost, Amortized.Potential.potential, tsub_le_iff_right]
   cases op with
   | push x =>
-    simp only [Amortized.Op.applyOp, applyOp, potential]
+    simp only [applyOp, potential]
     cases h_front : q.front <;> (rw [Raw.push, Raw.rebalance, h_front] at ⊢; grind)
   | pop =>
-    simp only [Amortized.Op.applyOp, applyOp, potential]
+    simp only [applyOp, potential]
     cases h_front : q.front <;> (rw [Raw.pop, h_front] at ⊢; grind [Raw.rebalance])
 
 /-- cost of applying operations to a queue -/
 theorem costQueueOps {α : Type u}
     (q : Raw.FunctionalQueue α) (ops : List (queueOp α))
-    : (Amortized.applyOps q ops).time
-        + potential (Amortized.applyOps q ops).ret
+    : (List.foldlM (fun q op => applyOp q op) q ops).time
+        + potential (List.foldlM (fun q op => applyOp q op) q ops).ret
         - potential q
       ≤ (2 : ℤ) * ops.length
     := by
-  have useful
-    := Amortized.constantAmortizedCostL 2 amortizedCostQueueOp q ops
-  simp only [Amortized.Potential.potential]
-    at useful
-  grind only
+  have h_bound (x : Raw.FunctionalQueue α) (op : queueOp α)
+      : (applyOp x op).time + potential (applyOp x op).ret - potential x ≤ (2 : ℤ) :=
+    amortizedCostQueueOp x op
+  revert q
+  induction ops with
+  | nil => intro q; simp
+  | cons op ops2 ih =>
+    intro q
+    simp only [List.foldlM, TimeM.time_bind, Nat.cast_add, TimeM.ret_bind,
+      List.length_cons, Nat.cast_one]
+    have step := h_bound q op
+    have rest := ih (applyOp q op).ret
+    linarith
 
 end Complexity
 

--- a/Cslib/Algorithms/Lean/FunctionalQueue/FunctionalQueue.lean
+++ b/Cslib/Algorithms/Lean/FunctionalQueue/FunctionalQueue.lean
@@ -1,13 +1,22 @@
-
+/-
+Copyright (c) 2026 Simon Cruanes. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Simon Cruanes
+-/
 
 module
 
-/- public import Cslib.Algorithms.Lean.TimeM -/
+import Cslib.Init
 
 /-!
-  The simplest functional queue. -/
+# Functional Queue
+
+A classic two-list queue with amortized O(1) `push` and `pop`.
+-/
 
 @[expose] public section
+
+set_option autoImplicit false
 
 namespace Cslib.Algorithms.Lean
 
@@ -17,87 +26,64 @@ universe u
   front : List α
   back : List α
 
-@[simp] def invariant {α : Type u} (q : RawFunctionalQueue α) : Prop :=
+/-- Well-formedness: if front is empty, back must be empty too. -/
+def invariant {α : Type u} (q : RawFunctionalQueue α) : Prop :=
   q.front = [] → q.back = []
 
-@[simp] def ghostList {α : Type u} (q : RawFunctionalQueue α) : List α :=
+/-- The logical contents of the queue: `front ++ back.reverse`. -/
+def ghostList {α : Type u} (q : RawFunctionalQueue α) : List α :=
   List.append q.front q.back.reverse
 
+/-- The empty queue. -/
 def empty {α : Type u} : RawFunctionalQueue α := ⟨ [], [] ⟩
 
+/-- Internal: rebalance by moving `back.reverse` to `front` when `front` is empty. -/
 def rebalance {α : Type u} (q : RawFunctionalQueue α) : RawFunctionalQueue α :=
   match q.front with
   | [] => ⟨ (q.back).reverse, [] ⟩
   | _ => q
 
-theorem rebalanceInvert {α : Type u} (q : RawFunctionalQueue α) : (rebalance q).front = [] → q = empty := by
-  intro h_reb
-  rw [empty]
-  generalize gen_reb : (rebalance q).front = q_reb_hd
-  obtain ⟨ q_hd, q_tl ⟩ := q
-  simp [rebalance] at h_reb
-  induction q_reb_hd with
-  | nil =>
-    induction q_hd with
-    | nil =>
-      simp at h_reb; simp [rebalance] at gen_reb; rw [h_reb]
-    | cons q_hd_hd q_hd_tl q_hd_hyp =>
-      grind only
-  | cons q_reb_hd_hd q_reb_hd_tl q_reb_hd_hyp =>
-    induction q_hd with
-    | nil =>
-      simp at h_reb
-      grind only
-    | cons _ _ _ =>
-      simp at h_reb
+theorem rebalanceInvert {α : Type u} (q : RawFunctionalQueue α) :
+    (rebalance q).front = [] → q = empty := by
+  intro h
+  obtain ⟨f, b⟩ := q
+  simp only [rebalance, empty] at h ⊢
+  split at h <;> simp_all
 
-@[simp] theorem rebalanceInvariant {α : Type u} {q : RawFunctionalQueue α} : invariant (rebalance q) := by
-  generalize h_front : q.front = l
-  induction l with
-  | nil => simp [rebalance]; rw [h_front]; simp
-  | cons x tl h_cons =>
-    simp [rebalance]; rw [h_front]; simp; rw [h_front]; grind only
+theorem rebalanceInvariant {α : Type u} {q : RawFunctionalQueue α} :
+    invariant (rebalance q) := by
+  obtain ⟨f, b⟩ := q
+  simp [rebalance, invariant]
+  split <;> grind
 
-@[simp] theorem rebalanceIdempotent {α : Type u} (q : RawFunctionalQueue α) : rebalance (rebalance q) = rebalance q := by
-  generalize h : (rebalance q).front = hd
-  induction hd with
-  | nil =>
-    have h_q_empty : q = empty := rebalanceInvert q h
-    simp [rebalance]; rw [h_q_empty]; simp [empty]
-  | cons hd_hd hd_tl hd_hyp =>
-    generalize def_q2 : rebalance q = q2
-    rw [def_q2] at h
-    simp [rebalance]
-    rw [h]
+@[simp] theorem rebalanceIdempotent {α : Type u} (q : RawFunctionalQueue α) :
+    rebalance (rebalance q) = rebalance q := by
+  obtain ⟨f, b⟩ := q
+  simp [rebalance]
+  split <;> grind
 
-@[simp] theorem rebalancePreserveGhost {α : Type u} (q : RawFunctionalQueue α) : ghostList (rebalance q) = ghostList q := by
-  generalize def_hd : q.front = hd
-  induction hd with
-  | nil => simp [rebalance]; rw [def_hd]; simp
-  | cons hd_hd hd_tl h_ind =>
-    simp [rebalance]; rw [def_hd]; simp; grind only [=_ List.cons_append]
+@[simp] theorem rebalancePreserveGhost {α : Type u} (q : RawFunctionalQueue α) :
+    ghostList (rebalance q) = ghostList q := by
+  obtain ⟨f, b⟩ := q
+  simp [rebalance, ghostList]
+  split <;> grind [List.reverse_append]
 
-def push {α : Type u} (x : α) (q : RawFunctionalQueue α) : (RawFunctionalQueue α) :=
-  let q : RawFunctionalQueue α := ⟨ q.front, x :: q.back ⟩
-  rebalance q
+/-- Enqueue an element. -/
+def push {α : Type u} (x : α) (q : RawFunctionalQueue α) : RawFunctionalQueue α :=
+  rebalance ⟨ q.front, x :: q.back ⟩
 
-theorem appendInvariant {α : Type u} (x : α) (q : RawFunctionalQueue α)
-  : invariant q → invariant (push x q) := by
+theorem pushInvariant {α : Type u} (x : α) (q : RawFunctionalQueue α) :
+    invariant q → invariant (push x q) := by
   intro h
   rw [push]
   apply rebalanceInvariant
 
-theorem appendGhost {α : Type u} (x : α) (q : RawFunctionalQueue α) : ghostList (push x q) = ghostList q ++ [x] := by
-  generalize h_front : q.front = l
-  cases l with
-  | nil =>
-    simp [push, rebalance]; rw [h_front]; simp
-  | cons l_hd l_tl =>
-    rw [push]
-    rw [rebalancePreserveGhost]
-    rw [ghostList]
-    simp
+theorem pushGhost {α : Type u} (x : α) (q : RawFunctionalQueue α) :
+    ghostList (push x q) = ghostList q ++ [x] := by
+  rw [push, rebalancePreserveGhost, ghostList]
+  simp [ghostList, List.append_assoc]
 
+/-- Dequeue: returns `some (head, remaining)` or `none` if empty. -/
 def pop {α : Type u} (q : RawFunctionalQueue α) : Option (α × RawFunctionalQueue α) :=
   match q.front with
   | [] => none
@@ -106,17 +92,35 @@ def pop {α : Type u} (q : RawFunctionalQueue α) : Option (α × RawFunctionalQ
 
 theorem pop_invariant {α : Type u} (x : α) (q q2 : RawFunctionalQueue α) :
     invariant q → pop q = some (x, q2) → invariant q2 := by
-  intro hq hpop_is_some
-  simp at hq
-  rw [pop] at hpop_is_some
-  generalize h_front : q.front = l
-  cases l with
-  | nil =>
-    rw [h_front] at hpop_is_some; simp at hpop_is_some
-  | cons _ _ =>
-    rw [h_front] at hpop_is_some
-    simp only at hpop_is_some
-    obtain ⟨ rfl, rfl ⟩ := hpop_is_some
-    apply rebalanceInvariant
+  intro hq hpop
+  obtain ⟨f, b⟩ := q
+  simp [invariant] at hq
+  unfold pop at hpop
+  cases f with
+  | nil => simp at hpop
+  | cons y tl =>
+    simp only at hpop
+    obtain ⟨rfl, rfl⟩ := hpop
+    exact rebalanceInvariant
+
+@[simp] theorem emptyInvariant {α : Type u} : invariant (@empty α) := by
+  simp [invariant, empty]
+
+@[simp] theorem emptyGhost {α : Type u} : ghostList (@empty α) = [] := by
+  simp [ghostList, empty]
+
+theorem pop_ghost {α : Type u} {x : α} {q q2 : RawFunctionalQueue α} :
+    invariant q → pop q = some (x, q2) → ghostList q = x :: ghostList q2 := by
+  intro hq hpop
+  obtain ⟨f, b⟩ := q
+  simp [invariant] at hq
+  unfold pop at hpop
+  cases f with
+  | nil => simp at hpop
+  | cons y tl =>
+    simp only at hpop
+    obtain ⟨rfl, rfl⟩ := hpop
+    simp only [rebalancePreserveGhost]
+    simp [ghostList]
 
 end Cslib.Algorithms.Lean

--- a/Cslib/Algorithms/Lean/FunctionalQueue/FunctionalQueue.lean
+++ b/Cslib/Algorithms/Lean/FunctionalQueue/FunctionalQueue.lean
@@ -19,6 +19,8 @@ The representation uses two lists: a front list (for dequeue) and a back list
 (for enqueue). When the front list becomes empty, the back list is reversed
 and becomes the new front. This yields amortized O(1) operations.
 
+Cost model: each list cons is worth one `TimeM` tick.
+
 ## References
 
 * [Okasaki, *Purely Functional Data Structures*, 1996][okasaki1996]
@@ -190,6 +192,20 @@ theorem amortizedCostQueueOp {α : Type u} (q : Raw.FunctionalQueue α) (op : qu
   | pop =>
     simp only [Amortized.Op.applyOp, applyOp, potential]
     cases h_front : q.front <;> (rw [Raw.pop, h_front] at ⊢; grind [Raw.rebalance])
+
+/-- cost of applying operations to a queue -/
+theorem costQueueOps {α : Type u}
+    (q : Raw.FunctionalQueue α) (ops : List (queueOp α))
+    : (Amortized.applyOps q ops).time
+        + potential (Amortized.applyOps q ops).ret
+        - potential q
+      ≤ 2 * ops.length
+    := by
+  have useful
+    := Amortized.constantAmortizedCostL 2 amortizedCostQueueOp q ops
+  simp only [Amortized.amortizedCostL, Amortized.Potential.potential]
+    at useful
+  grind only
 
 end Complexity
 

--- a/Cslib/Algorithms/Lean/FunctionalQueue/FunctionalQueue.lean
+++ b/Cslib/Algorithms/Lean/FunctionalQueue/FunctionalQueue.lean
@@ -39,8 +39,11 @@ universe u
 
 namespace Raw
 
+/-- raw two-list representation: front list (for dequeue) and back list (for enqueue) -/
 structure FunctionalQueue (α : Type u) where
+  /-- list of elements ready to dequeue -/
   front : List α
+  /-- list of recently enqueued elements (stored reversed) -/
   back : List α
 
 /-- Well-formedness: if front is empty, back must be empty too. -/
@@ -157,6 +160,7 @@ end Raw
 
 namespace Complexity
 
+/-- size of the back list, used as credit invariant for amortized analysis -/
 def potential {α : Type u} (q : Raw.FunctionalQueue α) : ℤ :=
   q.back.length
 
@@ -164,10 +168,14 @@ instance functionalQueuePotential {α : Type u}
     : Amortized.Potential ℤ (Raw.FunctionalQueue α) :=
   ⟨ potential ⟩
 
+/-- a queue operation: push a value or pop the front -/
 inductive queueOp (α : Type u) where
+  /-- enqueue a value -/
   | push : α → queueOp α
+  /-- dequeue the front (no-op if empty) -/
   | pop
 
+/-- apply a `queueOp` to a raw queue, returning the updated queue -/
 def applyOp {α : Type u} (q : Raw.FunctionalQueue α) (op : queueOp α)
     : TimeM ℕ (Raw.FunctionalQueue α) :=
   match op with
@@ -219,16 +227,20 @@ end Complexity
 /-- A functional queue with invariant. -/
 @[ext]
 structure FunctionalQueue (α : Type u) where
+  /-- the underlying raw queue with no invariant guarantee -/
   raw : Raw.FunctionalQueue α
   inv : Raw.Invariant raw
 
+/-- the empty queue -/
 def empty {α : Type u} : FunctionalQueue α := ⟨ @Raw.empty α, Raw.Invariant.empty ⟩
 
+/-- enqueue `x`, amortized O(1) -/
 def push {α : Type u} (x : α) (q : FunctionalQueue α)
     : TimeM ℕ (FunctionalQueue α) :=
   let r := Raw.push x q.raw
   ⟨ ⟨ r.ret, Raw.Invariant.push x q.raw q.inv ⟩, r.time ⟩
 
+/-- dequeue the front element, returning `none` if empty -/
 def pop {α : Type u} (q : FunctionalQueue α)
     : TimeM ℕ (Option (α × FunctionalQueue α)) :=
   let r := Raw.pop q.raw

--- a/Cslib/Algorithms/Lean/FunctionalQueue/FunctionalQueue.lean
+++ b/Cslib/Algorithms/Lean/FunctionalQueue/FunctionalQueue.lean
@@ -22,7 +22,7 @@ namespace Cslib.Algorithms.Lean
 
 universe u
 
-@[ext] structure RawFunctionalQueue (α : Type u) where
+structure RawFunctionalQueue (α : Type u) where
   front : List α
   back : List α
 
@@ -37,7 +37,7 @@ def ghostList {α : Type u} (q : RawFunctionalQueue α) : List α :=
   List.append q.front q.back.reverse
 
 /-- The empty queue. -/
-def emptyRaw {α : Type u} : RawFunctionalQueue α := ⟨ [], [] ⟩
+def empty {α : Type u} : RawFunctionalQueue α := ⟨ [], [] ⟩
 
 /-- Internal: rebalance by moving `back.reverse` to `front` when `front` is empty. -/
 def rebalance {α : Type u} (q : RawFunctionalQueue α) : RawFunctionalQueue α :=
@@ -46,10 +46,10 @@ def rebalance {α : Type u} (q : RawFunctionalQueue α) : RawFunctionalQueue α 
   | _ => q
 
 theorem rebalanceInvert {α : Type u} (q : RawFunctionalQueue α) :
-    (rebalance q).front = [] → q = emptyRaw := by
+    (rebalance q).front = [] → q = Raw.empty := by
   intro h
   obtain ⟨f, b⟩ := q
-  simp only [rebalance, emptyRaw] at h ⊢
+  simp only [rebalance, Raw.empty] at h ⊢
   split at h <;> simp_all
 
 theorem rebalanceInvariant {α : Type u} {q : RawFunctionalQueue α} :
@@ -71,33 +71,33 @@ theorem rebalanceInvariant {α : Type u} {q : RawFunctionalQueue α} :
   split <;> grind [List.reverse_append]
 
 /-- Enqueue an element. -/
-def pushRaw {α : Type u} (x : α) (q : RawFunctionalQueue α) : RawFunctionalQueue α :=
+def push {α : Type u} (x : α) (q : RawFunctionalQueue α) : RawFunctionalQueue α :=
   rebalance ⟨ q.front, x :: q.back ⟩
 
 theorem pushInvariant {α : Type u} (x : α) (q : RawFunctionalQueue α) :
-    invariant q → invariant (pushRaw x q) := by
+    invariant q → invariant (push x q) := by
   intro h
-  rw [pushRaw]
+  rw [push]
   apply rebalanceInvariant
 
 theorem pushGhost {α : Type u} (x : α) (q : RawFunctionalQueue α) :
-    ghostList (pushRaw x q) = ghostList q ++ [x] := by
-  rw [pushRaw, rebalancePreserveGhost, ghostList]
+    ghostList (push x q) = ghostList q ++ [x] := by
+  rw [push, rebalancePreserveGhost, ghostList]
   simp [ghostList, List.append_assoc]
 
 /-- Dequeue: returns `some (head, remaining)` or `none` if empty. -/
-def popRaw {α : Type u} (q : RawFunctionalQueue α) : Option (α × RawFunctionalQueue α) :=
+def pop {α : Type u} (q : RawFunctionalQueue α) : Option (α × RawFunctionalQueue α) :=
   match q.front with
   | [] => none
   | x :: tl =>
     some (x, rebalance ⟨ tl, q.back ⟩)
 
 theorem popInvariant {α : Type u} (x : α) (q q2 : RawFunctionalQueue α) :
-    invariant q → popRaw q = some (x, q2) → invariant q2 := by
+    invariant q → pop q = some (x, q2) → invariant q2 := by
   intro hq hpop
   obtain ⟨f, b⟩ := q
   simp [invariant] at hq
-  unfold popRaw at hpop
+  unfold pop at hpop
   cases f with
   | nil => simp at hpop
   | cons y tl =>
@@ -105,18 +105,18 @@ theorem popInvariant {α : Type u} (x : α) (q q2 : RawFunctionalQueue α) :
     obtain ⟨rfl, rfl⟩ := hpop
     exact rebalanceInvariant
 
-@[simp] theorem emptyInvariant {α : Type u} : invariant (@emptyRaw α) := by
-  simp [invariant, emptyRaw]
+@[simp] theorem emptyInvariant {α : Type u} : invariant (@Raw.empty α) := by
+  simp [invariant, Raw.empty]
 
-@[simp] theorem emptyGhost {α : Type u} : ghostList (@emptyRaw α) = [] := by
-  simp [ghostList, emptyRaw]
+@[simp] theorem emptyGhost {α : Type u} : ghostList (@Raw.empty α) = [] := by
+  simp [ghostList, Raw.empty]
 
 theorem popGhost {α : Type u} {x : α} {q q2 : RawFunctionalQueue α} :
-    invariant q → popRaw q = some (x, q2) → ghostList q = x :: ghostList q2 := by
+    invariant q → pop q = some (x, q2) → ghostList q = x :: ghostList q2 := by
   intro hq hpop
   obtain ⟨f, b⟩ := q
   simp [invariant] at hq
-  unfold popRaw at hpop
+  unfold pop at hpop
   cases f with
   | nil => simp at hpop
   | cons y tl =>
@@ -128,26 +128,28 @@ theorem popGhost {α : Type u} {x : α} {q q2 : RawFunctionalQueue α} :
 end Raw
 
 /-- A functional queue with invariant. -/
+@[ext]
 structure FunctionalQueue (α : Type u) where
-  q : RawFunctionalQueue α
-  inv : Raw.invariant q
+  raw : RawFunctionalQueue α
+  inv : Raw.invariant raw
 
-def empty {α : Type u} : FunctionalQueue α := ⟨ @Raw.emptyRaw α, Raw.emptyInvariant ⟩
+def empty {α : Type u} : FunctionalQueue α := ⟨ @Raw.empty α, Raw.emptyInvariant ⟩
 
 def push {α : Type u} (x : α) (q : FunctionalQueue α) : FunctionalQueue α :=
-  ⟨ Raw.pushRaw x q.q, Raw.pushInvariant x q.q q.inv ⟩
+  ⟨ Raw.push x q.raw, Raw.pushInvariant x q.raw q.inv ⟩
 
 def pop {α : Type u} (q : FunctionalQueue α) : Option (α × FunctionalQueue α) :=
-  match h : Raw.popRaw q.q with
+  match h : Raw.pop q.raw with
   | none => none
   | some (x, q2) =>
-    some (x, ⟨ q2, Raw.popInvariant x q.q q2 q.inv h ⟩)
+    some (x, ⟨ q2, Raw.popInvariant x q.raw q2 q.inv h ⟩)
 
-@[simp] def ghostList {α : Type u} (q : FunctionalQueue α) : List α := Raw.ghostList q.q
+/-- project to a list view, an ordered sequence of elements -/
+def ghostList {α : Type u} (q : FunctionalQueue α) : List α := Raw.ghostList q.raw
 
 theorem pushGhost {α : Type u} (x : α) (q : FunctionalQueue α) :
     ghostList (push x q) = ghostList q ++ [x] :=
-  Raw.pushGhost x q.q
+  Raw.pushGhost x q.raw
 
 theorem popGhost {α : Type u} {x : α} {q q2 : FunctionalQueue α} :
     pop q = some (x, q2) → ghostList q = x :: ghostList q2 := by
@@ -156,7 +158,7 @@ theorem popGhost {α : Type u} {x : α} {q q2 : FunctionalQueue α} :
   split at h
   · simp only [reduceCtorEq] at h
   · rename_i x2 q2' heq
-    obtain ⟨ h1, h2 ⟩ := h
-    apply @Raw.popGhost α x q.q q2' q.inv; grind
+    obtain ⟨h1, h2⟩ := h
+    exact @Raw.popGhost α x q.raw q2' q.inv heq
 
 end Cslib.Algorithms.Lean

--- a/Cslib/Algorithms/Lean/FunctionalQueue/FunctionalQueue.lean
+++ b/Cslib/Algorithms/Lean/FunctionalQueue/FunctionalQueue.lean
@@ -44,7 +44,7 @@ structure FunctionalQueue (α : Type u) where
   back : List α
 
 /-- Well-formedness: if front is empty, back must be empty too. -/
-def invariant {α : Type u} (q : Raw.FunctionalQueue α) : Prop :=
+def Invariant {α : Type u} (q : Raw.FunctionalQueue α) : Prop :=
   q.front = [] → q.back = []
 
 /-- The logical contents of the queue: `front ++ back.reverse`. -/
@@ -71,9 +71,9 @@ theorem rebalanceInvert {α : Type u} (q : FunctionalQueue α) :
   split at h <;> simp_all
 
 theorem rebalanceInvariant {α : Type u} {q : FunctionalQueue α} :
-    invariant (rebalance q).ret := by
+    Invariant (rebalance q).ret := by
   obtain ⟨f, b⟩ := q
-  simp [rebalance, invariant]
+  simp [rebalance, Invariant]
   split <;> grind
 
 @[simp] theorem rebalanceIdempotent {α : Type u} (q : FunctionalQueue α) :
@@ -94,10 +94,10 @@ def push {α : Type u} (x : α) (q : FunctionalQueue α)
   TimeM.tick 1
   rebalance ⟨ q.front, x :: q.back ⟩
 
-theorem pushInvariant {α : Type u} (x : α) (q : FunctionalQueue α)
-    : invariant q → invariant (push x q).ret := by
+theorem Invariant.push {α : Type u} (x : α) (q : FunctionalQueue α)
+    : Invariant q → Invariant (push x q).ret := by
   intro h
-  rw [push]
+  rw [Raw.push]
   apply rebalanceInvariant
 
 theorem pushToList {α : Type u} (x : α) (q : Raw.FunctionalQueue α)
@@ -116,14 +116,14 @@ def pop {α : Type u} (q : Raw.FunctionalQueue α)
     let q2 ← rebalance ⟨ tl, q.back ⟩
     pure (some (x, q2))
 
-theorem popInvariant {α : Type u} (x : α) (q q2 : FunctionalQueue α)
-    : invariant q →
+theorem Invariant.pop {α : Type u} (x : α) (q q2 : FunctionalQueue α)
+    : Invariant q →
       (pop q).ret = some (x, q2) →
-      invariant q2 := by
+      Invariant q2 := by
   intro hq hpop
   obtain ⟨f, b⟩ := q
-  simp [invariant] at hq
-  unfold pop at hpop
+  simp [Invariant] at hq
+  unfold Raw.pop at hpop
   cases f with
   | nil => simp at hpop
   | cons y tl =>
@@ -131,19 +131,19 @@ theorem popInvariant {α : Type u} (x : α) (q q2 : FunctionalQueue α)
     obtain ⟨rfl, rfl⟩ := hpop
     exact rebalanceInvariant
 
-@[simp] theorem emptyInvariant {α : Type u} : invariant (@Raw.empty α) := by
-  simp [invariant, Raw.empty]
+@[simp] theorem Invariant.empty {α : Type u} : Invariant (@Raw.empty α) := by
+  simp [Invariant, Raw.empty]
 
 @[simp] theorem emptyToList {α : Type u} : toList (@Raw.empty α) = [] := by
   simp [toList, Raw.empty]
 
 theorem popToList {α : Type u} {x : α} {q q2 : Raw.FunctionalQueue α}
-    : invariant q →
+    : Invariant q →
       (pop q).ret = some (x, q2) →
       toList q = x :: toList q2 := by
   intro hq hpop
   obtain ⟨f, b⟩ := q
-  simp [invariant] at hq
+  simp [Invariant] at hq
   unfold pop at hpop
   cases f with
   | nil => simp at hpop
@@ -216,14 +216,14 @@ end Complexity
 @[ext]
 structure FunctionalQueue (α : Type u) where
   raw : Raw.FunctionalQueue α
-  inv : Raw.invariant raw
+  inv : Raw.Invariant raw
 
-def empty {α : Type u} : FunctionalQueue α := ⟨ @Raw.empty α, Raw.emptyInvariant ⟩
+def empty {α : Type u} : FunctionalQueue α := ⟨ @Raw.empty α, Raw.Invariant.empty ⟩
 
 def push {α : Type u} (x : α) (q : FunctionalQueue α)
     : TimeM ℕ (FunctionalQueue α) :=
   let r := Raw.push x q.raw
-  ⟨ ⟨ r.ret, Raw.pushInvariant x q.raw q.inv ⟩, r.time ⟩
+  ⟨ ⟨ r.ret, Raw.Invariant.push x q.raw q.inv ⟩, r.time ⟩
 
 def pop {α : Type u} (q : FunctionalQueue α)
     : TimeM ℕ (Option (α × FunctionalQueue α)) :=
@@ -231,7 +231,7 @@ def pop {α : Type u} (q : FunctionalQueue α)
   match h : r.ret with
   | none => ⟨ none, r.time ⟩
   | some (x, q2) =>
-    ⟨ some (x, ⟨ q2, Raw.popInvariant x q.raw q2 q.inv h ⟩), r.time ⟩
+    ⟨ some (x, ⟨ q2, Raw.Invariant.pop x q.raw q2 q.inv h ⟩), r.time ⟩
 
 /-- project to a list view, an ordered sequence of elements -/
 def toList {α : Type u} (q : FunctionalQueue α) : List α := Raw.toList q.raw

--- a/Cslib/Algorithms/Lean/FunctionalQueue/FunctionalQueue.lean
+++ b/Cslib/Algorithms/Lean/FunctionalQueue/FunctionalQueue.lean
@@ -23,24 +23,24 @@ universe u
 @[simp] def ghostList {α : Type u} (q : RawFunctionalQueue α) : List α :=
   List.append q.front q.back.reverse
 
-@[simp] def empty {α : Type u} : RawFunctionalQueue α := ⟨ [], [] ⟩
+def empty {α : Type u} : RawFunctionalQueue α := ⟨ [], [] ⟩
 
-@[simp] def rebalance {α : Type u} (q : RawFunctionalQueue α) : RawFunctionalQueue α :=
+def rebalance {α : Type u} (q : RawFunctionalQueue α) : RawFunctionalQueue α :=
   match q.front with
   | [] => ⟨ (q.back).reverse, [] ⟩
   | _ => q
 
 theorem rebalanceInvert {α : Type u} (q : RawFunctionalQueue α) : (rebalance q).front = [] → q = empty := by
   intro h_reb
+  rw [empty]
   generalize gen_reb : (rebalance q).front = q_reb_hd
   obtain ⟨ q_hd, q_tl ⟩ := q
-  simp; simp at h_reb
+  simp [rebalance] at h_reb
   induction q_reb_hd with
   | nil =>
     induction q_hd with
     | nil =>
-      simp at h_reb
-      grind only
+      simp at h_reb; simp [rebalance] at gen_reb; rw [h_reb]
     | cons q_hd_hd q_hd_tl q_hd_hyp =>
       grind only
   | cons q_reb_hd_hd q_reb_hd_tl q_reb_hd_hyp =>
@@ -51,34 +51,33 @@ theorem rebalanceInvert {α : Type u} (q : RawFunctionalQueue α) : (rebalance q
     | cons _ _ _ =>
       simp at h_reb
 
-theorem rebalanceInvariant {α : Type u} {q : RawFunctionalQueue α} : invariant (rebalance q) := by
+@[simp] theorem rebalanceInvariant {α : Type u} {q : RawFunctionalQueue α} : invariant (rebalance q) := by
   generalize h_front : q.front = l
   induction l with
-  | nil => simp; rw [h_front]; simp
+  | nil => simp [rebalance]; rw [h_front]; simp
   | cons x tl h_cons =>
-    simp; rw [h_front]; simp; rw [h_front]; grind only
+    simp [rebalance]; rw [h_front]; simp; rw [h_front]; grind only
 
 @[simp] theorem rebalanceIdempotent {α : Type u} (q : RawFunctionalQueue α) : rebalance (rebalance q) = rebalance q := by
   generalize h : (rebalance q).front = hd
   induction hd with
   | nil =>
     have h_q_empty : q = empty := rebalanceInvert q h
-    rw [h_q_empty]
-    simp
+    simp [rebalance]; rw [h_q_empty]; simp [empty]
   | cons hd_hd hd_tl hd_hyp =>
     generalize def_q2 : rebalance q = q2
     rw [def_q2] at h
-    simp
+    simp [rebalance]
     rw [h]
 
 @[simp] theorem rebalancePreserveGhost {α : Type u} (q : RawFunctionalQueue α) : ghostList (rebalance q) = ghostList q := by
   generalize def_hd : q.front = hd
   induction hd with
-  | nil => simp; rw [def_hd]; simp
+  | nil => simp [rebalance]; rw [def_hd]; simp
   | cons hd_hd hd_tl h_ind =>
-    simp; rw [def_hd]; simp; grind only [=_ List.cons_append]
+    simp [rebalance]; rw [def_hd]; simp; grind only [=_ List.cons_append]
 
-@[simp] def push {α : Type u} (x : α) (q : RawFunctionalQueue α) : (RawFunctionalQueue α) :=
+def push {α : Type u} (x : α) (q : RawFunctionalQueue α) : (RawFunctionalQueue α) :=
   let q : RawFunctionalQueue α := ⟨ q.front, x :: q.back ⟩
   rebalance q
 
@@ -92,20 +91,20 @@ theorem appendGhost {α : Type u} (x : α) (q : RawFunctionalQueue α) : ghostLi
   generalize h_front : q.front = l
   cases l with
   | nil =>
-    simp; rw [h_front]; simp
+    simp [push, rebalance]; rw [h_front]; simp
   | cons l_hd l_tl =>
     rw [push]
     rw [rebalancePreserveGhost]
     rw [ghostList]
     simp
 
-def pop {α : Type} (q : RawFunctionalQueue α) : Option (α × RawFunctionalQueue α) :=
+def pop {α : Type u} (q : RawFunctionalQueue α) : Option (α × RawFunctionalQueue α) :=
   match q.front with
   | [] => none
   | x :: tl =>
     some (x, rebalance ⟨ tl, q.back ⟩)
 
-theorem pop_invariant {α : Type} (x : α) (q q2 : RawFunctionalQueue α) :
+theorem pop_invariant {α : Type u} (x : α) (q q2 : RawFunctionalQueue α) :
     invariant q → pop q = some (x, q2) → invariant q2 := by
   intro hq hpop_is_some
   simp at hq

--- a/Cslib/Algorithms/Lean/FunctionalQueue/FunctionalQueue.lean
+++ b/Cslib/Algorithms/Lean/FunctionalQueue/FunctionalQueue.lean
@@ -176,45 +176,20 @@ instance functionalQueueApplyOp {α : Type u}
     : Amortized.Op (Raw.FunctionalQueue α) (queueOp α) :=
   ⟨ applyOp ⟩
 
-theorem costRebalanceEmpty {α : Type u} (q : Raw.FunctionalQueue α)
-    : q.front = [] → (Raw.rebalance q).time = potential q := by
-  intro h
-  simp only [Raw.rebalance]; rw [h]; simp [potential]
+theorem potentialEmptyIsZero {α : Type u}
+    : potential (@Raw.empty α) = 0 := by
+  simp [potential, Raw.empty]
 
-grind_pattern costRebalanceEmpty => (Raw.rebalance q).time
-
-theorem costRebalanceNonEmpty {α : Type u} (q : Raw.FunctionalQueue α)
-    : q.front ≠ [] → (Raw.rebalance q).time = 0 := by
-  intro h
-  simp [Raw.rebalance]
-
-grind_pattern costRebalanceNonEmpty => (Raw.rebalance q).time
-
-theorem costPush {α : Type u} (x : α) (q : Raw.FunctionalQueue α)
-    : (Raw.push x q).time ≤ potential q := by
-  simp [Raw.push]
-  sorry
-  /- cases q.front <;> grind -/
-  /-     grind [Raw.push] -/
-
-theorem costApplyOp {α : Type u} (op : queueOp α) (q : Raw.FunctionalQueue α)
-    : (applyOp q op).time ≤ 1 + potential q := by
-  sorry
-  /- cases op with -/
-  /- | .pu -/
-  /- simp [applyOp] -/
-  /- grind -/
-
-theorem constantTimeAmortized {α : Type u} :
-    ∀ (q : Raw.FunctionalQueue α) (ops : List (queueOp α)),
-    (Amortized.applyOps ops q).time ≤ 2 * potential (Amortized.applyOps ops q).ret
-    := by
-  intro q ops
-  induction ops generalizing q with
-  | nil => simp
-  | cons op otherOps hOps =>
-    simp
-    sorry
+theorem amortizedCostQueueOp {α : Type u} (q : Raw.FunctionalQueue α) (op : queueOp α)
+    : Amortized.amortizedCost q op ≤ 2 := by
+  simp only [Amortized.amortizedCost, Amortized.Potential.potential, Nat.sub_le_iff_le_add]
+  cases op with
+  | push x =>
+    simp only [Amortized.Op.applyOp, applyOp, potential]
+    cases h_front : q.front <;> (rw [Raw.push, Raw.rebalance, h_front] at ⊢; grind)
+  | pop =>
+    simp only [Amortized.Op.applyOp, applyOp, potential]
+    cases h_front : q.front <;> (rw [Raw.pop, h_front] at ⊢; grind [Raw.rebalance])
 
 end Complexity
 
@@ -251,7 +226,6 @@ theorem popGhost {α : Type u} {x : α} {q2 : FunctionalQueue α} :
     (pop q).ret = some (x, q2) → ghostList q = x :: ghostList q2 := by
   intro q h
   simp only [pop, ghostList] at h ⊢
-  simp only [TimeM.ret] at h
   split at h
   · simp only [reduceCtorEq] at h
   · rename_i x2 q2' heq

--- a/Cslib/Algorithms/Lean/FunctionalQueue/FunctionalQueue.lean
+++ b/Cslib/Algorithms/Lean/FunctionalQueue/FunctionalQueue.lean
@@ -48,8 +48,8 @@ def invariant {α : Type u} (q : Raw.FunctionalQueue α) : Prop :=
   q.front = [] → q.back = []
 
 /-- The logical contents of the queue: `front ++ back.reverse`. -/
-def ghostList {α : Type u} (q : FunctionalQueue α) : List α :=
-  List.append q.front q.back.reverse
+def toList {α : Type u} (q : FunctionalQueue α) : List α :=
+  q.front ++ q.back.reverse
 
 /-- The empty queue. -/
 def empty {α : Type u} : FunctionalQueue α := ⟨ [], [] ⟩
@@ -83,9 +83,9 @@ theorem rebalanceInvariant {α : Type u} {q : FunctionalQueue α} :
   split <;> grind
 
 @[simp] theorem rebalancePreserveGhost {α : Type u} (q : FunctionalQueue α) :
-    ghostList (rebalance q).ret = ghostList q := by
+    toList (rebalance q).ret = toList q := by
   obtain ⟨f, b⟩ := q
-  simp [rebalance, ghostList]
+  simp [rebalance, toList]
   split <;> grind [List.reverse_append]
 
 /-- Enqueue an element. -/
@@ -100,12 +100,12 @@ theorem pushInvariant {α : Type u} (x : α) (q : FunctionalQueue α)
   rw [push]
   apply rebalanceInvariant
 
-theorem pushGhost {α : Type u} (x : α) (q : Raw.FunctionalQueue α)
-    : ghostList (push x q).ret = ghostList q ++ [x] := by
+theorem pushToList {α : Type u} (x : α) (q : Raw.FunctionalQueue α)
+    : toList (push x q).ret = toList q ++ [x] := by
   rw [push]
   simp only [TimeM.ret_bind, rebalancePreserveGhost]
-  rw [ghostList]
-  simp [ghostList, List.append_assoc]
+  rw [toList]
+  simp [toList, List.append_assoc]
 
 /-- Dequeue: returns `some (head, remaining)` or `none` if empty. -/
 def pop {α : Type u} (q : Raw.FunctionalQueue α)
@@ -134,13 +134,13 @@ theorem popInvariant {α : Type u} (x : α) (q q2 : FunctionalQueue α)
 @[simp] theorem emptyInvariant {α : Type u} : invariant (@Raw.empty α) := by
   simp [invariant, Raw.empty]
 
-@[simp] theorem emptyGhost {α : Type u} : ghostList (@Raw.empty α) = [] := by
-  simp [ghostList, Raw.empty]
+@[simp] theorem emptyToList {α : Type u} : toList (@Raw.empty α) = [] := by
+  simp [toList, Raw.empty]
 
-theorem popGhost {α : Type u} {x : α} {q q2 : Raw.FunctionalQueue α}
+theorem popToList {α : Type u} {x : α} {q q2 : Raw.FunctionalQueue α}
     : invariant q →
       (pop q).ret = some (x, q2) →
-      ghostList q = x :: ghostList q2 := by
+      toList q = x :: toList q2 := by
   intro hq hpop
   obtain ⟨f, b⟩ := q
   simp [invariant] at hq
@@ -151,7 +151,7 @@ theorem popGhost {α : Type u} {x : α} {q q2 : Raw.FunctionalQueue α}
     simp only at hpop
     obtain ⟨rfl, rfl⟩ := hpop
     simp only [rebalancePreserveGhost]
-    simp [ghostList]
+    simp [toList]
 
 end Raw
 
@@ -234,22 +234,22 @@ def pop {α : Type u} (q : FunctionalQueue α)
     ⟨ some (x, ⟨ q2, Raw.popInvariant x q.raw q2 q.inv h ⟩), r.time ⟩
 
 /-- project to a list view, an ordered sequence of elements -/
-def ghostList {α : Type u} (q : FunctionalQueue α) : List α := Raw.ghostList q.raw
+def toList {α : Type u} (q : FunctionalQueue α) : List α := Raw.toList q.raw
 
 theorem pushGhost {α : Type u} (x : α) (q : FunctionalQueue α) :
-    ghostList (push x q).ret = ghostList q ++ [x] :=
-  Raw.pushGhost x q.raw
+    toList (push x q).ret = toList q ++ [x] :=
+  Raw.pushToList x q.raw
 
 theorem popGhost {α : Type u} {x : α} {q2 : FunctionalQueue α} :
     ∀ {q : FunctionalQueue α},
-    (pop q).ret = some (x, q2) → ghostList q = x :: ghostList q2 := by
+    (pop q).ret = some (x, q2) → toList q = x :: toList q2 := by
   intro q h
-  simp only [pop, ghostList] at h ⊢
+  simp only [pop, toList] at h ⊢
   split at h
   · simp only [reduceCtorEq] at h
   · rename_i x2 q2' heq
     obtain ⟨h1, h2⟩ := h
-    exact @Raw.popGhost α x q.raw q2' q.inv heq
+    exact @Raw.popToList α x q.raw q2' q.inv heq
 
 end
 

--- a/Cslib/Algorithms/Lean/FunctionalQueue/FunctionalQueue.lean
+++ b/Cslib/Algorithms/Lean/FunctionalQueue/FunctionalQueue.lean
@@ -7,6 +7,7 @@ Authors: Simon Cruanes
 module
 
 import Cslib.Init
+public import Mathlib.Algebra.Ring.Int.Defs
 public import Cslib.Algorithms.Lean.Amortized
 public import Cslib.Algorithms.Lean.TimeM
 
@@ -154,11 +155,14 @@ end Raw
 
 namespace Complexity
 
-def potential {α : Type u} (q : Raw.FunctionalQueue α) : Nat :=
+def potential {α : Type u} (q : Raw.FunctionalQueue α) : ℤ :=
   q.back.length
 
+set_option trace.Meta.synthInstance true
+#synth CommRing ℤ
+
 instance functionalQueuePotential {α : Type u}
-    : Amortized.Potential (Raw.FunctionalQueue α) :=
+    : Amortized.Potential ℤ (Raw.FunctionalQueue α) :=
   ⟨ potential ⟩
 
 inductive queueOp (α : Type u) where

--- a/Cslib/Algorithms/Lean/FunctionalQueue/FunctionalQueue.lean
+++ b/Cslib/Algorithms/Lean/FunctionalQueue/FunctionalQueue.lean
@@ -1,0 +1,123 @@
+
+
+module
+
+/- public import Cslib.Algorithms.Lean.TimeM -/
+
+/-!
+  The simplest functional queue. -/
+
+@[expose] public section
+
+namespace Cslib.Algorithms.Lean
+
+universe u
+
+@[ext] structure RawFunctionalQueue (α : Type u) where
+  front : List α
+  back : List α
+
+@[simp] def invariant {α : Type u} (q : RawFunctionalQueue α) : Prop :=
+  q.front = [] → q.back = []
+
+@[simp] def ghostList {α : Type u} (q : RawFunctionalQueue α) : List α :=
+  List.append q.front q.back.reverse
+
+@[simp] def empty {α : Type u} : RawFunctionalQueue α := ⟨ [], [] ⟩
+
+@[simp] def rebalance {α : Type u} (q : RawFunctionalQueue α) : RawFunctionalQueue α :=
+  match q.front with
+  | [] => ⟨ (q.back).reverse, [] ⟩
+  | _ => q
+
+theorem rebalanceInvert {α : Type u} (q : RawFunctionalQueue α) : (rebalance q).front = [] → q = empty := by
+  intro h_reb
+  generalize gen_reb : (rebalance q).front = q_reb_hd
+  obtain ⟨ q_hd, q_tl ⟩ := q
+  simp; simp at h_reb
+  induction q_reb_hd with
+  | nil =>
+    induction q_hd with
+    | nil =>
+      simp at h_reb
+      grind only
+    | cons q_hd_hd q_hd_tl q_hd_hyp =>
+      grind only
+  | cons q_reb_hd_hd q_reb_hd_tl q_reb_hd_hyp =>
+    induction q_hd with
+    | nil =>
+      simp at h_reb
+      grind only
+    | cons _ _ _ =>
+      simp at h_reb
+
+theorem rebalanceInvariant {α : Type u} {q : RawFunctionalQueue α} : invariant (rebalance q) := by
+  generalize h_front : q.front = l
+  induction l with
+  | nil => simp; rw [h_front]; simp
+  | cons x tl h_cons =>
+    simp; rw [h_front]; simp; rw [h_front]; grind only
+
+@[simp] theorem rebalanceIdempotent {α : Type u} (q : RawFunctionalQueue α) : rebalance (rebalance q) = rebalance q := by
+  generalize h : (rebalance q).front = hd
+  induction hd with
+  | nil =>
+    have h_q_empty : q = empty := rebalanceInvert q h
+    rw [h_q_empty]
+    simp
+  | cons hd_hd hd_tl hd_hyp =>
+    generalize def_q2 : rebalance q = q2
+    rw [def_q2] at h
+    simp
+    rw [h]
+
+@[simp] theorem rebalancePreserveGhost {α : Type u} (q : RawFunctionalQueue α) : ghostList (rebalance q) = ghostList q := by
+  generalize def_hd : q.front = hd
+  induction hd with
+  | nil => simp; rw [def_hd]; simp
+  | cons hd_hd hd_tl h_ind =>
+    simp; rw [def_hd]; simp; grind only [=_ List.cons_append]
+
+@[simp] def push {α : Type u} (x : α) (q : RawFunctionalQueue α) : (RawFunctionalQueue α) :=
+  let q : RawFunctionalQueue α := ⟨ q.front, x :: q.back ⟩
+  rebalance q
+
+theorem appendInvariant {α : Type u} (x : α) (q : RawFunctionalQueue α)
+  : invariant q → invariant (push x q) := by
+  intro h
+  rw [push]
+  apply rebalanceInvariant
+
+theorem appendGhost {α : Type u} (x : α) (q : RawFunctionalQueue α) : ghostList (push x q) = ghostList q ++ [x] := by
+  generalize h_front : q.front = l
+  cases l with
+  | nil =>
+    simp; rw [h_front]; simp
+  | cons l_hd l_tl =>
+    rw [push]
+    rw [rebalancePreserveGhost]
+    rw [ghostList]
+    simp
+
+def pop {α : Type} (q : RawFunctionalQueue α) : Option (α × RawFunctionalQueue α) :=
+  match q.front with
+  | [] => none
+  | x :: tl =>
+    some (x, rebalance ⟨ tl, q.back ⟩)
+
+theorem pop_invariant {α : Type} (x : α) (q q2 : RawFunctionalQueue α) :
+    invariant q → pop q = some (x, q2) → invariant q2 := by
+  intro hq hpop_is_some
+  simp at hq
+  rw [pop] at hpop_is_some
+  generalize h_front : q.front = l
+  cases l with
+  | nil =>
+    rw [h_front] at hpop_is_some; simp at hpop_is_some
+  | cons _ _ =>
+    rw [h_front] at hpop_is_some
+    simp only at hpop_is_some
+    obtain ⟨ rfl, rfl ⟩ := hpop_is_some
+    apply rebalanceInvariant
+
+end Cslib.Algorithms.Lean

--- a/Cslib/Algorithms/Lean/FunctionalQueue/FunctionalQueue.lean
+++ b/Cslib/Algorithms/Lean/FunctionalQueue/FunctionalQueue.lean
@@ -7,7 +7,9 @@ Authors: Simon Cruanes
 module
 
 import Cslib.Init
+import Mathlib
 public import Mathlib.Algebra.Ring.Int.Defs
+public import Mathlib.Algebra.Order.Ring.Int
 public import Cslib.Algorithms.Lean.Amortized
 public import Cslib.Algorithms.Lean.TimeM
 
@@ -158,9 +160,6 @@ namespace Complexity
 def potential {α : Type u} (q : Raw.FunctionalQueue α) : ℤ :=
   q.back.length
 
-set_option trace.Meta.synthInstance true
-#synth CommRing ℤ
-
 instance functionalQueuePotential {α : Type u}
     : Amortized.Potential ℤ (Raw.FunctionalQueue α) :=
   ⟨ potential ⟩
@@ -187,8 +186,8 @@ theorem potentialEmptyIsZero {α : Type u}
   simp [potential, Raw.empty]
 
 theorem amortizedCostQueueOp {α : Type u} (q : Raw.FunctionalQueue α) (op : queueOp α)
-    : Amortized.amortizedCost q op ≤ 2 := by
-  simp only [Amortized.amortizedCost, Amortized.Potential.potential, Nat.sub_le_iff_le_add]
+    : Amortized.amortizedCost q op ≤ (2 : ℤ) := by
+  simp only [Amortized.amortizedCost, Amortized.Potential.potential, tsub_le_iff_right]
   cases op with
   | push x =>
     simp only [Amortized.Op.applyOp, applyOp, potential]
@@ -203,11 +202,11 @@ theorem costQueueOps {α : Type u}
     : (Amortized.applyOps q ops).time
         + potential (Amortized.applyOps q ops).ret
         - potential q
-      ≤ 2 * ops.length
+      ≤ (2 : ℤ) * ops.length
     := by
   have useful
     := Amortized.constantAmortizedCostL 2 amortizedCostQueueOp q ops
-  simp only [Amortized.amortizedCostL, Amortized.Potential.potential]
+  simp only [Amortized.Potential.potential]
     at useful
   grind only
 

--- a/Cslib/Algorithms/Lean/TimeM.lean
+++ b/Cslib/Algorithms/Lean/TimeM.lean
@@ -85,7 +85,7 @@ instance [Add T] : SeqLeft (TimeM T) where
 instance [Add T] : SeqRight (TimeM T) where
   seqRight x y := ⟨(y ()).ret, x.time + (y ()).time⟩
 
-instance [AddZero T] : Monad (TimeM T) where
+instance [Add T] [Zero T] : Monad (TimeM T) where
   pure := Pure.pure
   bind := Bind.bind
   map := Functor.map


### PR DESCRIPTION
Hi, this is my first attempt at contributing Lean code.

I dug out the old Okasaki, and started off with the simple queue. This should
contain a correctness proof, a complexity proof, and a mapping to a ghost list
of elements. `TimeM` doesn't seem to be enough for amortized complexity so
I added a module for that, and I also removed the `ZeroAdd` typeclass constraint
because `\N` doesn't implement it(!).

AI disclosure: all code is mine, but I had some assistance from GLM 5.1 to
tidy up proof terms and get unstuck.
