### PR TITLE
feat(algorithms): add bubble, insertion, counting, and quicksort

### DIFF
--- a/Cslib.lean
+++ b/Cslib.lean
@@ -1,6 +1,12 @@
 module  -- shake: keep-all
 
+public import Cslib.Algorithms.Lean.Sorting
+public import Cslib.Algorithms.Lean.BubbleSort.BubbleSort
+public import Cslib.Algorithms.Lean.CountingSort.CountingSort
+public import Cslib.Algorithms.Lean.InsertionSort.InsertionSort
 public import Cslib.Algorithms.Lean.MergeSort.MergeSort
+public import Cslib.Algorithms.Lean.QuickSort.QuickSort
+public import Cslib.Algorithms.Lean.RandomTimeM
 public import Cslib.Algorithms.Lean.TimeM
 public import Cslib.Computability.Automata.Acceptors.Acceptor
 public import Cslib.Computability.Automata.Acceptors.OmegaAcceptor

--- a/Cslib.lean
+++ b/Cslib.lean
@@ -1,12 +1,12 @@
 module  -- shake: keep-all
 
-public import Cslib.Algorithms.Lean.Sorting
 public import Cslib.Algorithms.Lean.BubbleSort.BubbleSort
 public import Cslib.Algorithms.Lean.CountingSort.CountingSort
 public import Cslib.Algorithms.Lean.InsertionSort.InsertionSort
 public import Cslib.Algorithms.Lean.MergeSort.MergeSort
 public import Cslib.Algorithms.Lean.QuickSort.QuickSort
 public import Cslib.Algorithms.Lean.RandomTimeM
+public import Cslib.Algorithms.Lean.Sorting
 public import Cslib.Algorithms.Lean.TimeM
 public import Cslib.Computability.Automata.Acceptors.Acceptor
 public import Cslib.Computability.Automata.Acceptors.OmegaAcceptor

--- a/Cslib/Algorithms/Lean/BubbleSort/BubbleSort.lean
+++ b/Cslib/Algorithms/Lean/BubbleSort/BubbleSort.lean
@@ -8,8 +8,11 @@ module
 
 public import Cslib.Algorithms.Lean.Sorting
 public import Cslib.Algorithms.Lean.TimeM
-public import Mathlib.Data.List.Sort
 public import Mathlib.Data.Nat.Basic
+public import Mathlib.Order.Lattice
+public import Mathlib.Tactic.Attr.Core
+public import Mathlib.Tactic.Finiteness.Attr
+public import Batteries.Data.List.Lemmas
 
 /-!
 # Stable bubble sort on lists
@@ -125,7 +128,6 @@ private theorem bubbleMax_perm (candidate : α) (xs : List α) :
 A bubbling pass is stable. Since equal values are never swapped, filtering by any value gives the
 same subsequence before and after the pass.
 -/
-@[simp]
 private theorem bubbleMax_stable (candidate : α) (xs : List α) :
     StableByValue (candidate :: xs)
       ((⟪bubbleMax candidate xs⟫).1 ++ [(⟪bubbleMax candidate xs⟫).2]) := by

--- a/Cslib/Algorithms/Lean/BubbleSort/BubbleSort.lean
+++ b/Cslib/Algorithms/Lean/BubbleSort/BubbleSort.lean
@@ -1,0 +1,203 @@
+/-
+Copyright (c) 2026 Robert Joseph George. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Robert Joseph George
+-/
+
+module
+
+public import Cslib.Algorithms.Lean.Sorting
+public import Cslib.Algorithms.Lean.TimeM
+public import Mathlib.Data.List.Sort
+public import Mathlib.Data.Nat.Basic
+
+/-!
+# Stable bubble sort on lists
+
+`bubbleSort` returns a `TimeM ℕ (List α)`: the return value is the sorted list, and the time
+component counts comparisons.
+
+Each pass moves one maximal element to the end. Stability comes from the strict swap test: equal
+elements are copied forward in their original order instead of being exchanged.
+-/
+
+@[expose] public section
+
+set_option autoImplicit false
+
+namespace Cslib.Algorithms.Lean.TimeM
+
+variable {α : Type} [LinearOrder α]
+
+/--
+One stable bubbling pass. `bubbleMax candidate xs` returns a prefix and a final element.
+The final element is maximal among `candidate :: xs`.
+
+The pass swaps only when the next value is strictly smaller than the current candidate. Equal values
+are therefore never swapped, which is the local reason the full sort is stable.
+-/
+def bubbleMax : α → List α → TimeM ℕ (List α × α)
+  | candidate, [] => return ([], candidate)
+  | candidate, x :: xs => do
+    ✓ let swap := x < candidate
+    if swap then
+      let result ← bubbleMax candidate xs
+      return (x :: result.1, result.2)
+    else
+      let result ← bubbleMax x xs
+      return (candidate :: result.1, result.2)
+
+/-- A bubbling pass keeps exactly one element out of the prefix. -/
+@[simp, grind =]
+private theorem bubbleMax_length (candidate : α) (xs : List α) :
+    (⟪bubbleMax candidate xs⟫).1.length = xs.length := by
+  induction xs generalizing candidate with
+  | nil => simp [bubbleMax]
+  | cons x xs ih =>
+    simp [bubbleMax]
+    split <;> simp [ih]
+
+/-- A bubbling pass performs one comparison for each element it scans. -/
+@[simp, grind =]
+private theorem bubbleMax_time (candidate : α) (xs : List α) :
+    (bubbleMax candidate xs).time = xs.length := by
+  induction xs generalizing candidate with
+  | nil => simp [bubbleMax]
+  | cons x xs ih =>
+    simp [bubbleMax]
+    split <;> simp [ih, Nat.add_comm]
+
+/-- Sorts a list using stable bubble sort, counting comparisons as time cost. -/
+def bubbleSort : List α → TimeM ℕ (List α)
+  | [] => return []
+  | x :: xs =>
+    let pass := bubbleMax x xs
+    let sortedPrefix := bubbleSort pass.ret.1
+    ⟨sortedPrefix.ret ++ [pass.ret.2], pass.time + sortedPrefix.time⟩
+termination_by xs => xs.length
+decreasing_by
+  simp_wf
+
+section Correctness
+
+/-- The final element produced by a bubbling pass is at least the initial candidate. -/
+@[simp]
+private theorem bubbleMax_candidate_le_output (candidate : α) (xs : List α) :
+    candidate ≤ (⟪bubbleMax candidate xs⟫).2 := by
+  induction xs generalizing candidate with
+  | nil => simp [bubbleMax]
+  | cons x xs ih =>
+    by_cases h : x < candidate
+      <;> simp only [bubbleMax, h, ↓reduceIte, ret_bind, ret_pure]
+      <;> grind
+
+/-- Every element left in the prefix of a bubbling pass is bounded by the final element. -/
+@[simp]
+private theorem bubbleMax_prefix_le_output (candidate : α) (xs : List α) :
+    ∀ z ∈ (⟪bubbleMax candidate xs⟫).1, z ≤ (⟪bubbleMax candidate xs⟫).2 := by
+  induction xs generalizing candidate with
+  | nil => simp [bubbleMax]
+  | cons x xs ih =>
+    by_cases h : x < candidate
+      <;> simp only [bubbleMax, h, ↓reduceIte, ret_bind, ret_pure, List.mem_cons]
+      <;> intro z hz
+      <;> rcases hz with rfl | hz
+    · exact le_trans (le_of_lt h) (bubbleMax_candidate_le_output candidate xs)
+    · exact ih candidate z hz
+    · exact le_trans (le_of_not_gt h) (bubbleMax_candidate_le_output x xs)
+    · exact ih x z hz
+
+/-- A bubbling pass is a permutation of the candidate and the remaining input. -/
+@[simp]
+private theorem bubbleMax_perm (candidate : α) (xs : List α) :
+    ((⟪bubbleMax candidate xs⟫).1 ++ [(⟪bubbleMax candidate xs⟫).2]).Perm
+      (candidate :: xs) := by
+  induction xs generalizing candidate with
+  | nil => simp [bubbleMax]
+  | cons x xs ih =>
+    by_cases h : x < candidate
+    · simpa only [bubbleMax, h, ↓reduceIte, ret_bind, ret_pure, List.cons_append] using
+        (List.Perm.cons x (ih candidate)).trans (List.Perm.swap candidate x xs)
+    · simpa only [bubbleMax, h, ↓reduceIte, ret_bind, ret_pure, List.cons_append] using
+        List.Perm.cons candidate (ih x)
+
+/--
+A bubbling pass is stable. Since equal values are never swapped, filtering by any value gives the
+same subsequence before and after the pass.
+-/
+@[simp]
+private theorem bubbleMax_stable (candidate : α) (xs : List α) :
+    StableByValue (candidate :: xs)
+      ((⟪bubbleMax candidate xs⟫).1 ++ [(⟪bubbleMax candidate xs⟫).2]) := by
+  induction xs generalizing candidate with
+  | nil => simp [StableByValue, bubbleMax]
+  | cons x xs ih =>
+    intro y
+    by_cases h : x < candidate
+    · have := ih candidate y
+      by_cases hxy : x = y <;> by_cases hcy : candidate = y <;> grind [bubbleMax]
+    · have := ih x y
+      by_cases hcy : candidate = y <;> grind [bubbleMax]
+
+/-- Bubble sort returns a permutation of its input. -/
+theorem bubbleSort_perm (xs : List α) : (⟪bubbleSort xs⟫).Perm xs := by
+  fun_induction bubbleSort xs with
+  | case1 => simp
+  | case2 x xs pass _ ih =>
+    exact (List.Perm.append_right [pass.ret.2] ih).trans (by simp [pass])
+
+/-- Bubble sort is stable: equal values occur in the same order after sorting. -/
+theorem bubbleSort_stable (xs : List α) : StableByValue xs ⟪bubbleSort xs⟫ := by
+  fun_induction bubbleSort xs with
+  | case1 => simp [StableByValue]
+  | case2 x xs pass _ ih =>
+    intro y
+    simp only [List.filter_append]
+    rw [ih y]
+    simpa [pass, List.filter_append] using bubbleMax_stable x xs y
+
+/--
+Bubble sort returns a sorted list. The recursive call sorts the prefix, and `bubbleMax` proves every
+prefix element is below the final element appended at the end.
+-/
+theorem bubbleSort_sorted (xs : List α) : List.Pairwise (· ≤ ·) ⟪bubbleSort xs⟫ := by
+  fun_induction bubbleSort xs with
+  | case1 => simp
+  | case2 x xs pass _ ih =>
+    change ((bubbleSort pass.ret.1).ret ++ [pass.ret.2]).Pairwise (· ≤ ·)
+    rw [List.pairwise_append]
+    have hprefix := bubbleMax_prefix_le_output x xs
+    have hperm := bubbleSort_perm pass.ret.1
+    grind
+
+/-- Bubble sort is functionally correct. -/
+theorem bubbleSort_correct (xs : List α) : List.Pairwise (· ≤ ·) ⟪bubbleSort xs⟫ ∧
+    (⟪bubbleSort xs⟫).Perm xs ∧ StableByValue xs ⟪bubbleSort xs⟫ := by
+  exact ⟨bubbleSort_sorted xs, bubbleSort_perm xs, bubbleSort_stable xs⟩
+
+end Correctness
+
+section TimeComplexity
+
+/-- Bubble sort performs at most a full bubbling pass for each output position. -/
+theorem bubbleSort_time (xs : List α) :
+    let n := xs.length
+    (bubbleSort xs).time ≤ n * n := by
+  fun_induction bubbleSort xs with
+  | case1 => simp
+  | case2 x xs pass _ ih =>
+    simp only [List.length_cons]
+    change pass.time + (bubbleSort pass.ret.1).time ≤ (xs.length + 1) * (xs.length + 1)
+    have hpass : pass.ret.1.length = xs.length := by simp [pass]
+    calc
+      pass.time + (bubbleSort pass.ret.1).time
+          ≤ pass.time + pass.ret.1.length * pass.ret.1.length := by omega
+      _ = xs.length + pass.ret.1.length * pass.ret.1.length := by simp [pass]
+      _ = xs.length + xs.length * xs.length := by rw [hpass]
+      _ = xs.length * (xs.length + 1) := by simp [Nat.mul_succ, Nat.add_comm]
+      _ ≤ (xs.length + 1) * (xs.length + 1) :=
+        Nat.mul_le_mul_right (xs.length + 1) (Nat.le_succ xs.length)
+
+end TimeComplexity
+
+end Cslib.Algorithms.Lean.TimeM

