### PR TITLE
refactor: use `Option State` rather than `Sum State Unit` in `LTS.totalize` construction

### DIFF
--- a/Cslib/Computability/Automata/NA/Concat.lean
+++ b/Cslib/Computability/Automata/NA/Concat.lean
@@ -138,20 +138,20 @@ namespace FinAcc
 
 /-- `finConcat na1 na2` is the concatenation of the "totalized" versions of `na1` and `na2`. -/
 def finConcat (na1 : FinAcc State1 Symbol) (na2 : FinAcc State2 Symbol)
-  : NA ((State1 ⊕ Unit) ⊕ (State2 ⊕ Unit)) Symbol :=
-  concat ⟨na1.totalize, inl '' na1.accept⟩ na2.totalize
+  : NA (Option State1 ⊕ Option State2) Symbol :=
+  concat ⟨na1.totalize, some '' na1.accept⟩ na2.totalize
 
 variable {na1 : FinAcc State1 Symbol} {na2 : FinAcc State2 Symbol}
 
 /-- `finConcat na1 na2` is total. -/
 instance : (finConcat na1 na2).Total where
   total s x := match s with
-    | inl _ => ⟨inl (inr ()), by grind [finConcat, concat, NA.totalize, LTS.totalize]⟩
-    | inr _ => ⟨inr (inr ()), by grind [finConcat, concat, NA.totalize, LTS.totalize]⟩
+    | inl _ => ⟨inl none, by grind [finConcat, concat, NA.totalize, LTS.totalize]⟩
+    | inr _ => ⟨inr none, by grind [finConcat, concat, NA.totalize, LTS.totalize]⟩
 
 /-- `finConcat na1 na2` accepts the concatenation of the languages of `na1` and `na2`. -/
 theorem finConcat_language_eq [Inhabited Symbol] :
-    language (FinAcc.mk (finConcat na1 na2) (inr '' (inl '' na2.accept))) =
+    language (FinAcc.mk (finConcat na1 na2) (inr '' (some '' na2.accept))) =
     language na1 * language na2 := by
   ext xl
   constructor
