### PR TITLE
chore(ci): bump lint-style-action pin off reverted commit

### DIFF
--- a/.github/workflows/lean_action_ci.yml
+++ b/.github/workflows/lean_action_ci.yml
@@ -34,6 +34,6 @@ jobs:
         run: |
           set -e
           lake exe checkInitImports
-      - uses: leanprover-community/lint-style-action@91923b046cc6a468e9ae340f32f8defe586bd08f # 2026-05-12
+      - uses: leanprover-community/lint-style-action@e6128ab22cb03b509075ae46c33727e3952ffab7 # 2026-05-12
         with:
           mode: check


### PR DESCRIPTION
Follow-up to https://github.com/leanprover/cslib/pull/561.

This PR moves `leanprover-community/lint-style-action` from `91923b04` (the merge of the now-reverted https://github.com/leanprover-community/lint-style-action/pull/5) to `e6128ab2` (the merge of the revert PR https://github.com/leanprover-community/lint-style-action/pull/6).

cslib does not set `lint-bib-file: true`, so the broken `Install bibtool` step shipped in `91923b04` was gated off and never actually ran here — the previous pin was functionally harmless. This is purely a cosmetic move off a known-bad SHA onto the current clean tip, restoring parity with mathlib4's pin (which is still `a7e7428`, functionally identical to `e6128ab2` at the `action.yml` level after the revert).

🤖 Prepared with Claude Code