### PR TITLE
chore(ci): pin lint-style-action to a SHA instead of @main

### DIFF
--- a/.github/workflows/lean_action_ci.yml
+++ b/.github/workflows/lean_action_ci.yml
@@ -34,6 +34,6 @@ jobs:
         run: |
           set -e
           lake exe checkInitImports
-      - uses: leanprover-community/lint-style-action@main
+      - uses: leanprover-community/lint-style-action@91923b046cc6a468e9ae340f32f8defe586bd08f # 2026-05-12
         with:
           mode: check


### PR DESCRIPTION
This PR pins `leanprover-community/lint-style-action` to commit `91923b04` (2026-05-12) instead of tracking `@main`. SHA-pinning third-party GitHub Actions is the standard hardening practice — it prevents a compromised or accidentally-broken upstream commit from silently affecting CI here, and makes the action version reproducible.

The chosen pin matches what mathlib4 uses (after the companion bump in https://github.com/leanprover-community/mathlib4/pull/39228) and includes https://github.com/leanprover-community/lint-style-action/pull/5 - feat(install-bibtool): use --no-install-recommends with apt-get, which trims ~167 MB of unused texlive packages off every run of the Lint style step.

Going forward, bumping the pin can be a periodic, reviewed step rather than an implicit dependency on whatever HEAD happens to be.

🤖 Prepared with Claude Code