--- a/Cslib/Algorithms/Lean/CountingSort/CountingSort.lean
+++ b/Cslib/Algorithms/Lean/CountingSort/CountingSort.lean
@@ -1,0 +1,223 @@
+/-
+Copyright (c) 2026 Robert Joseph George. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Robert Joseph George
+-/
+
+module
+
+public import Cslib.Algorithms.Lean.Sorting
+public import Cslib.Algorithms.Lean.TimeM
+public import Mathlib.Data.List.Count
+public import Mathlib.Data.List.Sort
+public import Mathlib.Data.Nat.Basic
+
+/-!
+# Counting sort on natural-number lists
+
+`countingSort` sorts a `List ℕ` using an explicit upper bound `bound`. It scans the input once for
+each key in `0, ..., bound` and returns a `TimeM ℕ (List ℕ)`.
+
+The cost model counts one key comparison while scanning an input element. Constructing output
+blocks, appending lists, arithmetic, and pattern matching are free.
+
+Correctness is proved through counts: each generated block contributes exactly the copies for one
+key, and bounded inputs ensure no out-of-range key is missing from the output.
+-/
+
+@[expose] public section
+
+set_option autoImplicit false
+
+namespace Cslib.Algorithms.Lean.TimeM
+
+/-- `xs` is bounded by `bound` when every entry is at most `bound`. -/
+abbrev BoundedBy (bound : ℕ) (xs : List ℕ) : Prop := ∀ x ∈ xs, x ≤ bound
+
+/-- Counts occurrences of one key, charging one tick for each inspected input element. -/
+def countKey (key : ℕ) : List ℕ → TimeM ℕ ℕ
+  | [] => return 0
+  | x :: xs => do
+    ✓ let hit := x == key
+    let rest ← countKey key xs
+    return rest + if hit then 1 else 0
+
+/-- Builds the sorted blocks for keys `start, ..., start + fuel - 1`. -/
+def buildCountedFrom (start fuel : ℕ) (xs : List ℕ) : TimeM ℕ (List ℕ) :=
+  match fuel with
+  | 0 => return []
+  | fuel' + 1 => do
+    let count ← countKey start xs
+    let rest ← buildCountedFrom (start + 1) fuel' xs
+    return List.replicate count start ++ rest
+
+/-- Sorts natural-number lists by counting all keys from `0` through `bound`. -/
+def countingSort (bound : ℕ) (xs : List ℕ) : TimeM ℕ (List ℕ) :=
+  buildCountedFrom 0 (bound + 1) xs
+
+section Correctness
+
+/-- Timed key counting computes `List.count`. -/
+@[simp, grind =]
+private theorem ret_countKey (key : ℕ) (xs : List ℕ) : ⟪countKey key xs⟫ = xs.count key := by
+  induction xs with
+  | nil => simp [countKey]
+  | cons x xs ih =>
+    by_cases h : x = key <;> simp [countKey, ih, h]
+
+/-- Counting one key performs one comparison per input element. -/
+@[simp, grind =]
+private theorem countKey_time (key : ℕ) (xs : List ℕ) : (countKey key xs).time = xs.length := by
+  induction xs with
+  | nil => simp [countKey]
+  | cons x xs ih => simp [countKey, ih, Nat.add_comm]
+
+@[simp]
+private theorem count_replicate_of_ne {key value count : ℕ} (h : value ≠ key) :
+    (List.replicate count value).count key = 0 := by
+  simp [List.count_replicate, h]
+
+/-- The generated blocks contain no key below the requested start. -/
+private theorem buildCountedFrom_start_le_of_mem {value start fuel : ℕ} {xs : List ℕ} :
+    value ∈ ⟪buildCountedFrom start fuel xs⟫ → start ≤ value := by
+  induction fuel generalizing start value with
+  | zero => simp [buildCountedFrom]
+  | succ fuel ih =>
+    simp only [buildCountedFrom, ret_bind, ret_pure, ret_countKey, List.mem_append,
+      List.mem_replicate]
+    intro h
+    rcases h with h | h
+    · exact le_of_eq h.2.symm
+    · exact le_trans (Nat.le_succ start) (ih h)
+
+/--
+The generated blocks contain the right number of copies for each key. This is the main counting
+invariant: keys outside `start, ..., start + fuel - 1` occur zero times.
+-/
+@[grind =]
+private theorem buildCountedFrom_count (key start fuel : ℕ) (xs : List ℕ) :
+    (⟪buildCountedFrom start fuel xs⟫).count key =
+      if start ≤ key ∧ key < start + fuel then xs.count key else 0 := by
+  induction fuel generalizing start with
+  | zero => simp [buildCountedFrom]
+  | succ fuel ih =>
+    by_cases hstart : start = key
+    · subst key
+      simp [buildCountedFrom, ih]
+    · simp only [buildCountedFrom, ret_bind, ret_pure, ret_countKey, List.count_append]
+      simp only [ne_eq, hstart, not_false_eq_true, count_replicate_of_ne, ih, Nat.zero_add]
+      by_cases htotal : start ≤ key ∧ key < start + (fuel + 1)
+      · have htail : start + 1 ≤ key ∧ key < start + 1 + fuel := by omega
+        simp [htotal, htail]
+      · have htail : ¬(start + 1 ≤ key ∧ key < start + 1 + fuel) := by omega
+        rw [if_neg htail, if_neg htotal]
+
+/-- In-range keys are counted exactly as in the input. -/
+theorem countingSort_count_of_le_bound {bound key : ℕ} (xs : List ℕ) (hkey : key ≤ bound) :
+    (⟪countingSort bound xs⟫).count key = xs.count key := by
+  rw [countingSort, buildCountedFrom_count]
+  split_ifs with h
+  · rfl
+  · omega
+
+/-- Out-of-range keys never appear in the output. -/
+theorem countingSort_count_of_bound_lt {bound key : ℕ} (xs : List ℕ) (hkey : bound < key) :
+    (⟪countingSort bound xs⟫).count key = 0 := by
+  rw [countingSort, buildCountedFrom_count]
+  split_ifs with h
+  · omega
+  · rfl
+
+/-- If the input is bounded, every out-of-range key has count zero in the input too. -/
+private theorem bounded_count_eq_zero_of_bound_lt {bound key : ℕ} {xs : List ℕ}
+    (hxs : BoundedBy bound xs) (hkey : bound < key) : xs.count key = 0 := by
+  rw [List.count_eq_zero]
+  intro hmem
+  have := hxs key hmem
+  omega
+
+/-- Counting sort is a permutation because every key has the same count in input and output. -/
+theorem countingSort_perm (bound : ℕ) (xs : List ℕ) (hxs : BoundedBy bound xs) :
+    (⟪countingSort bound xs⟫).Perm xs := by
+  rw [List.perm_iff_count]
+  intro key
+  by_cases hkey : key ≤ bound
+  · exact countingSort_count_of_le_bound xs hkey
+  · have hlt : bound < key := Nat.lt_of_not_ge hkey
+    rw [countingSort_count_of_bound_lt xs hlt, bounded_count_eq_zero_of_bound_lt hxs hlt]
+
+/-- Every generated block list is sorted because later blocks only contain larger keys. -/
+private theorem buildCountedFrom_sorted (start fuel : ℕ) (xs : List ℕ) :
+    List.Pairwise (· ≤ ·) ⟪buildCountedFrom start fuel xs⟫ := by
+  induction fuel generalizing start with
+  | zero => simp [buildCountedFrom]
+  | succ fuel ih =>
+    simp only [buildCountedFrom, ret_bind, ret_pure, ret_countKey]
+    rw [List.pairwise_append]
+    refine ⟨by simp [List.pairwise_replicate], ih (start + 1), ?_⟩
+    intro a ha b hb
+    have haEq : a = start := (List.mem_replicate.mp ha).2
+    have hbLower : start + 1 ≤ b := buildCountedFrom_start_le_of_mem hb
+    omega
+
+/-- Counting sort returns a sorted list. -/
+theorem countingSort_sorted (bound : ℕ) (xs : List ℕ) :
+    List.Pairwise (· ≤ ·) ⟪countingSort bound xs⟫ := by
+  exact buildCountedFrom_sorted 0 (bound + 1) xs
+
+/-- Filtering a list by one value gives exactly `count` copies of that value. -/
+private theorem filter_eq_replicate_count (key : ℕ) (xs : List ℕ) :
+    xs.filter (fun x => x = key) = List.replicate (xs.count key) key := by
+  induction xs with
+  | nil => simp
+  | cons x xs ih =>
+    by_cases h : x = key
+    · simp [h, ih, List.replicate_succ]
+    · simp [h, ih]
+
+/--
+Counting sort is stable for natural numbers because every equal-value subsequence is just a block of
+identical copies, and the count theorem proves that block has the same length as in the input.
+-/
+theorem countingSort_stable (bound : ℕ) (xs : List ℕ) (hxs : BoundedBy bound xs) :
+    StableByValue xs ⟪countingSort bound xs⟫ := by
+  intro key
+  rw [filter_eq_replicate_count key ⟪countingSort bound xs⟫, filter_eq_replicate_count key xs]
+  by_cases hkey : key ≤ bound
+  · rw [countingSort_count_of_le_bound xs hkey]
+  · have hlt : bound < key := Nat.lt_of_not_ge hkey
+    rw [countingSort_count_of_bound_lt xs hlt, bounded_count_eq_zero_of_bound_lt hxs hlt]
+
+/-- Counting sort is functionally correct for inputs covered by the supplied bound. -/
+theorem countingSort_correct (bound : ℕ) (xs : List ℕ) (hxs : BoundedBy bound xs) :
+    List.Pairwise (· ≤ ·) ⟪countingSort bound xs⟫ ∧ (⟪countingSort bound xs⟫).Perm xs ∧
+      StableByValue xs ⟪countingSort bound xs⟫ := by
+  exact ⟨countingSort_sorted bound xs, countingSort_perm bound xs hxs,
+    countingSort_stable bound xs hxs⟩
+
+end Correctness
+
+section TimeComplexity
+
+/-- Building counted blocks scans the input once for each generated key. -/
+@[simp]
+private theorem buildCountedFrom_time (start fuel : ℕ) (xs : List ℕ) :
+    (buildCountedFrom start fuel xs).time = fuel * xs.length := by
+  induction fuel generalizing start with
+  | zero => simp [buildCountedFrom]
+  | succ fuel ih => simp [buildCountedFrom, ih, Nat.succ_mul, Nat.add_comm]
+
+/-- Time complexity of counting sort under the stated cost model. -/
+theorem countingSort_time (bound : ℕ) (xs : List ℕ) :
+    (countingSort bound xs).time = (bound + 1) * xs.length := by
+  simp [countingSort]
+
+/-- A convenient upper bound form of `countingSort_time`. -/
+theorem countingSort_time_le (bound : ℕ) (xs : List ℕ) :
+    let n := xs.length
+    (countingSort bound xs).time ≤ (bound + 1) * n := by
+  simp [countingSort_time]
+
+end TimeComplexity
+
+end Cslib.Algorithms.Lean.TimeM