@@ -166,7 +166,7 @@ theorem finConcat_language_eq [Inhabited Symbol] :
       #adaptation_note
       /-- A grind regression found moving to nightly-2026-03-31 (changes from lean#13166) -/
       have : ss xl.length = inr (ss2 (xl.length - n)) := by grind
-      have hl : (ss2 (xl.length - n)).isLeft := by grind
+      have hl : (ss2 (xl.length - n)).isSome := by grind
       obtain ⟨s2, t2, h_mtr2, _, _, _⟩ := totalize_run_mtr h_run2 hl
       refine ⟨s2, ?_, t2, ?_, ?_⟩ <;> grind [drop_append_of_le_length, take_append_of_le_length]
     · exact xl.take_append_drop n

--- a/Cslib/Computability/Automata/NA/Loop.lean
+++ b/Cslib/Computability/Automata/NA/Loop.lean
@@ -167,14 +167,14 @@ namespace FinAcc
 open scoped Computability
 
 /-- `finLoop na` is the loop construction applied to the "totalized" version of `na`. -/
-def finLoop (na : FinAcc State Symbol) : NA (Unit ⊕ (State ⊕ Unit)) Symbol :=
-  FinAcc.loop ⟨na.totalize, inl '' na.accept⟩
+def finLoop (na : FinAcc State Symbol) : NA (Unit ⊕ Option State) Symbol :=
+  FinAcc.loop ⟨na.totalize, some '' na.accept⟩
 
 /-- `finLoop na` is total, assuming that `na` has at least one start state. -/
 instance [h : Nonempty na.start] : na.finLoop.Total where
   total s x := match s with
-    | inl _ => ⟨inr (inr ()), by simpa [finLoop, loop, NA.totalize, LTS.totalize] using h⟩
-    | inr _ => ⟨inr (inr ()), by grind [finLoop, loop, NA.totalize, LTS.totalize]⟩
+    | inl _ => ⟨inr none, by simpa [finLoop, loop, NA.totalize, LTS.totalize] using h⟩
+    | inr _ => ⟨inr none, by grind [finLoop, loop, NA.totalize, LTS.totalize]⟩
 
 /-- `finLoop na` accepts the Kleene star of the language of `na`, assuming that
 the latter is nonempty. -/

--- a/Cslib/Computability/Automata/NA/Total.lean
+++ b/Cslib/Computability/Automata/NA/Total.lean
@@ -16,25 +16,25 @@ public import Cslib.Foundations.Semantics.LTS.Total
 
 namespace Cslib.Automata.NA
 
-open Sum ωSequence Acceptor
+open Option ωSequence Acceptor
 
 variable {Symbol State : Type*}
 
 /-- `NA.totalize` makes the original NA total by replacing its LTS with `LTS.totalize`
 and its starting states with their lifted non-sink versions. -/
-def totalize (na : NA State Symbol) : NA (State ⊕ Unit) Symbol where
+def totalize (na : NA State Symbol) : NA (Option State) Symbol where
   toLTS := na.toLTS.totalize
-  start := inl '' na.start
+  start := some '' na.start
 
 variable {na : NA State Symbol}
 
 /-- In an infinite execution of `NA.totalize`, as long as the NA stays in a non-sink state,
 the execution so far corresponds to a finite execution of the original NA. -/
-theorem totalize_run_mtr {xs : ωSequence Symbol} {ss : ωSequence (State ⊕ Unit)} {n : ℕ}
-    (h : na.totalize.Run xs ss) (hl : (ss n).isLeft) :
-    ∃ s t, na.MTr s (xs.take n) t ∧ s ∈ na.start ∧ ss 0 = inl s ∧ ss n = inl t := by
+theorem totalize_run_mtr {xs : ωSequence Symbol} {ss : ωSequence (Option State)} {n : ℕ}
+    (h : na.totalize.Run xs ss) (hl : (ss n).isSome) :
+    ∃ s t, na.MTr s (xs.take n) t ∧ s ∈ na.start ∧ ss 0 = some s ∧ ss n = some t := by
   obtain ⟨s, _, eq₁⟩ := h.start
-  obtain ⟨t, eq₂⟩ := isLeft_iff.mp hl
+  obtain ⟨t, eq₂⟩ := isSome_iff_exists.mp hl
   use s, t
   refine ⟨?_, by grind⟩
   -- TODO: `grind` does not use congruence relations with `na.totalize.MTr`
@@ -45,7 +45,7 @@ theorem totalize_run_mtr {xs : ωSequence Symbol} {ss : ωSequence (State ⊕ Un
 `NA.totalize`, provided that the alphabet is inbabited. -/
 theorem totalize_mtr_run [Inhabited Symbol] {xl : List Symbol} {s t : State}
     (hs : s ∈ na.start) (hm : na.MTr s xl t) :
-    ∃ xs ss, na.totalize.Run (xl ++ω xs) ss ∧ ss 0 = inl s ∧ ss xl.length = inl t := by
+    ∃ xs ss, na.totalize.Run (xl ++ω xs) ss ∧ ss 0 = some s ∧ ss xl.length = some t := by
   grind [totalize, Run, LTS.Total.extend_omegaExecution <| LTS.totalize.nonsink_mtr_iff.mpr hm]
 
 namespace FinAcc
@@ -53,7 +53,7 @@ namespace FinAcc
 /-- `NA.totalize` and the original NA accept the same language of finite words,
 as long as the accepting states are also lifted in the obvious way. -/
 theorem totalize_language_eq {na : FinAcc State Symbol} :
-    language (FinAcc.mk na.totalize (inl '' na.accept)) = language na := by
+    language (FinAcc.mk na.totalize (some '' na.accept)) = language na := by
   ext xl
   simp +instances [totalize]
 

--- a/Cslib/Computability/Languages/RegularLanguage.lean
+++ b/Cslib/Computability/Languages/RegularLanguage.lean
@@ -158,8 +158,8 @@ theorem IsRegular.mul [Inhabited Symbol] {l1 l2 : Language Symbol}
   rw [IsRegular.iff_nfa] at h1 h2 ⊢
   obtain ⟨State1, h_fin1, nfa1, rfl⟩ := h1
   obtain ⟨State2, h_fin1, nfa2, rfl⟩ := h2
-  use (State1 ⊕ Unit) ⊕ (State2 ⊕ Unit), inferInstance,
-    ⟨finConcat nfa1 nfa2, inr '' (inl '' nfa2.accept)⟩
+  use Option State1 ⊕ Option State2, inferInstance,
+    ⟨finConcat nfa1 nfa2, inr '' (some '' nfa2.accept)⟩
   exact finConcat_language_eq
 
 -- TODO: fix proof to work with backward.isDefEq.respectTransparency
@@ -173,7 +173,7 @@ theorem IsRegular.kstar [Inhabited Symbol] {l : Language Symbol}
   · simp [h_l]
   · rw [IsRegular.iff_nfa] at h ⊢
     obtain ⟨State, h_fin, nfa, rfl⟩ := h
-    use Unit ⊕ (State ⊕ Unit), inferInstance, ⟨finLoop nfa, {inl ()}⟩, loop_language_eq h_l
+    use Unit ⊕ Option State, inferInstance, ⟨finLoop nfa, {inl ()}⟩, loop_language_eq h_l
 
 /-- If a right congruence is of finite index, then each of its equivalence classes is regular. -/
 @[simp]

--- a/Cslib/Foundations/Semantics/LTS/Total.lean
+++ b/Cslib/Foundations/Semantics/LTS/Total.lean
@@ -20,7 +20,7 @@ and a "totalize" construction that converts any LTS into a total LTS.
 
 namespace Cslib.LTS
 
-open ωSequence Sum
+open ωSequence
 
 variable {State Label : Type*} {lts : LTS State Label}
 
@@ -62,22 +62,24 @@ theorem Total.extend_omegaExecution [Inhabited Label] [ht : lts.Total]
   grind [OmegaExecution.append hm ho h0]
 
 /-- `totalize` constructs a total LTS from any given LTS by adding a sink state. -/
-def totalize (lts : LTS State Label) : LTS (State ⊕ Unit) Label where
+def totalize (lts : LTS State Label) : LTS (Option State) Label where
   Tr s' μ t' := match s', t' with
-    | Sum.inl s, Sum.inl t => lts.Tr s μ t
-    | _, Sum.inr () => True
-    | Sum.inr (), Sum.inl _ => False
+    | some s, some t => lts.Tr s μ t
+    | _, none => True
+    | none, some _ => False
 
 /-- The LTS constructed by `totalize` is indeed total. -/
 instance (lts : LTS State Label) : lts.totalize.Total where
-  total _ _ := by simp [totalize]
+  total _ _ := by
+    use none
+    simp [totalize]
 
 /-- In `totalize`, there is no finite execution from the sink state to any non-sink state. -/
 theorem totalize.no_sink_to_nonsink {μs : List Label} {t : State} :
-    ¬ lts.totalize.MTr (Sum.inr ()) μs (Sum.inl t) := by
+    ¬ lts.totalize.MTr (none) μs (some t) := by
   intro h
-  generalize h_s : (Sum.inr () : State ⊕ Unit) = s'
-  generalize h_t : (Sum.inl t : State ⊕ Unit) = t'
+  generalize h_s : (none : Option State) = s'
+  generalize h_t : (some t : Option State) = t'
   rw [h_s, h_t] at h
   induction h <;> grind [totalize]
 
@@ -85,25 +87,25 @@ theorem totalize.no_sink_to_nonsink {μs : List Label} {t : State} :
 the transitions in the original LTS. -/
 @[simp]
 theorem totalize.nonsink_tr_iff {μ : Label} {s t : State} :
-    lts.totalize.Tr (Sum.inl s) μ (Sum.inl t) ↔ lts.Tr s μ t := by
+    lts.totalize.Tr (some s) μ (some t) ↔ lts.Tr s μ t := by
   simp [totalize]
 
 /-- In `totalize`, the multistep transitions between non-sink states correspond exactly to
 the multistep transitions in the original LTS. -/
 @[simp]
 theorem totalize.nonsink_mtr_iff {μs : List Label} {s t : State} :
-    lts.totalize.MTr (Sum.inl s) μs (Sum.inl t) ↔ lts.MTr s μs t := by
+    lts.totalize.MTr (some s) μs (some t) ↔ lts.MTr s μs t := by
   constructor <;> intro h
-  · generalize h_s : (Sum.inl s : State ⊕ Unit) = s'
-    generalize h_t : (Sum.inl t : State ⊕ Unit) = t'
+  · generalize h_s : (some s : Option State) = s'
+    generalize h_t : (some t : Option State) = t'
     rw [h_s, h_t] at h
     induction h generalizing s
     case refl _ => grind [MTr]
     case stepL t1' μ t2' μs t3' h_tr h_mtr h_ind =>
       obtain ⟨rfl⟩ := h_s
       cases t2'
-      case inl t2 => grind [MTr, totalize.nonsink_tr_iff.mp h_tr]
-      case inr t2 => grind [totalize.no_sink_to_nonsink]
+      case some t2 => grind [MTr, totalize.nonsink_tr_iff.mp h_tr]
+      case none => grind [totalize.no_sink_to_nonsink]
   · induction h
     case refl _ => grind [MTr]
     case stepL t1 μ t2 μs t3 h_tr h_mtr h_ind =>


### PR DESCRIPTION
The `LTS.totalize` construction adds a "sink state" and transitions to the sink state in order to make the LTS total.  Originally the sink state is represented by the `()` in the RHS of a direct sum `State ⊕ Unit`.  This PR changes the state space of `LTS.totalize` to `Option State` instead, where the sink state is represented by `none`.  This equivalent representation is easier to read and, more importantly, avoids the confusing "sum of sums" types in NA/Concat.lean and NA.Loop.lean, where another level of constructions also use the direct sum types.
