### PR TITLE
feat: decidable `LcAt` and `LC`

### DIFF
--- a/Cslib/Languages/LambdaCalculus/LocallyNameless/Untyped/LcAt.lean
+++ b/Cslib/Languages/LambdaCalculus/LocallyNameless/Untyped/LcAt.lean
@@ -27,10 +27,10 @@ variable {Var : Type u}
 
 /-- `LcAt k M` is satisfied when all bound indices of M are smaller than `k`. -/
 @[simp, scoped grind =]
-def LcAt (k : ℕ) : Term Var → Prop
+def LcAt (k : ℕ) : Term Var → Bool
 | bvar i => i < k
-| fvar _ => True
-| app t₁ t₂ => LcAt k t₁ ∧ LcAt k t₂
+| fvar _ => true
+| app t₁ t₂ => LcAt k t₁ && LcAt k t₂
 | abs t => LcAt (k + 1) t
 
 /-- `depth` counts the maximum number of the lambdas that are enclosing variables. -/
@@ -82,6 +82,10 @@ theorem lcAt_iff_LC (M : Term Var) [HasFresh Var] : LcAt 0 M ↔ M.LC := by
         rcases h2 with ⟨⟩|⟨L,_,_⟩
         grind [fresh_exists L]
     | _ => grind [cases LC]
+
+instance [HasFresh Var] (t : Term Var) : Decidable t.LC := by
+  rw [← lcAt_iff_LC]
+  infer_instance
 
 /- Opening for some term at i-th bound variable increments `LcAt` by one -/
 lemma lcAt_openRec_lcAt (M N : Term Var) (i : ℕ) :


### PR DESCRIPTION
This PR makes `LcAt` and `LC` decidable.

Before:

```lean
def Term_LA0L1 : Term String := .abs (.app (.bvar 0) (.abs (.bvar 1)))

theorem LA0L1_lc : Term_LA0L1.LC := by
unfold Term_LA0L1
apply LC.abs
intros
simp [open', openRec]
apply LC.app
grind
apply LC.abs
intros
simp [open', openRec]
grind
exact ∅
exact ∅
```

After: 

```lean
theorem LA0L1_lc : LcAt 0 Term_LA0L1 := by decide
```