--- a/Cslib/Algorithms/Lean/CountingSort/CountingSort.lean
+++ b/Cslib/Algorithms/Lean/CountingSort/CountingSort.lean
@@ -8,9 +8,11 @@ module
 
 public import Cslib.Algorithms.Lean.Sorting
 public import Cslib.Algorithms.Lean.TimeM
-public import Mathlib.Data.List.Count
-public import Mathlib.Data.List.Sort
 public import Mathlib.Data.Nat.Basic
+public import Mathlib.Order.RelClasses
+public import Mathlib.Tactic.Attr.Core
+public import Mathlib.Tactic.Finiteness.Attr
+public import Batteries.Data.List.Lemmas
 
 /-!
 # Counting sort on natural-number lists

--- a/Cslib/Algorithms/Lean/InsertionSort/InsertionSort.lean
+++ b/Cslib/Algorithms/Lean/InsertionSort/InsertionSort.lean
@@ -1,0 +1,159 @@
+/-
+Copyright (c) 2026 Robert Joseph George. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Robert Joseph George
+-/
+
+module
+
+public import Cslib.Algorithms.Lean.Sorting
+public import Cslib.Algorithms.Lean.TimeM
+public import Mathlib.Data.List.Sort
+public import Mathlib.Data.Nat.Basic
+
+/-!
+# Stable insertion sort on lists
+
+`insertionSort` returns a `TimeM ℕ (List α)`: the return value is the sorted list, and the time
+component counts comparisons.
+
+Equal values are inserted before equal values already in the sorted tail. Since the sort processes
+the input from right to left, this preserves the original order of equal values.
+
+The cost model charges exactly one tick for each comparison made while searching for the insertion
+point.
+-/
+
+@[expose] public section
+
+set_option autoImplicit false
+
+namespace Cslib.Algorithms.Lean.TimeM
+
+variable {α : Type} [LinearOrder α]
+
+/--
+Inserts one value into a sorted list, counting comparisons as time cost. The test is `x ≤ y`, so
+the new value is placed before equal values in the already-sorted tail.
+-/
+def insert (x : α) : List α → TimeM ℕ (List α)
+  | [] => return [x]
+  | y :: ys => do
+    ✓ let inFront := x ≤ y
+    if inFront then
+      return x :: y :: ys
+    else
+      let rest ← insert x ys
+      return y :: rest
+
+/-- Sorts a list using stable insertion sort, counting comparisons as time cost. -/
+def insertionSort : List α → TimeM ℕ (List α)
+  | [] => return []
+  | x :: xs => do
+    let sortedTail ← insertionSort xs
+    insert x sortedTail
+
+section Correctness
+
+/-- Timed `insert` computes mathlib's ordered insertion. -/
+@[simp, grind =]
+theorem ret_insert (x : α) (xs : List α) :
+    ⟪insert x xs⟫ = xs.orderedInsert (· ≤ ·) x := by
+  induction xs with
+  | nil => simp [insert]
+  | cons y ys ih =>
+    by_cases h : x ≤ y <;> simp [insert, h, ih]
+
+/-- Timed insertion sort computes mathlib's insertion sort. -/
+@[simp, grind =]
+theorem ret_insertionSort (xs : List α) :
+    ⟪insertionSort xs⟫ = xs.insertionSort (· ≤ ·) := by
+  induction xs with
+  | nil => simp [insertionSort]
+  | cons x xs ih => simp [insertionSort, ih]
+
+/-- Inserting one value keeps exactly the original values. -/
+@[simp]
+private theorem insert_perm (x : α) (xs : List α) : (⟪insert x xs⟫).Perm (x :: xs) := by
+  simpa using List.perm_orderedInsert (· ≤ ·) x xs
+
+/-- Insertion sort returns a permutation of its input. -/
+theorem insertionSort_perm (xs : List α) : (⟪insertionSort xs⟫).Perm xs := by
+  simpa using List.perm_insertionSort (· ≤ ·) xs
+
+/-- Inserting one value is stable with respect to filtering by any fixed value. -/
+@[simp]
+private theorem insert_stable (x : α) (xs : List α) : StableByValue (x :: xs) ⟪insert x xs⟫ := by
+  induction xs with
+  | nil => simp [StableByValue, insert]
+  | cons y ys ih =>
+    intro z
+    by_cases h : x ≤ y
+    · simp [insert, h]
+    · have ihz := ih z
+      by_cases hyz : y = z <;> by_cases hxz : x = z <;> grind [insert]
+
+/--
+Insertion sort is stable. The induction uses stability of the recursive tail and then stability of
+one insertion step.
+-/
+theorem insertionSort_stable (xs : List α) : StableByValue xs ⟪insertionSort xs⟫ := by
+  induction xs with
+  | nil => simp [StableByValue, insertionSort]
+  | cons x xs ih =>
+    intro z
+    simp only [insertionSort, ret_bind]
+    rw [insert_stable x ⟪insertionSort xs⟫ z]
+    simp only [List.filter_cons]
+    rw [ih z]
+
+/-- Insertion sort returns a sorted list. -/
+theorem insertionSort_sorted (xs : List α) : List.Pairwise (· ≤ ·) ⟪insertionSort xs⟫ := by
+  simpa using List.pairwise_insertionSort (· ≤ ·) xs
+
+/-- Insertion sort is functionally correct. -/
+theorem insertionSort_correct (xs : List α) : List.Pairwise (· ≤ ·) ⟪insertionSort xs⟫ ∧
+    (⟪insertionSort xs⟫).Perm xs ∧ StableByValue xs ⟪insertionSort xs⟫ := by
+  exact ⟨insertionSort_sorted xs, insertionSort_perm xs, insertionSort_stable xs⟩
+
+end Correctness
+
+section TimeComplexity
+
+/-- Inserting into a list performs at most one comparison per possible insertion point. -/
+private theorem insert_time_le (x : α) (xs : List α) : (insert x xs).time ≤ xs.length + 1 := by
+  induction xs with
+  | nil => simp [insert]
+  | cons y ys ih =>
+    by_cases h : x ≤ y
+    · simp [insert, h]
+    · simp [insert, h]
+      omega
+
+/-- Insertion sort preserves length. -/
+@[simp]
+private theorem insertionSort_length (xs : List α) : ⟪insertionSort xs⟫.length = xs.length := by
+  simp
+
+/-- Time complexity of insertion sort. -/
+theorem insertionSort_time (xs : List α) :
+    let n := xs.length
+    (insertionSort xs).time ≤ n * n := by
+  induction xs with
+  | nil => simp [insertionSort]
+  | cons x xs ih =>
+    simp only [List.length_cons]
+    simp only [insertionSort, time_bind]
+    have hinsert := insert_time_le x ⟪insertionSort xs⟫
+    have hlen : ⟪insertionSort xs⟫.length = xs.length := by simp
+    have hsquare : xs.length * xs.length + (xs.length + 1) ≤
+        (xs.length + 1) * (xs.length + 1) := by
+      exact Nat.le_trans
+        (Nat.add_le_add_right
+          (Nat.mul_le_mul_right xs.length (Nat.le_succ xs.length)) (xs.length + 1))
+        (by rw [Nat.mul_succ])
+    omega
+
+end TimeComplexity
+
+end Cslib.Algorithms.Lean.TimeM

--- a/Cslib/Algorithms/Lean/InsertionSort/InsertionSort.lean
+++ b/Cslib/Algorithms/Lean/InsertionSort/InsertionSort.lean
@@ -73,7 +73,6 @@ theorem ret_insertionSort (xs : List α) :
   | cons x xs ih => simp [insertionSort, ih]
 
 /-- Inserting one value keeps exactly the original values. -/
-@[simp]
 private theorem insert_perm (x : α) (xs : List α) : (⟪insert x xs⟫).Perm (x :: xs) := by
   simpa using List.perm_orderedInsert (· ≤ ·) x xs
 
@@ -82,7 +81,6 @@ theorem insertionSort_perm (xs : List α) : (⟪insertionSort xs⟫).Perm xs := 
   simpa using List.perm_insertionSort (· ≤ ·) xs
 
 /-- Inserting one value is stable with respect to filtering by any fixed value. -/
-@[simp]
 private theorem insert_stable (x : α) (xs : List α) : StableByValue (x :: xs) ⟪insert x xs⟫ := by
   induction xs with
   | nil => simp [StableByValue, insert]
@@ -131,7 +129,6 @@ private theorem insert_time_le (x : α) (xs : List α) : (insert x xs).time ≤ 
       omega
 
 /-- Insertion sort preserves length. -/
-@[simp]
 private theorem insertionSort_length (xs : List α) : ⟪insertionSort xs⟫.length = xs.length := by
   simp
 

--- a/Cslib/Algorithms/Lean/QuickSort/QuickSort.lean
+++ b/Cslib/Algorithms/Lean/QuickSort/QuickSort.lean
@@ -180,7 +180,6 @@ private theorem randomizedQuickSortFuel_support_cons {fuel : ℕ} {x : α} {xs :
 section Correctness
 
 /-- Every low-bucket element is below the pivot. -/
-@[simp]
 theorem lt_pivot_of_mem_partition3_left (pivot : α) (xs : List α) :
     ∀ z ∈ (partition3 pivot xs).ret.1, z < pivot := by
   induction xs with
@@ -193,7 +192,6 @@ theorem lt_pivot_of_mem_partition3_left (pivot : α) (xs : List α) :
       <;> grind
 
 /-- Every middle-bucket element is equal to the pivot. -/
-@[simp]
 theorem eq_pivot_of_mem_partition3_middle (pivot : α) (xs : List α) :
     ∀ z ∈ (partition3 pivot xs).ret.2.1, z = pivot := by
   induction xs with
@@ -206,7 +204,6 @@ theorem eq_pivot_of_mem_partition3_middle (pivot : α) (xs : List α) :
       <;> grind
 
 /-- Every high-bucket element is above the pivot. -/
-@[simp]
 theorem pivot_lt_of_mem_partition3_right (pivot : α) (xs : List α) :
     ∀ z ∈ (partition3 pivot xs).ret.2.2, pivot < z := by
   induction xs with
@@ -219,7 +216,6 @@ theorem pivot_lt_of_mem_partition3_right (pivot : α) (xs : List α) :
       <;> grind
 
 /-- Partitioning only rearranges elements into the three buckets. -/
-@[simp]
 theorem partition3_perm (pivot : α) (xs : List α) :
     ((partition3 pivot xs).ret.1 ++ (partition3 pivot xs).ret.2.1 ++
         (partition3 pivot xs).ret.2.2).Perm xs := by

--- a/Cslib/Algorithms/Lean/QuickSort/QuickSort.lean
+++ b/Cslib/Algorithms/Lean/QuickSort/QuickSort.lean
@@ -9,6 +9,7 @@ module
 public import Cslib.Algorithms.Lean.RandomTimeM
 public import Mathlib.Data.List.Sort
 public import Mathlib.Data.Nat.Basic
+public import Mathlib.NumberTheory.Harmonic.Bounds
 public import Mathlib.Probability.Distributions.Uniform
 public import Mathlib.Tactic.Linarith
 
@@ -20,8 +21,9 @@ items into elements below, equal to, and above the pivot. The equal bucket is no
 sorted, which is the usual duplicate-safe randomized quicksort.
 
 The cost model counts the two order tests used by the three-way partition. The theorems prove a
-quadratic worst-case bound for every random run and the corresponding bound on
-`RandomTimeM.expectedTime`.
+quadratic worst-case bound for every random run, the corresponding bound on
+`RandomTimeM.expectedTime`, and the standard harmonic estimate for the rank recurrence used in the
+all-distinct average-case analysis.
 -/
 
 @[expose] public section
@@ -397,6 +399,25 @@ end Correctness
 
 section TimeComplexity
 
+/--
+One nonempty quicksort step as an expected-time recurrence. The outer sum averages over the sampled
+pivot index; each branch pays the partition cost plus the expected costs of the two recursive calls.
+-/
+theorem randomizedQuickSortFuel_expectedTimeENNReal_cons (fuel : ℕ) (x : α) (xs : List α) :
+    RandomTimeM.expectedTimeENNReal (randomizedQuickSortFuel (fuel + 1) (x :: xs)) =
+      ∑' pivotIndex : Fin (x :: xs).length,
+        randomPivotIndex (x :: xs) (by simp) pivotIndex *
+          (let pivot := (x :: xs)[pivotIndex]
+           let rest := (x :: xs).eraseIdx pivotIndex
+           let parts := partition3 pivot rest
+           ((parts.time : ENNReal) +
+             RandomTimeM.expectedTimeENNReal (randomizedQuickSortFuel fuel parts.ret.1) +
+             RandomTimeM.expectedTimeENNReal (randomizedQuickSortFuel fuel parts.ret.2.2))) := by
+  rw [randomizedQuickSortFuel, RandomTimeM.expectedTimeENNReal_bind]
+  apply tsum_congr
+  intro pivotIndex
+  rw [RandomTimeM.expectedTimeENNReal_bind_pure_add_pair]
+
 /-- Every possible randomized quicksort run obeys a quadratic worst-case comparison bound. -/
 theorem randomizedQuickSortFuel_time (fuel : ℕ) (xs : List α) (hfuel : xs.length ≤ fuel) :
     ∀ result ∈ (randomizedQuickSortFuel fuel xs).support,
@@ -454,11 +475,32 @@ theorem randomizedQuickSort_time (xs : List α) :
 
 /--
 Expected-time bound for the actual PMF semantics of `randomizedQuickSort`. This follows from the
-pointwise worst-case theorem, so it is quadratic rather than the sharper average-case recurrence.
+pointwise worst-case theorem.
 -/
 theorem randomizedQuickSort_expectedTime_le_quadratic (xs : List α) :
     RandomTimeM.expectedTime (randomizedQuickSort xs) ≤ (2 * xs.length * xs.length : ℕ) := by
   exact RandomTimeM.expectedTime_le_of_time_le_on_support (randomizedQuickSort_time xs)
+
+/-- The same worst-case expected-time bound, stated for the `ENNReal` expectation algebra. -/
+theorem randomizedQuickSort_expectedTimeENNReal_le_quadratic (xs : List α) :
+    RandomTimeM.expectedTimeENNReal (randomizedQuickSort xs) ≤ (2 * xs.length * xs.length : ℕ) := by
+  exact RandomTimeM.expectedTimeENNReal_le_of_time_le_on_support (randomizedQuickSort_time xs)
+
+/--
+Closed form for the all-distinct rank recurrence. A subproblem of size `n + 1` pays `2 * n` tests
+to partition, then chooses each pivot rank uniformly; solving that recurrence gives this expression.
+-/
+noncomputable def quickSortRankExpectedTests (n : ℕ) : ℝ :=
+  4 * (n + 1 : ℝ) * (harmonic n : ℝ) - 8 * n
+
+/-- The harmonic closed form is `O(n log n)` with an explicit constant. -/
+theorem quickSortRankExpectedTests_le_log (n : ℕ) :
+    quickSortRankExpectedTests n ≤ 4 * (n + 1 : ℝ) * (1 + Real.log n) := by
+  have hharmonic := harmonic_le_one_add_log n
+  have hcoef : 0 ≤ 4 * (n + 1 : ℝ) := by positivity
+  have hscaled := mul_le_mul_of_nonneg_left hharmonic hcoef
+  unfold quickSortRankExpectedTests
+  nlinarith
 
 end TimeComplexity
 

--- a/Cslib/Algorithms/Lean/QuickSort/QuickSort.lean
+++ b/Cslib/Algorithms/Lean/QuickSort/QuickSort.lean
@@ -1,0 +1,465 @@
+/-
+Copyright (c) 2026 Robert Joseph George. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Robert Joseph George
+-/
+
+module
+
+public import Cslib.Algorithms.Lean.RandomTimeM
+public import Mathlib.Data.List.Sort
+public import Mathlib.Data.Nat.Basic
+public import Mathlib.Probability.Distributions.Uniform
+public import Mathlib.Tactic.Linarith
+
+/-!
+# Randomized quicksort on lists
+
+The algorithm samples a pivot index uniformly, removes that occurrence, and partitions the remaining
+items into elements below, equal to, and above the pivot. The equal bucket is not recursively
+sorted, which is the usual duplicate-safe randomized quicksort.
+
+The cost model counts the two order tests used by the three-way partition. The theorems prove a
+quadratic worst-case bound for every random run and the corresponding bound on
+`RandomTimeM.expectedTime`.
+-/
+
+@[expose] public section
+
+set_option autoImplicit false
+
+namespace Cslib.Algorithms.Lean.TimeM
+
+variable {α : Type}
+
+/-- Chooses an index uniformly from a nonempty list. -/
+noncomputable def randomPivotIndex (xs : List α) (hxs : 0 < xs.length) : PMF (Fin xs.length) := by
+  letI : Nonempty (Fin xs.length) := ⟨⟨0, hxs⟩⟩
+  exact PMF.uniformOfFintype (Fin xs.length)
+
+/-- Removing a valid pivot occurrence strictly shortens the list. -/
+private theorem eraseIdx_length_lt (xs : List α) (i : Fin xs.length) :
+    (xs.eraseIdx i).length < xs.length := by
+  have h : (xs.eraseIdx i).length + 1 = xs.length := by
+    simpa using List.length_eraseIdx_add_one (l := xs) (i := (i : ℕ)) i.isLt
+  omega
+
+variable [LinearOrder α]
+
+/--
+Three-way partition around a pivot. It costs two comparisons per scanned element: one test for
+`x < pivot`, and if needed one test for `pivot < x`.
+-/
+def partition3 (pivot : α) : List α → TimeM ℕ (List α × List α × List α)
+  | [] => return ([], [], [])
+  | x :: xs => do
+    ✓ let less := x < pivot
+    ✓ let greater := pivot < x
+    let rest ← partition3 pivot xs
+    if less then
+      return (x :: rest.1, rest.2.1, rest.2.2)
+    else if greater then
+      return (rest.1, rest.2.1, x :: rest.2.2)
+    else
+      return (rest.1, x :: rest.2.1, rest.2.2)
+
+/-- The three buckets contain exactly the scanned elements. -/
+@[simp, grind =]
+theorem partition3_length_sum (pivot : α) (xs : List α) :
+    (partition3 pivot xs).ret.1.length + (partition3 pivot xs).ret.2.1.length +
+        (partition3 pivot xs).ret.2.2.length = xs.length := by
+  induction xs with
+  | nil => simp [partition3]
+  | cons x xs ih =>
+    by_cases hlt : x < pivot
+      <;> by_cases hgt : pivot < x
+      <;> simp [partition3, hlt, hgt, ih, Nat.add_assoc, Nat.add_comm, Nat.add_left_comm]
+
+/-- The low bucket is no longer than the input. -/
+theorem partition3_length_left_le (pivot : α) (xs : List α) :
+    (partition3 pivot xs).ret.1.length ≤ xs.length := by
+  have h := partition3_length_sum pivot xs
+  omega
+
+/-- The high bucket is no longer than the input. -/
+theorem partition3_length_right_le (pivot : α) (xs : List α) :
+    (partition3 pivot xs).ret.2.2.length ≤ xs.length := by
+  have h := partition3_length_sum pivot xs
+  omega
+
+/-- After removing a pivot, both recursive buckets fit in one less unit of fuel. -/
+private theorem partition3_fuel_bounds {fuel : ℕ} {full : List α} (pivot : α)
+    (pivotIndex : Fin full.length) (hfuel : full.length ≤ fuel + 1) :
+    (partition3 pivot (full.eraseIdx pivotIndex)).ret.1.length ≤ fuel ∧
+      (partition3 pivot (full.eraseIdx pivotIndex)).ret.2.2.length ≤ fuel := by
+  have hrest : (full.eraseIdx pivotIndex).length < full.length :=
+    eraseIdx_length_lt full pivotIndex
+  constructor
+  · have hleft := partition3_length_left_le pivot (full.eraseIdx pivotIndex)
+    omega
+  · have hright := partition3_length_right_le pivot (full.eraseIdx pivotIndex)
+    omega
+
+/-- A three-way partition performs two order tests for each scanned element. -/
+@[simp, grind =]
+theorem partition3_time (pivot : α) (xs : List α) :
+    (partition3 pivot xs).time = 2 * xs.length := by
+  induction xs with
+  | nil => simp [partition3]
+  | cons x xs ih =>
+    by_cases hlt : x < pivot
+      <;> by_cases hgt : pivot < x
+      <;> simp [partition3, hlt, hgt, ih, Nat.mul_succ]
+      <;> omega
+
+/-- Randomized quicksort with explicit recursion fuel. -/
+noncomputable def randomizedQuickSortFuel : ℕ → List α → RandomTimeM ℕ (List α)
+  | 0, xs => PMF.pure ⟨xs, 0⟩
+  | _ + 1, [] => PMF.pure (return [])
+  | fuel + 1, x :: xs =>
+    let full := x :: xs
+    have hxs : 0 < full.length := by simp [full]
+    (randomPivotIndex full hxs).bind fun pivotIndex =>
+      let pivot := full[pivotIndex]
+      let rest := full.eraseIdx pivotIndex
+      let parts := partition3 pivot rest
+      (randomizedQuickSortFuel fuel parts.ret.1).bind fun sortedLeft =>
+        (randomizedQuickSortFuel fuel parts.ret.2.2).bind fun sortedRight =>
+          PMF.pure ⟨(sortedLeft.ret ++ (pivot :: parts.ret.2.1)) ++ sortedRight.ret,
+            parts.time + sortedLeft.time + sortedRight.time⟩
+
+/-- Sorts a list with duplicate-safe randomized quicksort. -/
+noncomputable def randomizedQuickSort (xs : List α) : RandomTimeM ℕ (List α) :=
+  randomizedQuickSortFuel xs.length xs
+
+/--
+The zero-fuel branch returns the input unchanged. This small support eliminator keeps the recursive
+correctness proofs from repeating `PMF.pure` bookkeeping.
+-/
+private theorem randomizedQuickSortFuel_support_zero {xs : List α} {result : TimeM ℕ (List α)}
+    (hresult : result ∈ (randomizedQuickSortFuel 0 xs).support) :
+    result = ⟨xs, 0⟩ := by
+  simpa [randomizedQuickSortFuel] using hresult
+
+/--
+Sorting the empty list has only one possible timed result, regardless of the remaining fuel.
+-/
+private theorem randomizedQuickSortFuel_support_nil {fuel : ℕ} {result : TimeM ℕ (List α)}
+    (hresult : result ∈ (randomizedQuickSortFuel fuel ([] : List α)).support) :
+    result = ⟨[], 0⟩ := by
+  cases fuel with
+  | zero => exact randomizedQuickSortFuel_support_zero hresult
+  | succ fuel => simpa [randomizedQuickSortFuel] using hresult
+
+/--
+Unpacks one nonempty randomized quicksort step. Every support point comes from a sampled pivot
+index, a possible left-recursive run, and a possible right-recursive run.
+-/
+private theorem randomizedQuickSortFuel_support_cons {fuel : ℕ} {x : α} {xs : List α}
+    {result : TimeM ℕ (List α)}
+    (hresult : result ∈ (randomizedQuickSortFuel (fuel + 1) (x :: xs)).support) :
+    ∃ pivotIndex : Fin (x :: xs).length,
+      ∃ sortedLeft ∈
+        (randomizedQuickSortFuel fuel
+          (partition3 (x :: xs)[pivotIndex] ((x :: xs).eraseIdx pivotIndex)).ret.1).support,
+      ∃ sortedRight ∈
+        (randomizedQuickSortFuel fuel
+          (partition3 (x :: xs)[pivotIndex] ((x :: xs).eraseIdx pivotIndex)).ret.2.2).support,
+        result = ⟨(sortedLeft.ret ++ ((x :: xs)[pivotIndex] ::
+            (partition3 (x :: xs)[pivotIndex] ((x :: xs).eraseIdx pivotIndex)).ret.2.1)) ++
+            sortedRight.ret,
+          (partition3 (x :: xs)[pivotIndex] ((x :: xs).eraseIdx pivotIndex)).time +
+            sortedLeft.time + sortedRight.time⟩ := by
+  simp only [randomizedQuickSortFuel, PMF.mem_support_bind_iff] at hresult
+  rcases hresult with ⟨pivotIndex, _, sortedLeft, hleft, sortedRight, hright, hresult⟩
+  rw [PMF.mem_support_pure_iff] at hresult
+  exact ⟨pivotIndex, sortedLeft, hleft, sortedRight, hright, hresult⟩
+
+section Correctness
+
+/-- Every low-bucket element is below the pivot. -/
+@[simp]
+theorem lt_pivot_of_mem_partition3_left (pivot : α) (xs : List α) :
+    ∀ z ∈ (partition3 pivot xs).ret.1, z < pivot := by
+  induction xs with
+  | nil => simp [partition3]
+  | cons x xs ih =>
+    intro z hz
+    by_cases hlt : x < pivot
+      <;> by_cases hgt : pivot < x
+      <;> simp only [partition3, hlt, hgt, ↓reduceIte, ret_bind, ret_pure, List.mem_cons] at hz
+      <;> grind
+
+/-- Every middle-bucket element is equal to the pivot. -/
+@[simp]
+theorem eq_pivot_of_mem_partition3_middle (pivot : α) (xs : List α) :
+    ∀ z ∈ (partition3 pivot xs).ret.2.1, z = pivot := by
+  induction xs with
+  | nil => simp [partition3]
+  | cons x xs ih =>
+    intro z hz
+    by_cases hlt : x < pivot
+      <;> by_cases hgt : pivot < x
+      <;> simp only [partition3, hlt, hgt, ↓reduceIte, ret_bind, ret_pure, List.mem_cons] at hz
+      <;> grind
+
+/-- Every high-bucket element is above the pivot. -/
+@[simp]
+theorem pivot_lt_of_mem_partition3_right (pivot : α) (xs : List α) :
+    ∀ z ∈ (partition3 pivot xs).ret.2.2, pivot < z := by
+  induction xs with
+  | nil => simp [partition3]
+  | cons x xs ih =>
+    intro z hz
+    by_cases hlt : x < pivot
+      <;> by_cases hgt : pivot < x
+      <;> simp only [partition3, hlt, hgt, ↓reduceIte, ret_bind, ret_pure, List.mem_cons] at hz
+      <;> grind
+
+/-- Partitioning only rearranges elements into the three buckets. -/
+@[simp]
+theorem partition3_perm (pivot : α) (xs : List α) :
+    ((partition3 pivot xs).ret.1 ++ (partition3 pivot xs).ret.2.1 ++
+        (partition3 pivot xs).ret.2.2).Perm xs := by
+  induction xs with
+  | nil => simp [partition3]
+  | cons x xs ih =>
+    by_cases hlt : x < pivot
+    · simpa only [partition3, hlt, ↓reduceIte, ret_bind, ret_pure, List.cons_append] using
+        List.Perm.cons x ih
+    · by_cases hgt : pivot < x
+      · simp only [partition3, hlt, hgt, ↓reduceIte, ret_bind, ret_pure]
+        exact (List.perm_middle (a := x)
+          (l₁ := (partition3 pivot xs).ret.1 ++ (partition3 pivot xs).ret.2.1)
+          (l₂ := (partition3 pivot xs).ret.2.2)).trans (List.Perm.cons x ih)
+      · simp only [partition3, hlt, hgt, ↓reduceIte, ret_bind, ret_pure, List.append_assoc]
+        simpa [List.append_assoc] using
+          (((List.perm_middle (a := x) (l₁ := (partition3 pivot xs).ret.1)
+            (l₂ := (partition3 pivot xs).ret.2.1)).append_right
+            (partition3 pivot xs).ret.2.2).trans (List.Perm.cons x ih))
+
+/--
+If the recursive calls return permutations of the low and high buckets, adding back the pivot and
+middle bucket gives a permutation of `pivot :: rest`.
+-/
+private theorem partition3_recombine_perm (pivot : α) (rest sortedLeft sortedRight : List α)
+    (hleft : sortedLeft.Perm (partition3 pivot rest).ret.1)
+    (hright : sortedRight.Perm (partition3 pivot rest).ret.2.2) :
+    ((sortedLeft ++ (pivot :: (partition3 pivot rest).ret.2.1)) ++ sortedRight).Perm
+      (pivot :: rest) := by
+  let parts := partition3 pivot rest
+  have hparts : (parts.ret.1 ++ parts.ret.2.1 ++ parts.ret.2.2).Perm rest := by
+    simpa [parts] using partition3_perm pivot rest
+  have hrecursive :
+      ((sortedLeft ++ (pivot :: parts.ret.2.1)) ++ sortedRight).Perm
+        ((parts.ret.1 ++ (pivot :: parts.ret.2.1)) ++ parts.ret.2.2) :=
+    List.Perm.append (List.Perm.append hleft (List.Perm.refl _)) hright
+  have hpivot :
+      ((parts.ret.1 ++ (pivot :: parts.ret.2.1)) ++ parts.ret.2.2).Perm
+        (pivot :: (parts.ret.1 ++ parts.ret.2.1 ++ parts.ret.2.2)) := by
+    exact ((List.perm_middle (a := pivot) (l₁ := parts.ret.1)
+      (l₂ := parts.ret.2.1)).append_right parts.ret.2.2)
+  exact hrecursive.trans (hpivot.trans (List.Perm.cons pivot hparts))
+
+/-- A list whose elements are all the same pivot is sorted. -/
+private theorem pairwise_le_of_eq_pivot (pivot : α) (xs : List α) (hxs : ∀ z ∈ xs, z = pivot) :
+    List.Pairwise (· ≤ ·) xs := by
+  induction xs with
+  | nil => simp
+  | cons x xs ih =>
+    refine List.Pairwise.cons ?_ (ih fun z hz => hxs z (List.mem_cons_of_mem _ hz))
+    intro y hy
+    rw [hxs x (by simp), hxs y (List.mem_cons_of_mem _ hy)]
+
+/-- The pivot plus the middle bucket consists only of pivot-equal values. -/
+private theorem eq_pivot_of_mem_pivot_middle (pivot : α) (xs : List α) :
+    ∀ z ∈ pivot :: (partition3 pivot xs).ret.2.1, z = pivot := by
+  intro z hz
+  rcases List.mem_cons.mp hz with rfl | hz
+  · rfl
+  · exact eq_pivot_of_mem_partition3_middle pivot xs z hz
+
+/-- The pivot plus the middle bucket is sorted because all its values are equal. -/
+private theorem pairwise_pivot_middle (pivot : α) (xs : List α) :
+    List.Pairwise (· ≤ ·) (pivot :: (partition3 pivot xs).ret.2.1) := by
+  exact pairwise_le_of_eq_pivot pivot (pivot :: (partition3 pivot xs).ret.2.1)
+    (eq_pivot_of_mem_pivot_middle pivot xs)
+
+/--
+Combines the three sorted quicksort blocks. The low block is below the pivot, the middle block is
+all pivot-equal values, and the high block is above the pivot.
+-/
+private theorem pairwise_three_way_append {pivot : α} {left middle right : List α}
+    (hleftSorted : List.Pairwise (· ≤ ·) left)
+    (hmiddleSorted : List.Pairwise (· ≤ ·) (pivot :: middle))
+    (hrightSorted : List.Pairwise (· ≤ ·) right)
+    (hleft : ∀ z ∈ left, z < pivot)
+    (hmiddle : ∀ z ∈ pivot :: middle, z = pivot)
+    (hright : ∀ z ∈ right, pivot < z) :
+    List.Pairwise (· ≤ ·) ((left ++ (pivot :: middle)) ++ right) := by
+  rw [List.pairwise_append]
+  refine ⟨?_, hrightSorted, ?_⟩
+  · rw [List.pairwise_append]
+    refine ⟨hleftSorted, hmiddleSorted, ?_⟩
+    intro low hlow mid hmid
+    rw [hmiddle mid hmid]
+    exact le_of_lt (hleft low hlow)
+  · intro lowOrMid hblock high hhigh
+    rcases List.mem_append.mp hblock with hlow | hmid
+    · exact le_trans (le_of_lt (hleft lowOrMid hlow)) (le_of_lt (hright high hhigh))
+    · rw [hmiddle lowOrMid hmid]
+      exact le_of_lt (hright high hhigh)
+
+/-- Every possible randomized quicksort output is a permutation of its input. -/
+theorem randomizedQuickSortFuel_perm (fuel : ℕ) (xs : List α) :
+    ∀ result ∈ (randomizedQuickSortFuel fuel xs).support, result.ret.Perm xs := by
+  induction fuel generalizing xs with
+  | zero =>
+    intro result hresult
+    simp [randomizedQuickSortFuel_support_zero hresult]
+  | succ fuel ih =>
+    intro result hresult
+    cases xs with
+    | nil =>
+      simp [randomizedQuickSortFuel_support_nil hresult]
+    | cons x xs =>
+      rcases randomizedQuickSortFuel_support_cons hresult with
+        ⟨pivotIndex, sortedLeft, hleft, sortedRight, hright, rfl⟩
+      let full := x :: xs
+      let pivot := full[pivotIndex]
+      let rest := full.eraseIdx pivotIndex
+      let parts := partition3 pivot rest
+      have hpermLeft := ih parts.ret.1 sortedLeft hleft
+      have hpermRight := ih parts.ret.2.2 sortedRight hright
+      have hsplit : (pivot :: rest).Perm full := by
+        simpa [pivot, rest] using
+          (List.getElem_cons_eraseIdx_perm (l := full) (n := (pivotIndex : ℕ)) pivotIndex.isLt)
+      change ((sortedLeft.ret ++ (pivot :: parts.ret.2.1)) ++ sortedRight.ret).Perm full
+      have hrecombined :
+          ((sortedLeft.ret ++ (pivot :: parts.ret.2.1)) ++ sortedRight.ret).Perm
+            (pivot :: rest) := by
+        simpa [parts] using
+          partition3_recombine_perm pivot rest sortedLeft.ret sortedRight.ret hpermLeft
+            hpermRight
+      exact hrecombined.trans hsplit
+
+/-- Every possible randomized quicksort output is sorted when the fuel covers the input length. -/
+theorem randomizedQuickSortFuel_sorted (fuel : ℕ) (xs : List α) (hfuel : xs.length ≤ fuel) :
+    ∀ result ∈ (randomizedQuickSortFuel fuel xs).support, List.Pairwise (· ≤ ·) result.ret := by
+  induction fuel generalizing xs with
+  | zero =>
+    intro result hresult
+    cases xs with
+    | nil =>
+      simp [randomizedQuickSortFuel_support_zero hresult]
+    | cons x xs => simp at hfuel
+  | succ fuel ih =>
+    intro result hresult
+    cases xs with
+    | nil =>
+      simp [randomizedQuickSortFuel_support_nil hresult]
+    | cons x xs =>
+      rcases randomizedQuickSortFuel_support_cons hresult with
+        ⟨pivotIndex, sortedLeft, hleft, sortedRight, hright, rfl⟩
+      let full := x :: xs
+      let pivot := full[pivotIndex]
+      let rest := full.eraseIdx pivotIndex
+      let parts := partition3 pivot rest
+      change full.length ≤ fuel + 1 at hfuel
+      have ⟨hleftFuel, hrightFuel⟩ :
+          parts.ret.1.length ≤ fuel ∧ parts.ret.2.2.length ≤ fuel := by
+        simpa [parts, rest] using partition3_fuel_bounds pivot pivotIndex hfuel
+      have hleftSorted := ih parts.ret.1 hleftFuel sortedLeft hleft
+      have hrightSorted := ih parts.ret.2.2 hrightFuel sortedRight hright
+      have hpermLeft := randomizedQuickSortFuel_perm fuel parts.ret.1 sortedLeft hleft
+      have hpermRight := randomizedQuickSortFuel_perm fuel parts.ret.2.2 sortedRight hright
+      have hmiddle : ∀ z ∈ pivot :: parts.ret.2.1, z = pivot := by
+        simpa [parts] using eq_pivot_of_mem_pivot_middle pivot rest
+      have hmidSorted : List.Pairwise (· ≤ ·) (pivot :: parts.ret.2.1) := by
+        simpa [parts] using pairwise_pivot_middle pivot rest
+      have hleftAll : ∀ z ∈ sortedLeft.ret, z < pivot :=
+        fun z hz => lt_pivot_of_mem_partition3_left pivot rest z (hpermLeft.mem_iff.mp hz)
+      have hrightAll : ∀ z ∈ sortedRight.ret, pivot < z :=
+        fun z hz => pivot_lt_of_mem_partition3_right pivot rest z (hpermRight.mem_iff.mp hz)
+      change List.Pairwise (· ≤ ·) ((sortedLeft.ret ++ (pivot :: parts.ret.2.1)) ++
+        sortedRight.ret)
+      exact pairwise_three_way_append hleftSorted hmidSorted hrightSorted hleftAll hmiddle hrightAll
+
+/-- Randomized quicksort is functionally correct for every possible run. -/
+theorem randomizedQuickSort_correct (xs : List α) :
+    ∀ result ∈ (randomizedQuickSort xs).support,
+      List.Pairwise (· ≤ ·) result.ret ∧ result.ret.Perm xs := by
+  intro result hresult
+  exact ⟨randomizedQuickSortFuel_sorted xs.length xs le_rfl result hresult,
+    randomizedQuickSortFuel_perm xs.length xs result hresult⟩
+
+end Correctness
+
+section TimeComplexity
+
+/-- Every possible randomized quicksort run obeys a quadratic worst-case comparison bound. -/
+theorem randomizedQuickSortFuel_time (fuel : ℕ) (xs : List α) (hfuel : xs.length ≤ fuel) :
+    ∀ result ∈ (randomizedQuickSortFuel fuel xs).support,
+      result.time ≤ 2 * xs.length * xs.length := by
+  induction fuel generalizing xs with
+  | zero =>
+    intro result hresult
+    cases xs with
+    | nil =>
+      simp [randomizedQuickSortFuel_support_zero hresult]
+    | cons x xs => simp at hfuel
+  | succ fuel ih =>
+    intro result hresult
+    cases xs with
+    | nil =>
+      simp [randomizedQuickSortFuel_support_nil hresult]
+    | cons x xs =>
+      rcases randomizedQuickSortFuel_support_cons hresult with
+        ⟨pivotIndex, sortedLeft, hleft, sortedRight, hright, rfl⟩
+      let full := x :: xs
+      let pivot := full[pivotIndex]
+      let rest := full.eraseIdx pivotIndex
+      let parts := partition3 pivot rest
+      change full.length ≤ fuel + 1 at hfuel
+      have ⟨hleftFuel, hrightFuel⟩ :
+          parts.ret.1.length ≤ fuel ∧ parts.ret.2.2.length ≤ fuel := by
+        simpa [parts, rest] using partition3_fuel_bounds pivot pivotIndex hfuel
+      have ihleft := ih parts.ret.1 hleftFuel sortedLeft hleft
+      have ihright := ih parts.ret.2.2 hrightFuel sortedRight hright
+      have hsum : parts.ret.1.length + parts.ret.2.1.length + parts.ret.2.2.length =
+          rest.length := by
+        simp [parts]
+      have htime : parts.time = 2 * rest.length := by
+        simp [parts]
+      change parts.time + sortedLeft.time + sortedRight.time ≤ 2 * full.length * full.length
+      calc
+        parts.time + sortedLeft.time + sortedRight.time
+            ≤ 2 * rest.length + 2 * (rest.length * rest.length) := by
+              nlinarith
+        _ = 2 * rest.length * (rest.length + 1) := by nlinarith
+        _ ≤ 2 * full.length * full.length := by
+              have hlen : rest.length + 1 = full.length := by
+                simpa [rest] using
+                  List.length_eraseIdx_add_one (l := full) (i := (pivotIndex : ℕ))
+                    pivotIndex.isLt
+              rw [← hlen]
+              exact Nat.mul_le_mul_right (rest.length + 1)
+                (Nat.mul_le_mul_left 2 (Nat.le_succ rest.length))
+
+/-- Worst-case comparison bound for every possible randomized quicksort run. -/
+theorem randomizedQuickSort_time (xs : List α) :
+    ∀ result ∈ (randomizedQuickSort xs).support,
+      result.time ≤ 2 * xs.length * xs.length := by
+  exact randomizedQuickSortFuel_time xs.length xs le_rfl
+
+/--
+Expected-time bound for the actual PMF semantics of `randomizedQuickSort`. This follows from the
+pointwise worst-case theorem, so it is quadratic rather than the sharper average-case recurrence.
+-/
+theorem randomizedQuickSort_expectedTime_le_quadratic (xs : List α) :
+    RandomTimeM.expectedTime (randomizedQuickSort xs) ≤ (2 * xs.length * xs.length : ℕ) := by
+  exact RandomTimeM.expectedTime_le_of_time_le_on_support (randomizedQuickSort_time xs)
+
+end TimeComplexity
+
+end Cslib.Algorithms.Lean.TimeM

--- a/Cslib/Algorithms/Lean/QuickSort/QuickSort.lean
+++ b/Cslib/Algorithms/Lean/QuickSort/QuickSort.lean
@@ -474,7 +474,8 @@ Expected-time bound for the actual PMF semantics of `randomizedQuickSort`. This 
 pointwise worst-case theorem.
 -/
 theorem randomizedQuickSort_expectedTime_le_quadratic (xs : List α) :
-    RandomTimeM.expectedTime (randomizedQuickSort xs) ≤ (2 * xs.length * xs.length : ℕ) := by
+    RandomTimeM.expectedTime (randomizedQuickSort xs) ≤
+      ((2 * xs.length * xs.length : ℕ) : ℝ) := by
   exact RandomTimeM.expectedTime_le_of_time_le_on_support (randomizedQuickSort_time xs)
 
 /-- The same worst-case expected-time bound, stated for the `ENNReal` expectation algebra. -/

--- a/Cslib/Algorithms/Lean/RandomTimeM.lean
+++ b/Cslib/Algorithms/Lean/RandomTimeM.lean
@@ -1,0 +1,108 @@
+/-
+Copyright (c) 2026 Robert Joseph George. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Robert Joseph George
+-/
+
+module
+
+public import Cslib.Algorithms.Lean.TimeM
+public import Mathlib.Data.Real.Basic
+public import Mathlib.Probability.ProbabilityMassFunction.Monad
+
+/-!
+# Random timed computations
+
+`RandomTimeM T α` is a probability distribution over timed computations returning `α`. Keeping this
+wrapper outside `TimeM.lean` lets deterministic timed algorithms avoid probability-theory imports.
+-/
+
+@[expose] public section
+
+set_option autoImplicit false
+
+namespace Cslib.Algorithms.Lean
+
+/-- A randomized timed computation is a probability mass function over timed outputs. -/
+abbrev RandomTimeM (T : Type*) (α : Type*) := PMF (TimeM T α)
+
+namespace RandomTimeM
+
+variable {α : Type}
+
+/-- The real-valued probability masses of a PMF are summable. -/
+private theorem summable_pmf_toReal (p : PMF α) : Summable fun x => (p x).toReal :=
+  ENNReal.summable_toReal p.tsum_coe_ne_top
+
+/-- The real-valued probability masses of a PMF sum to one. -/
+private theorem tsum_pmf_toReal_eq_one (p : PMF α) : ∑' x, (p x).toReal = 1 := by
+  rw [← ENNReal.tsum_toReal_eq]
+  · simp
+  · intro x
+    exact ne_of_lt ((p.coe_le_one x).trans_lt ENNReal.one_lt_top)
+
+/-- Weighted average of a real-valued quantity over a PMF. -/
+noncomputable def expectedValue (p : PMF α) (value : α → ℝ) : ℝ :=
+  ∑' x, (p x).toReal * value x
+
+/-- A weighted average of nonnegative values is nonnegative. -/
+theorem expectedValue_nonneg {p : PMF α} {value : α → ℝ} (hvalue : ∀ x, 0 ≤ value x) :
+    0 ≤ expectedValue p value := by
+  unfold expectedValue
+  exact tsum_nonneg fun x => mul_nonneg ENNReal.toReal_nonneg (hvalue x)
+
+/--
+If a nonnegative quantity is bounded on every possible outcome, then its weighted average satisfies
+the same bound.
+-/
+theorem expectedValue_le_of_nonneg_le_on_support {p : PMF α} {value : α → ℝ} {bound : ℝ}
+    (hvalue : ∀ x, 0 ≤ value x) (hbound : ∀ x ∈ p.support, value x ≤ bound) :
+    expectedValue p value ≤ bound := by
+  unfold expectedValue
+  let probability : α → ℝ := fun x => (p x).toReal
+  let weightedBound : α → ℝ := fun x => probability x * bound
+  have hweightedBound : Summable weightedBound := by
+    dsimp [weightedBound, probability]
+    exact (summable_pmf_toReal p).mul_right bound
+  have hterm_le : ∀ x : α, probability x * value x ≤ weightedBound x := by
+    intro x
+    by_cases hx : x ∈ p.support
+    · dsimp [probability, weightedBound]
+      exact mul_le_mul_of_nonneg_left (hbound x hx) ENNReal.toReal_nonneg
+    · have hp : p x = 0 := by
+        rw [PMF.apply_eq_zero_iff]
+        exact hx
+      simp [probability, weightedBound, hp]
+  have hterm_summable : Summable fun x : α => probability x * value x :=
+    Summable.of_nonneg_of_le
+      (fun x => mul_nonneg ENNReal.toReal_nonneg (hvalue x)) hterm_le hweightedBound
+  calc
+    ∑' x : α, probability x * value x
+        ≤ ∑' x : α, weightedBound x := by
+          exact Summable.tsum_le_tsum hterm_le hterm_summable hweightedBound
+    _ = (∑' x : α, probability x) * bound := by
+          dsimp [weightedBound]
+          rw [tsum_mul_right]
+    _ = bound := by simp [probability, tsum_pmf_toReal_eq_one]
+
+/-- Expected running time is the weighted average of the time component of each result. -/
+noncomputable def expectedTime (p : RandomTimeM ℕ α) : ℝ :=
+  expectedValue p fun result => result.time
+
+/-- Expected running time is nonnegative. -/
+theorem expectedTime_nonneg (p : RandomTimeM ℕ α) : 0 ≤ p.expectedTime := by
+  exact expectedValue_nonneg fun result => by exact_mod_cast Nat.zero_le result.time
+
+/--
+If every supported run has cost at most `bound`, then the expected cost is at most `bound`. This is
+the basic bridge from pointwise `TimeM` bounds to randomized timed computations.
+-/
+theorem expectedTime_le_of_time_le_on_support {p : RandomTimeM ℕ α} {bound : ℕ}
+    (hbound : ∀ result ∈ p.support, result.time ≤ bound) :
+    p.expectedTime ≤ (bound : ℝ) := by
+  exact expectedValue_le_of_nonneg_le_on_support
+    (fun result => by exact_mod_cast Nat.zero_le result.time)
+    (fun result hresult => by exact_mod_cast hbound result hresult)
+
+end RandomTimeM
+end Cslib.Algorithms.Lean

--- a/Cslib/Algorithms/Lean/RandomTimeM.lean
+++ b/Cslib/Algorithms/Lean/RandomTimeM.lean
@@ -45,6 +45,14 @@ private theorem tsum_pmf_toReal_eq_one (p : PMF α) : ∑' x, (p x).toReal = 1 :
 noncomputable def expectedValue (p : PMF α) (value : α → ℝ) : ℝ :=
   ∑' x, (p x).toReal * value x
 
+/--
+Expectation of a natural-number-valued quantity, kept in `ENNReal`. This version has the clean monad
+law, so randomized algorithms can do the algebra there and convert back to `ℝ` once a finite bound
+is known.
+-/
+noncomputable def expectedNat (p : PMF α) (value : α → ℕ) : ENNReal :=
+  ∑' x, p x * value x
+
 /-- A weighted average of nonnegative values is nonnegative. -/
 theorem expectedValue_nonneg {p : PMF α} {value : α → ℝ} (hvalue : ∀ x, 0 ≤ value x) :
     0 ≤ expectedValue p value := by
@@ -85,13 +93,157 @@ theorem expectedValue_le_of_nonneg_le_on_support {p : PMF α} {value : α → �
           rw [tsum_mul_right]
     _ = bound := by simp [probability, tsum_pmf_toReal_eq_one]
 
+/-- A pure distribution has the obvious expectation. -/
+@[simp]
+theorem expectedNat_pure (x : α) (value : α → ℕ) :
+    expectedNat (PMF.pure x) value = value x := by
+  unfold expectedNat
+  rw [tsum_eq_single x]
+  · simp
+  · intro y hy
+    simp [PMF.pure_apply_of_ne _ _ hy]
+
+/-- The `ENNReal` expectation satisfies the monad law without any finiteness side condition. -/
+theorem expectedNat_bind {β : Type} (p : PMF α) (f : α → PMF β) (value : β → ℕ) :
+    expectedNat (p.bind f) value =
+      ∑' x, p x * expectedNat (f x) value := by
+  unfold expectedNat
+  calc
+    ∑' y, (p.bind f) y * value y
+        = ∑' y, (∑' x, p x * f x y) * value y := by
+          simp
+    _ = ∑' y, ∑' x, p x * f x y * value y := by
+          simp_rw [ENNReal.tsum_mul_right]
+    _ = ∑' x, ∑' y, p x * f x y * value y := by
+          exact ENNReal.tsum_comm
+    _ = ∑' x, p x * ∑' y, f x y * value y := by
+          simp_rw [mul_assoc, ENNReal.tsum_mul_left]
+
+/-- Expectation distributes over addition for natural-number-valued quantities. -/
+theorem expectedNat_add (p : PMF α) (value₁ value₂ : α → ℕ) :
+    expectedNat p (fun x => value₁ x + value₂ x) =
+      expectedNat p value₁ + expectedNat p value₂ := by
+  unfold expectedNat
+  simp_rw [Nat.cast_add, mul_add]
+  rw [ENNReal.tsum_add]
+
+/-- The expectation of a constant natural-number-valued quantity is that constant. -/
+theorem expectedNat_const (p : PMF α) (value : ℕ) :
+    expectedNat p (fun _ => value) = value := by
+  unfold expectedNat
+  rw [ENNReal.tsum_mul_right]
+  simp
+
+/-- A finite pointwise bound keeps the natural-number expectation finite. -/
+theorem expectedNat_le_of_le_on_support {p : PMF α} {value : α → ℕ} {bound : ℕ}
+    (hbound : ∀ x ∈ p.support, value x ≤ bound) :
+    expectedNat p value ≤ bound := by
+  unfold expectedNat
+  calc
+    ∑' x, p x * value x
+        ≤ ∑' x, p x * bound := by
+          exact ENNReal.tsum_le_tsum fun x => by
+            by_cases hx : x ∈ p.support
+            · exact mul_le_mul_right (by exact_mod_cast hbound x hx) (p x)
+            · have hp : p x = 0 := by
+                rw [PMF.apply_eq_zero_iff]
+                exact hx
+              simp [hp]
+    _ = (∑' x, p x) * bound := by
+          rw [ENNReal.tsum_mul_right]
+    _ = bound := by simp
+
 /-- Expected running time is the weighted average of the time component of each result. -/
 noncomputable def expectedTime (p : RandomTimeM ℕ α) : ℝ :=
   expectedValue p fun result => result.time
 
+/-- Expected running time as an extended nonnegative real. -/
+noncomputable def expectedTimeENNReal (p : RandomTimeM ℕ α) : ENNReal :=
+  expectedNat p fun result => result.time
+
+/-- The real and `ENNReal` expected-time views agree after converting back to `ℝ`. -/
+theorem expectedTime_eq_toReal_expectedTimeENNReal (p : RandomTimeM ℕ α) :
+    p.expectedTime = p.expectedTimeENNReal.toReal := by
+  unfold expectedTime expectedTimeENNReal expectedValue expectedNat
+  rw [ENNReal.tsum_toReal_eq]
+  · simp [ENNReal.toReal_mul]
+  · intro result
+    exact ENNReal.mul_ne_top
+      (ne_of_lt ((p.coe_le_one result).trans_lt ENNReal.one_lt_top))
+      (by exact_mod_cast (WithTop.coe_ne_top : (result.time : ENNReal) ≠ ⊤))
+
 /-- Expected running time is nonnegative. -/
 theorem expectedTime_nonneg (p : RandomTimeM ℕ α) : 0 ≤ p.expectedTime := by
   exact expectedValue_nonneg fun result => by exact_mod_cast Nat.zero_le result.time
+
+/-- The extended expected time satisfies the monad law. -/
+theorem expectedTimeENNReal_bind {β : Type} (p : PMF α) (f : α → RandomTimeM ℕ β) :
+    expectedTimeENNReal (p.bind f) =
+      ∑' x, p x * expectedTimeENNReal (f x) := by
+  exact expectedNat_bind p f fun result => result.time
+
+/-- Binding to a pure timed result with a fixed extra cost adds that cost to expected time. -/
+theorem expectedTimeENNReal_bind_pure_add {β : Type} (p : RandomTimeM ℕ α) (base : ℕ)
+    (ret : TimeM ℕ α → β) :
+    expectedTimeENNReal (p.bind fun result => PMF.pure ⟨ret result, base + result.time⟩) =
+      (base : ENNReal) + p.expectedTimeENNReal := by
+  rw [expectedTimeENNReal_bind]
+  simp only [expectedTimeENNReal, expectedNat_pure]
+  rw [← expectedNat]
+  calc
+    expectedNat p (fun result => base + result.time)
+        = expectedNat p (fun _ => base) + expectedNat p fun result => result.time := by
+          exact expectedNat_add p (fun _ => base) fun result => result.time
+    _ = (base : ENNReal) + expectedTimeENNReal p := by
+          rw [expectedNat_const]
+          rfl
+
+/--
+Expected time for two independent randomized timed computations followed by a pure recombination.
+This is the algebraic shape used by divide-and-conquer algorithms such as randomized quicksort.
+-/
+theorem expectedTimeENNReal_bind_pure_add_pair {β γ : Type} (left : RandomTimeM ℕ α)
+    (right : RandomTimeM ℕ β) (base : ℕ) (ret : TimeM ℕ α → TimeM ℕ β → γ) :
+    expectedTimeENNReal
+        (left.bind fun leftResult =>
+          right.bind fun rightResult =>
+            PMF.pure ⟨ret leftResult rightResult, base + leftResult.time + rightResult.time⟩) =
+      (base : ENNReal) + left.expectedTimeENNReal + right.expectedTimeENNReal := by
+  rw [expectedTimeENNReal_bind]
+  simp only [expectedTimeENNReal_bind_pure_add]
+  simp_rw [Nat.cast_add]
+  unfold expectedTimeENNReal expectedNat
+  have hleft :
+      (∑' leftResult : TimeM ℕ α, left leftResult * (↑base + ↑leftResult.time)) =
+        (base : ENNReal) + ∑' leftResult : TimeM ℕ α, left leftResult * ↑leftResult.time := by
+    have hbase : (∑' leftResult : TimeM ℕ α, left leftResult * (base : ENNReal)) = base := by
+      rw [ENNReal.tsum_mul_right]
+      simp
+    have hadd := expectedNat_add left (fun _ => base) fun leftResult => leftResult.time
+    unfold expectedNat at hadd
+    simp_rw [Nat.cast_add] at hadd
+    rw [hadd, hbase]
+  calc
+    ∑' leftResult, left leftResult * ((base : ENNReal) + ↑leftResult.time +
+        (∑' rightResult, right rightResult * ↑rightResult.time))
+        = (∑' leftResult, left leftResult * ((base : ENNReal) + ↑leftResult.time)) +
+            ∑' leftResult, left leftResult *
+              (∑' rightResult, right rightResult * ↑rightResult.time) := by
+          simp_rw [mul_add]
+          rw [ENNReal.tsum_add]
+    _ = (∑' leftResult, left leftResult * ((base : ENNReal) + ↑leftResult.time)) +
+            (∑' rightResult, right rightResult * ↑rightResult.time) := by
+          rw [ENNReal.tsum_mul_right]
+          simp
+    _ = (base : ENNReal) + (∑' leftResult, left leftResult * ↑leftResult.time) +
+            (∑' rightResult, right rightResult * ↑rightResult.time) := by
+          rw [hleft]
+
+/-- A pointwise time bound also bounds the extended expected time. -/
+theorem expectedTimeENNReal_le_of_time_le_on_support {p : RandomTimeM ℕ α} {bound : ℕ}
+    (hbound : ∀ result ∈ p.support, result.time ≤ bound) :
+    p.expectedTimeENNReal ≤ bound := by
+  exact expectedNat_le_of_le_on_support hbound
 
 /--
 If every supported run has cost at most `bound`, then the expected cost is at most `bound`. This is

--- a/Cslib/Algorithms/Lean/RandomTimeM.lean
+++ b/Cslib/Algorithms/Lean/RandomTimeM.lean
@@ -153,7 +153,11 @@ theorem expectedNat_le_of_le_on_support {p : PMF α} {value : α → ℕ} {bound
           rw [ENNReal.tsum_mul_right]
     _ = bound := by simp
 
-/-- Expected running time is the weighted average of the time component of each result. -/
+/--
+Expected running time as a real number. For algebraic work with randomized algorithms,
+`expectedTimeENNReal` is the safer primary view; this real-valued version is mainly convenient after
+a finite pointwise bound has already been proved.
+-/
 noncomputable def expectedTime (p : RandomTimeM ℕ α) : ℝ :=
   expectedValue p fun result => result.time
 
@@ -161,7 +165,10 @@ noncomputable def expectedTime (p : RandomTimeM ℕ α) : ℝ :=
 noncomputable def expectedTimeENNReal (p : RandomTimeM ℕ α) : ENNReal :=
   expectedNat p fun result => result.time
 
-/-- The real and `ENNReal` expected-time views agree after converting back to `ℝ`. -/
+/--
+The real and `ENNReal` expected-time views agree after converting back to `ℝ`. Use this only when
+the extended expectation is known to be finite, since `ENNReal.toReal ⊤ = 0`.
+-/
 theorem expectedTime_eq_toReal_expectedTimeENNReal (p : RandomTimeM ℕ α) :
     p.expectedTime = p.expectedTimeENNReal.toReal := by
   unfold expectedTime expectedTimeENNReal expectedValue expectedNat
@@ -189,7 +196,8 @@ theorem expectedTimeENNReal_bind_pure_add {β : Type} (p : RandomTimeM ℕ α) (
       (base : ENNReal) + p.expectedTimeENNReal := by
   rw [expectedTimeENNReal_bind]
   simp only [expectedTimeENNReal, expectedNat_pure]
-  rw [← expectedNat]
+  change expectedNat p (fun result => base + result.time) =
+    (base : ENNReal) + p.expectedTimeENNReal
   calc
     expectedNat p (fun result => base + result.time)
         = expectedNat p (fun _ => base) + expectedNat p fun result => result.time := by

--- a/Cslib/Algorithms/Lean/Sorting.lean
+++ b/Cslib/Algorithms/Lean/Sorting.lean
@@ -6,6 +6,8 @@ Authors: Robert Joseph George
 
 module
 
+public import Cslib.Init
+
 /-!
 # Sorting utilities
 

--- a/Cslib/Algorithms/Lean/Sorting.lean
+++ b/Cslib/Algorithms/Lean/Sorting.lean
@@ -1,0 +1,26 @@
+/-
+Copyright (c) 2026 Robert Joseph George. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Robert Joseph George
+-/
+
+module
+
+/-!
+# Sorting utilities
+
+For stable list sorts, filtering the input and output by any value records the relative order of
+the copies of that value.
+-/
+
+@[expose] public section
+
+set_option autoImplicit false
+
+namespace Cslib.Algorithms.Lean
+
+/-- `ys` preserves the order of equal values from `xs`. -/
+abbrev StableByValue {α : Type} [DecidableEq α] (xs ys : List α) : Prop :=
+  ∀ value, ys.filter (fun x => x = value) = xs.filter (fun x => x = value)
+
+end Cslib.Algorithms.Lean

--- a/Cslib/Algorithms/Lean/Sorting.lean
+++ b/Cslib/Algorithms/Lean/Sorting.lean
@@ -22,7 +22,7 @@ set_option autoImplicit false
 namespace Cslib.Algorithms.Lean
 
 /-- `ys` preserves the order of equal values from `xs`. -/
-abbrev StableByValue {α : Type} [DecidableEq α] (xs ys : List α) : Prop :=
+abbrev StableByValue {α : Type*} [DecidableEq α] (xs ys : List α) : Prop :=
   ∀ value, ys.filter (fun x => x = value) = xs.filter (fun x => x = value)
 
 end Cslib.Algorithms.Lean


### PR DESCRIPTION
I wanted to contribute more of the standard sorting algorithms alongside the existing MergeSort development. This PR adds stable bubble sort, stable insertion sort, counting sort for natural-number lists, and a duplicate-safe randomized quicksort, all using the existing TimeM style so the algorithms come with executable definitions, correctness theorems, and comparison-cost bounds.

For stability, I added a shared StableByValue predicate. The idea is that if we filter the input and output by any fixed value, we should get the same subsequence. This captures the usual list-level meaning of stability: equal elements appear in the same relative order after sorting. Bubble sort is stable because it swaps only when the next element is strictly smaller, never when two elements are equal. Insertion sort is stable because it processes the input from right to left and inserts a new element before equal elements already in the sorted tail. Counting sort is stable for List ℕ because each value’s filtered subsequence is completely determined by how many copies of that value occur.

The randomized quicksort part adds a small RandomTimeM abstraction: a PMF over timed computations. I used this because randomized algorithms do not produce one timed result; they produce a distribution over possible timed runs. The quicksort implementation samples a pivot index uniformly, removes that pivot occurrence, and partitions the rest into values below, equal to, and above the pivot. The equal bucket is not recursively sorted, so duplicates are handled directly instead of relying on a distinctness assumption.

For time complexity, the deterministic algorithms prove their expected comparison bounds directly in TimeM. For randomized quicksort, this PR proves sortedness and permutation correctness for every supported run, a quadratic worst-case comparison bound for every supported run, and the corresponding expected-time bound. It also adds reusable expected-time algebra for RandomTimeM, including the monad law for ENNReal expectations and a formal one-step expected-time recurrence for the actual quicksort implementation. I included the standard harmonic O(n log n) bound for the all-distinct rank recurrence as the next bridge toward the sharper average-case theorem.

AI usage: I used GPT-5.5 as an assistant while working on this PR, mainly for help navigating longer Lean proofs, trying proof refactors using some of the more advanced automation tactics. I reviewed the generated suggestions, ran the relevant CSLib checks locally, and take responsibility for the final code. Let me know if something looks bad or unnecessary. 

Concretely, this PR adds:

- StableByValue as a shared stability predicate for list sorting.
- Stable bubble sort with sortedness, permutation, stability, and quadratic time proofs.
- Stable insertion sort with sortedness, permutation, stability, and quadratic time proofs.
- Counting sort on List ℕ with count preservation, sortedness, permutation, stability, and exact time proofs.
- RandomTimeM, with expected-value and expected-time lemmas for randomized timed computations.
- Randomized quicksort with PMF semantics, duplicate-safe three-way partitioning, correctness for every supported run, quadratic worst-case time, expected-time bounds, and an expected-time recurrence lemma.

Validation run locally:

- lake build Cslib
- lake test
- lake lint
- lake exe checkInitImports
- lake exe lint-style
- lake exe mk_all --module