### PR TITLE
feat(Foundations/Logic): Notation typeclasses and models

### DIFF
--- a/Cslib/Foundations/Logic/Connectives.lean
+++ b/Cslib/Foundations/Logic/Connectives.lean
@@ -9,6 +9,8 @@ module
 public import Cslib.Init
 public import Mathlib.Order.Notation
 
+/-! # Notation classes for logical connectives -/
+
 @[expose] public section
 
 namespace Cslib.Logic
@@ -42,7 +44,8 @@ class HasNot (α : Type*) where
 @[inherit_doc] scoped notation:max "¬" a:40 => HasNot.not a
 
 /-- Instantiate negation for types with implication and a bottom element. NB: this has a lower
-  instance priority to account for proposition types with inbuilt negation. -/
+  instance priority to account for proposition types with inbuilt negation. Possibly it should be
+  a `def` instead? -/
 instance (priority := 900) instNotImplBot (α : Type*) [HasImpl α] [Bot α] : HasNot α where
   not a := a → ⊥
 

--- a/Cslib/Foundations/Logic/Connectives.lean
+++ b/Cslib/Foundations/Logic/Connectives.lean
@@ -1,0 +1,49 @@
+/-
+Copyright (c) 2025 Thomas Waring. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Thomas Waring
+-/
+
+module
+
+public import Cslib.Init
+public import Mathlib.Order.Notation
+
+@[expose] public section
+
+namespace Cslib.Logic
+
+/-- Class for implication. -/
+class HasImpl (α : Type*) where
+  /-- Implication. -/
+  impl : α → α → α
+
+@[inherit_doc] scoped infixr:25 " → " => HasImpl.impl
+
+/-- Class for conjunction. -/
+class HasAnd (α : Type*) where
+  /-- Conjunction. -/
+  and : α → α → α
+
+@[inherit_doc] scoped infixr:35 " ∧ " => HasAnd.and
+
+/-- Class for disjunction. -/
+class HasOr (α : Type*) where
+  /-- Disjunction. -/
+  or : α → α → α
+
+@[inherit_doc] scoped infixr:30 " ∨ " => HasOr.or
+
+/-- Class for negation. -/
+class HasNot (α : Type*) where
+  /-- Negation. -/
+  not : α → α
+
+@[inherit_doc] scoped notation:max "¬" a:40 => HasNot.not a
+
+/-- Instantiate negation for types with implication and a bottom element. NB: this has a lower
+  instance priority to account for proposition types with inbuilt negation. -/
+instance (priority := 900) instNotImplBot (α : Type*) [HasImpl α] [Bot α] : HasNot α where
+  not a := a → ⊥
+
+end Cslib.Logic

--- a/Cslib/Foundations/Logic/Model.lean
+++ b/Cslib/Foundations/Logic/Model.lean
@@ -1,0 +1,98 @@
+/-
+Copyright (c) 2025 Thomas Waring. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Thomas Waring
+-/
+
+module
+
+public import Cslib.Foundations.Logic.Connectives
+public import Cslib.Foundations.Logic.InferenceSystem
+public import Cslib.Logics.Modal.Basic
+
+public section
+
+namespace Cslib.Logic
+
+/-- Objects of type `β` carry a forcing relation with the proposition type `α`. -/
+class ModelClass (α : outParam (Type*)) (β : Type*) where
+  /-- `Forces b a` has the intended semantics "`a` is valid in the model `b`". -/
+  Forces : β → α → Prop
+
+scoped notation "⊨[" b "] " a => ModelClass.Forces b a
+
+/-- Objects of type `β` carry a forcing relation worlds of type `γ` and the proposition type `α`. -/
+class ParamModelClass (α : outParam (Type*)) (β : Type*) where
+  Param : β → Type*
+  /-- Forcing relation associated to each parameter. -/
+  ForcesAt (b : β) : (Param b) → α → Prop
+
+scoped notation w " ⊨[" b "] " a => ParamModelClass.ForcesAt b w a
+
+instance ParamModelClass.toModelClass {α β : Type*} [ParamModelClass α β] : ModelClass α β where
+  Forces M A := ∀ w : ParamModelClass.Param M, w ⊨[M] A
+
+/-- Bundled interpretation function. -/
+structure Interp (α β : Type*) where
+  /-- Interpret a proposition in a model. -/
+  interp : α → β
+
+/-- An `InterpModel` consists of an interpretation function, and a set specifying which
+  interpretations are considered valid. -/
+structure InterpModel (α β : Type*) extends Interp α β where
+  /-- The set of valid interpretations. -/
+  filter : Set β
+
+instance {α β : Type*} : ModelClass α (InterpModel α β) where
+  Forces M a := M.interp a ∈ M.filter
+
+namespace Interp
+
+class AlgebraicAnd {α β : Type*} [HasAnd α] [Min β] (M : Interp α β) where
+  interp_and_eq (x y : α) : M.interp (x ∧ y) = M.interp x ⊓ M.interp y
+
+class AlgebraicOr {α β : Type*} [HasOr α] [Max β] (M : Interp α β) where
+  interp_or_eq (x y : α) : M.interp (x ∨ y) = M.interp x ⊔ M.interp y
+
+class AlgebraicImpl {α β : Type*} [HasImpl α] [HImp β] (M : Interp α β) where
+  interp_impl_eq (x y : α) : M.interp (x → y) = M.interp x ⇨ M.interp y
+
+class AlgebraicNot {α β : Type*} [HasNot α] [Compl β] (M : Interp α β) where
+  interp_not_eq (x : α) : M.interp (¬ x) = (M.interp x)ᶜ
+
+end Interp
+
+open ModelClass ParamModelClass InferenceSystem
+
+def Sound {α β S : Type*} [ModelClass α β] [InferenceSystem S α] : Prop :=
+  ∀ (A : α) (b : β) , DerivableIn S A → ⊨[b] A
+
+def Complete {α β S : Type*} [ModelClass α β] [InferenceSystem S α] : Prop :=
+  ∀ A : α, (∀ b : β, ⊨[b] A) → DerivableIn S A
+
+def ParamModelClass.theory {α β : Type*} [ParamModelClass α β] {M : β} (w : Param M) : Set α :=
+  {A : α | w ⊨[M] A}
+
+def ModelClass.logic {α β : Type*} [ModelClass α β] (S : Set β) : Set α := {A | ∀ b ∈ S, ⊨[b] A}
+
+namespace Modal
+
+structure BundledModel (Atom : Type*) where
+  World : Type*
+  model : Model World Atom
+
+def Model.toBundledModel {World Atom : Type*} (M : Model World Atom) : BundledModel Atom :=
+  {World := World, model := M}
+
+instance {Atom : Type*} : ParamModelClass (Proposition Atom) (BundledModel Atom) where
+  Param M := M.World
+  ForcesAt M w A := Satisfies M.model w A
+
+example {World Atom : Type*} (S : Set (Model World Atom)) :
+    logic S = ModelClass.logic (Model.toBundledModel '' S) := by
+  simp [ModelClass.logic]
+  rfl
+
+end Modal
+
+end Cslib.Logic

--- a/Cslib/Foundations/Logic/Model.lean
+++ b/Cslib/Foundations/Logic/Model.lean
@@ -17,12 +17,11 @@ public import Cslib.Logics.HML.Basic
 This file is a **draft** proposal for how CSLib might factor out useful semantic concepts across
 different logics, in order to share notation and basic results. Some concepts we aim to unify are:
 
-- A satisfaction relation: `Models α β` (resp. `ParamModels α β`) indicates that a "model" `M : β`
-carries a satisfaction relation `Satisfies : β → α → Prop` over the "proposition" type α (resp.
-a local `SatisfiesAt : (b : β) → (Param b) → α → Prop`). Examples are `Modal.Satisfies` and
-`HML.Satisfies`.
+- A satisfaction relation: `HasEntails Model Formula` indicates that a "model" `M : Model`
+carries a satisfaction relation `Entails : Model → Formula → Prop` over the "proposition" type
+`Formula`. Examples are `Modal.Satisfies` and `HML.Satisfies`.
 - Soundness and completeness wrt an inference system.
-- The `theory` associated to a parameter, and the `logic` associated to a class of models. This
+- The `theory` associated to a single model, and the `logic` associated to a set of models. This
 captures `HML.theory`, `Modal.theory` and `Modal.logic`.
 
 Further developments could include relating different models of a given logic, models of
@@ -33,117 +32,112 @@ public section
 
 namespace Cslib.Logic
 
-/-- Objects of type `β` carry a forcing relation with the proposition type `α`. -/
-class Models (α : outParam Type*) (β : Type*) where
-  /-- `Satisfies b a` has the intended semantics "`a` is valid in the model `b`". -/
-  Satisfies : β → α → Prop
+/-- Objects of type `Model` carry a forcing relation with the proposition type `Formula`. -/
+class HasEntails (Model : Type*) (Formula : outParam Type*) where
+  /-- `Entails b a` has the intended semantics "`a` is valid in the model `b`". -/
+  Entails : Model → Formula → Prop
 
-scoped notation "⊨[" b "] " a => Models.Satisfies b a
-
-/-- Objects of type `β` carry a forcing relation worlds of type `γ` and the proposition type `α`. -/
-class ParamModels (α : outParam Type*) (β : Type*) where
-  Param : β → Type*
-  /-- Forcing relation associated to each parameter. -/
-  SatisfiesAt (b : β) : (Param b) → α → Prop
-
-scoped notation w " ⊨[" b "] " a => ParamModels.SatisfiesAt b w a
-
-instance ParamModels.toModels {α β : Type*} [ParamModels α β] : Models α β where
-  Satisfies M A := ∀ w : ParamModels.Param M, w ⊨[M] A
+scoped notation M " ⊨ " A => HasEntails.Entails M A
 
 /-- Bundled interpretation function. -/
-class HasInterp (α : outParam Type*) (β : Type*) where
+class HasInterp (Model : Type*) (Formula : outParam Type*) where
   /-- Type carrying interpretation. -/
-  Ground : β → Type*
+  Ground : Model → Type*
   /-- Interpret a proposition in a model. -/
-  interp : (b : β) → α → Ground b
+  interp : (M : Model) → Formula → Ground M
 
 /-- An `InterpModel` consists of an interpretation function, and a set specifying which
   interpretations are considered valid. -/
-class InterpModels (α : outParam (Type*)) (β : Type*) extends HasInterp α β where
+class HasInterpEntails (Model : Type*) (Formula : outParam Type*) extends
+    HasInterp Model Formula where
   /-- The set of valid interpretations. -/
-  filter (b : β) : Set (Ground b)
+  filter (M : Model) : Set (Ground M)
 
-instance InterpModels.instModels {α β : Type*} [InterpModels α β] : Models α β where
-  Satisfies b a := HasInterp.interp b a ∈ filter b
+instance HasInterpEntails.instHasEntails {Model Formula : Type*}
+    [HasInterpEntails Model Formula] : HasEntails Model Formula where
+  Entails b a := HasInterp.interp b a ∈ filter b
 
 namespace HasInterp
 
-class AlgebraicAnd (α β : Type*) [HasInterp α β] [HasAnd α] [∀ b : β, Min (Ground b)] where
-  interp_and_eq (M : β) (x y : α) : interp M (x ∧ y) = interp M x ⊓ interp M y
+class AlgebraicAnd (Model Formula : Type*) [HasInterp Model Formula] [HasAnd Formula]
+    [∀ M : Model, Min (Ground M)] where
+  interp_and_eq (M : Model) (x y : Formula) : interp M (x ∧ y) = interp M x ⊓ interp M y
 
-class AlgebraicOr (α β : Type*) [HasInterp α β] [HasOr α] [∀ b : β, Max (Ground b)] where
-  interp_or_eq (M : β) (x y : α) : interp M (x ∨ y) = interp M x ⊔ interp M y
+class AlgebraicOr (Model Formula : Type*) [HasInterp Model Formula] [HasOr Formula]
+    [∀ M : Model, Max (Ground M)] where
+  interp_or_eq (M : Model) (x y : Formula) : interp M (x ∨ y) = interp M x ⊔ interp M y
 
-class AlgebraicImpl (α β : Type*) [HasInterp α β] [HasImpl α] [∀ b : β, HImp (Ground b)] where
-  interp_impl_eq (M : β) (x y : α) : interp M (x → y) = interp M x ⇨ interp M y
+class AlgebraicImpl (Model Formula : Type*) [HasInterp Model Formula] [HasImpl Formula]
+    [∀ M : Model, HImp (Ground M)] where
+  interp_impl_eq (M : Model) (x y : Formula) : interp M (x → y) = interp M x ⇨ interp M y
 
-class AlgebraicNot (α β : Type*) [HasInterp α β] [HasNot α] [∀ b : β, Compl (Ground b)] where
-  interp_not_eq (M : β) (x y : α) : interp M (¬ x) = (interp M x)ᶜ
+class AlgebraicNot (Model Formula : Type*) [HasInterp Model Formula] [HasNot Formula]
+    [∀ M : Model, Compl (Ground M)] where
+  interp_not_eq (M : Model) (x y : Formula) : interp M (¬ x) = (interp M x)ᶜ
 
 end HasInterp
 
-open Models ParamModels InferenceSystem
+open HasEntails InferenceSystem
 
-variable {α β T} [Models α β] [InferenceSystem T α]
+variable {Model Formula T} [HasEntails Model Formula] [InferenceSystem T Formula]
 
-def SoundFor (α β T) [Models α β] [InferenceSystem T α] (S : Set β) : Prop :=
-  ∀ (A : α), DerivableIn T A → ∀ M ∈ S, ⊨[M] A
+def SoundFor (Model Formula T) [HasEntails Model Formula] [InferenceSystem T Formula]
+    (S : Set Model) : Prop := ∀ (A : Formula), DerivableIn T A → ∀ M ∈ S, M ⊨ A
 
-lemma SoundFor.subset {S S' : Set β} (hS : S ⊆ S') : SoundFor α β T S' → SoundFor α β T S :=
-  fun h A hA M hM => h A hA M (hS hM)
+lemma SoundFor.subset {S S' : Set Model} (hS : S ⊆ S') :
+    SoundFor Model Formula T S' → SoundFor Model Formula T S := fun h A hA M hM => h A hA M (hS hM)
 
-def CompleteFor (α β T : Type*) [Models α β] [InferenceSystem T α] (S : Set β) : Prop :=
-  ∀ A : α, (∀ M ∈ S, ⊨[M] A) → DerivableIn T A
+def CompleteFor (Model Formula T : Type*) [HasEntails Model Formula] [InferenceSystem T Formula]
+    (S : Set Model) : Prop := ∀ A : Formula, (∀ M ∈ S, M ⊨ A) → DerivableIn T A
 
-lemma CompleteFor.supset {S S' : Set β} (hS : S ⊆ S') :
-    CompleteFor α β T S → CompleteFor α β T S' := fun h A hA => h A (fun M hM => hA M (hS hM))
+lemma CompleteFor.supset {S S' : Set Model} (hS : S ⊆ S') :
+    CompleteFor Model Formula T S → CompleteFor Model Formula T S' :=
+  fun h A hA => h A (fun M hM => hA M (hS hM))
 
-def IsCompleteModel (α β T) [Models α β] [InferenceSystem T α] (M : β) : Prop :=
-  ∀ (A : α), (⊨[M] A) → DerivableIn T A
+def IsCompleteModel (Model Formula T) [HasEntails Model Formula] [InferenceSystem T Formula]
+    (M : Model) : Prop := ∀ (A : Formula), (M ⊨ A) → DerivableIn T A
 
-def ParamModels.theory {α β : Type*} [ParamModels α β] {M : β} (w : Param M) : Set α :=
-  {A : α | w ⊨[M] A}
+def HasEntails.theory {Model Formula : Type*} [HasEntails Model Formula] (M : Model) :
+    Set Formula := {A : Formula | M ⊨ A}
 
-def Models.logic {α β : Type*} [Models α β] (S : Set β) : Set α := {A | ∀ b ∈ S, ⊨[b] A}
+def HasEntails.logic {Model Formula : Type*} [HasEntails Model Formula] (S : Set Model) :
+    Set Formula := {A | ∀ M ∈ S, M ⊨ A}
 
-structure BundledModel (Atom : Type*) where
-  World : Type*
-  model : Modal.Model World Atom
+/-! ### Modal logic
 
-def Modal.Model.toBundledModel {World Atom : Type*} (M : Modal.Model World Atom) :
-  BundledModel Atom := {World := World, model := M}
+NB: we define entailment for pairs `(M, w)` of `M : Modal.Model World Atom` and a world `w`.
+-/
 
-/-- Instance using the bundled design. -/
-instance {Atom : Type*} : ParamModels (Modal.Proposition Atom) (BundledModel Atom) where
-  Param M := M.World
-  SatisfiesAt M w A := Modal.Satisfies M.model w A
-
-example {World Atom : Type*} (S : Set (Modal.Model World Atom)) :
-    Modal.logic S = Models.logic (Modal.Model.toBundledModel '' S) := by
-  simp [Models.logic]
-  rfl
-
-example {World Atom : Type*} (m : Modal.Model World Atom) (w : World) :
-    Modal.theory m w = ParamModels.theory (M := m.toBundledModel) w := rfl
+section Modal
 
 /-- Instance for "local forcing" (ie at the specific world) using unbundled design. -/
 instance {Atom World : Type*} :
-    Models (Modal.Proposition Atom) (Modal.Model World Atom × World) where
-  Satisfies M A := Modal.Satisfies M.1 M.2 A
+    HasEntails (Modal.Model World Atom × World) (Modal.Proposition Atom) where
+  Entails M A := Modal.Satisfies M.1 M.2 A
 
 /-- Global forcing in the unbundled design. -/
 instance {Atom World : Type*} :
-    Models (Modal.Proposition Atom) (Modal.Model World Atom) where
-  Satisfies M A := ∀ w : World, Modal.Satisfies M w A
+    HasEntails (Modal.Model World Atom) (Modal.Proposition Atom) where
+  Entails M A := ∀ w : World, Modal.Satisfies M w A
+
+example {World Atom : Type*} (M : Modal.Model World Atom) (w : World) (A : Modal.Proposition Atom) :
+    Modal.Satisfies M w A ↔ (M, w) ⊨ A := by rfl
+
+example {World Atom : Type*} (M : Modal.Model World Atom) (A : Modal.Proposition Atom) :
+    A.valid {M} ↔ M ⊨ A := by simp [Entails]; rfl
 
 example {World Atom : Type*} (M : Modal.Model World Atom) (w : World) :
-    Modal.theory M w = Models.logic {(M, w)} := by
-  simp [Modal.theory, logic]
-  rfl
+    Modal.theory M w = HasEntails.theory (M, w) := by rfl
 
 example {World Atom : Type*} (S : Set (Modal.Model World Atom)) :
-    Modal.logic S = Models.logic S := rfl
+    Modal.logic S = HasEntails.logic S := rfl
+
+end Modal
+
+/-! ### Propositional logic
+
+Examples for interpretation-style models of propositional logic.
+-/
 
 namespace PL
 
@@ -167,31 +161,31 @@ def HeytingModel.interp (M : HeytingModel Atom) : Proposition Atom → M.H
   | Proposition.or A B => M.interp A ⊔ M.interp B
   | Proposition.impl A B => M.interp A ⇨ M.interp B
 
-instance : InterpModels (Proposition Atom) (HeytingModel Atom) where
+instance : HasInterpEntails (HeytingModel Atom) (Proposition Atom) where
   Ground M := M.H
   interp := HeytingModel.interp
   filter _ := {⊤}
 
 instance (M : HeytingModel Atom) : GeneralizedHeytingAlgebra (HasInterp.Ground M) := M.inst
 
-instance : HasInterp.AlgebraicAnd (Proposition Atom) (HeytingModel Atom) where
+instance : HasInterp.AlgebraicAnd (HeytingModel Atom) (Proposition Atom) where
   interp_and_eq _ _ _ := rfl
 
-instance : HasInterp.AlgebraicOr (Proposition Atom) (HeytingModel Atom) where
+instance : HasInterp.AlgebraicOr (HeytingModel Atom) (Proposition Atom) where
   interp_or_eq _ _ _ := rfl
 
-instance : HasInterp.AlgebraicImpl (Proposition Atom) (HeytingModel Atom) where
+instance : HasInterp.AlgebraicImpl (HeytingModel Atom) (Proposition Atom) where
   interp_impl_eq _ _ _ := rfl
 
 theorem HeytingModel.sound [DecidableEq Atom] {T : Theory Atom} :
-    SoundFor (Proposition Atom) (HeytingModel Atom) T {M | ∀ A ∈ T, interp M A = ⊤} :=
+    SoundFor (HeytingModel Atom) (Proposition Atom) T {M | ∀ A ∈ T, interp M A = ⊤} :=
   sorry -- i have this in a branch
 
 def Theory.lindenbaum [DecidableEq Atom] (T : Theory Atom) : HeytingModel Atom :=
   sorry -- usual Heyting-algebra of propositions modulo equivalence
 
 theorem Theory.lindenbaum_complete [DecidableEq Atom] {T : Theory Atom} :
-    IsCompleteModel (Proposition Atom) (HeytingModel Atom) T T.lindenbaum :=
+    IsCompleteModel (HeytingModel Atom) (Proposition Atom) T T.lindenbaum :=
   sorry -- also in a branch
 
 abbrev Valuation (Atom : Type*) := Atom → Prop
@@ -202,22 +196,21 @@ def Valuation.interp (v : Valuation Atom) : Proposition Atom → Prop
   | .or A B => v.interp A ∨ v.interp B
   | .impl A B => v.interp A → v.interp B
 
-instance : InterpModels (Proposition Atom) (Valuation Atom) where
+instance : HasInterpEntails (Valuation Atom) (Proposition Atom) where
   Ground _ := Prop
   interp v A := v.interp A
   filter _ := {True}
 
 end PL
 
+/-! ### Hindley-Miller logic -/
+
 variable {State Label : Type*}
 
-instance : ParamModels (HML.Proposition Label) (LTS State Label) where
-  Param _ := State
-  SatisfiesAt := HML.Satisfies
+instance : HasEntails  (LTS State Label × State) (HML.Proposition Label) where
+  Entails M := HML.Satisfies M.1 M.2
 
 example (lts : LTS State Label) (s : State) :
-    HML.theory lts s = ParamModels.theory (M := lts) s := by
-  simp [theory, HML.theory]
-  rfl
+  HML.theory lts s = HasEntails.theory (lts, s) := by rfl
 
 end Cslib.Logic

--- a/Cslib/Foundations/Logic/Model.lean
+++ b/Cslib/Foundations/Logic/Model.lean
@@ -114,6 +114,7 @@ structure BundledModel (Atom : Type*) where
 def Modal.Model.toBundledModel {World Atom : Type*} (M : Modal.Model World Atom) :
   BundledModel Atom := {World := World, model := M}
 
+/-- Instance using the bundled design. -/
 instance {Atom : Type*} : ParamModels (Modal.Proposition Atom) (BundledModel Atom) where
   Param M := M.World
   SatisfiesAt M w A := Modal.Satisfies M.model w A
@@ -124,9 +125,25 @@ example {World Atom : Type*} (S : Set (Modal.Model World Atom)) :
   rfl
 
 example {World Atom : Type*} (m : Modal.Model World Atom) (w : World) :
-    Modal.theory m w = ParamModels.theory (M := m.toBundledModel) w := by
-  simp [theory, ParamModels.theory]
+    Modal.theory m w = ParamModels.theory (M := m.toBundledModel) w := rfl
+
+/-- Instance for "local forcing" (ie at the specific world) using unbundled design. -/
+instance {Atom World : Type*} :
+    Models (Modal.Proposition Atom) (Modal.Model World Atom × World) where
+  Satisfies M A := Modal.Satisfies M.1 M.2 A
+
+/-- Global forcing in the unbundled design. -/
+instance {Atom World : Type*} :
+    Models (Modal.Proposition Atom) (Modal.Model World Atom) where
+  Satisfies M A := ∀ w : World, Modal.Satisfies M w A
+
+example {World Atom : Type*} (M : Modal.Model World Atom) (w : World) :
+    Modal.theory M w = Models.logic {(M, w)} := by
+  simp [Modal.theory, logic]
   rfl
+
+example {World Atom : Type*} (S : Set (Modal.Model World Atom)) :
+    Modal.logic S = Models.logic S := rfl
 
 namespace PL
 

--- a/Cslib/Foundations/Logic/Model.lean
+++ b/Cslib/Foundations/Logic/Model.lean
@@ -165,6 +165,19 @@ theorem Theory.lindenbaum_complete [DecidableEq Atom] {T : Theory Atom} :
     IsCompleteModel (Proposition Atom) (HeytingModel Atom) T T.lindenbaum :=
   sorry -- also in a branch
 
+abbrev Valuation (Atom : Type*) := Atom → Prop
+
+def Valuation.interp (v : Valuation Atom) : Proposition Atom → Prop
+  | .atom x => v x
+  | .and A B => v.interp A ∧ v.interp B
+  | .or A B => v.interp A ∨ v.interp B
+  | .impl A B => v.interp A → v.interp B
+
+instance : InterpModels (Proposition Atom) (Valuation Atom) where
+  Ground _ := Prop
+  interp v A := v.interp A
+  filter _ := {True}
+
 end PL
 
 end Cslib.Logic

--- a/Cslib/Foundations/Logic/Model.lean
+++ b/Cslib/Foundations/Logic/Model.lean
@@ -18,22 +18,22 @@ public section
 namespace Cslib.Logic
 
 /-- Objects of type `β` carry a forcing relation with the proposition type `α`. -/
-class ModelClass (α : outParam Type*) (β : Type*) where
-  /-- `Forces b a` has the intended semantics "`a` is valid in the model `b`". -/
-  Forces : β → α → Prop
+class Models (α : outParam Type*) (β : Type*) where
+  /-- `Satisfies b a` has the intended semantics "`a` is valid in the model `b`". -/
+  Satisfies : β → α → Prop
 
-scoped notation "⊨[" b "] " a => ModelClass.Forces b a
+scoped notation "⊨[" b "] " a => Models.Satisfies b a
 
 /-- Objects of type `β` carry a forcing relation worlds of type `γ` and the proposition type `α`. -/
-class ParamModelClass (α : outParam Type*) (β : Type*) where
+class ParamModels (α : outParam Type*) (β : Type*) where
   Param : β → Type*
   /-- Forcing relation associated to each parameter. -/
-  ForcesAt (b : β) : (Param b) → α → Prop
+  SatisfiesAt (b : β) : (Param b) → α → Prop
 
-scoped notation w " ⊨[" b "] " a => ParamModelClass.ForcesAt b w a
+scoped notation w " ⊨[" b "] " a => ParamModels.SatisfiesAt b w a
 
-instance ParamModelClass.toModelClass {α β : Type*} [ParamModelClass α β] : ModelClass α β where
-  Forces M A := ∀ w : ParamModelClass.Param M, w ⊨[M] A
+instance ParamModels.toModels {α β : Type*} [ParamModels α β] : Models α β where
+  Satisfies M A := ∀ w : ParamModels.Param M, w ⊨[M] A
 
 /-- Bundled interpretation function. -/
 class HasInterp (α : outParam Type*) (β : Type*) where
@@ -44,12 +44,12 @@ class HasInterp (α : outParam Type*) (β : Type*) where
 
 /-- An `InterpModel` consists of an interpretation function, and a set specifying which
   interpretations are considered valid. -/
-class InterpModelClass (α : outParam (Type*)) (β : Type*) extends HasInterp α β where
+class InterpModels (α : outParam (Type*)) (β : Type*) extends HasInterp α β where
   /-- The set of valid interpretations. -/
   filter (b : β) : Set (Ground b)
 
-instance InterpModelClass.instModelClass {α β : Type*} [InterpModelClass α β] : ModelClass α β where
-  Forces b a := HasInterp.interp b a ∈ filter b
+instance InterpModels.instModels {α β : Type*} [InterpModels α β] : Models α β where
+  Satisfies b a := HasInterp.interp b a ∈ filter b
 
 namespace HasInterp
 
@@ -67,29 +67,29 @@ class AlgebraicNot (α β : Type*) [HasInterp α β] [HasNot α] [∀ b : β, Co
 
 end HasInterp
 
-open ModelClass ParamModelClass InferenceSystem
+open Models ParamModels InferenceSystem
 
-variable {α β T} [ModelClass α β] [InferenceSystem T α]
+variable {α β T} [Models α β] [InferenceSystem T α]
 
-def SoundFor (α β T) [ModelClass α β] [InferenceSystem T α] (S : Set β) : Prop :=
+def SoundFor (α β T) [Models α β] [InferenceSystem T α] (S : Set β) : Prop :=
   ∀ (A : α), DerivableIn T A → ∀ M ∈ S, ⊨[M] A
 
 lemma SoundFor.subset {S S' : Set β} (hS : S ⊆ S') : SoundFor α β T S' → SoundFor α β T S :=
   fun h A hA M hM => h A hA M (hS hM)
 
-def CompleteFor (α β T : Type*) [ModelClass α β] [InferenceSystem T α] (S : Set β) : Prop :=
+def CompleteFor (α β T : Type*) [Models α β] [InferenceSystem T α] (S : Set β) : Prop :=
   ∀ A : α, (∀ M ∈ S, ⊨[M] A) → DerivableIn T A
 
 lemma CompleteFor.supset {S S' : Set β} (hS : S ⊆ S') :
     CompleteFor α β T S → CompleteFor α β T S' := fun h A hA => h A (fun M hM => hA M (hS hM))
 
-def IsCompleteModel (α β T) [ModelClass α β] [InferenceSystem T α] (M : β) : Prop :=
+def IsCompleteModel (α β T) [Models α β] [InferenceSystem T α] (M : β) : Prop :=
   ∀ (A : α), (⊨[M] A) → DerivableIn T A
 
-def ParamModelClass.theory {α β : Type*} [ParamModelClass α β] {M : β} (w : Param M) : Set α :=
+def ParamModels.theory {α β : Type*} [ParamModels α β] {M : β} (w : Param M) : Set α :=
   {A : α | w ⊨[M] A}
 
-def ModelClass.logic {α β : Type*} [ModelClass α β] (S : Set β) : Set α := {A | ∀ b ∈ S, ⊨[b] A}
+def Models.logic {α β : Type*} [Models α β] (S : Set β) : Set α := {A | ∀ b ∈ S, ⊨[b] A}
 
 namespace Modal
 
@@ -100,18 +100,18 @@ structure BundledModel (Atom : Type*) where
 def Model.toBundledModel {World Atom : Type*} (M : Model World Atom) : BundledModel Atom :=
   {World := World, model := M}
 
-instance {Atom : Type*} : ParamModelClass (Proposition Atom) (BundledModel Atom) where
+instance {Atom : Type*} : ParamModels (Proposition Atom) (BundledModel Atom) where
   Param M := M.World
-  ForcesAt M w A := Satisfies M.model w A
+  SatisfiesAt M w A := Satisfies M.model w A
 
 example {World Atom : Type*} (S : Set (Model World Atom)) :
-    logic S = ModelClass.logic (Model.toBundledModel '' S) := by
-  simp [ModelClass.logic]
+    logic S = Models.logic (Model.toBundledModel '' S) := by
+  simp [Models.logic]
   rfl
 
 example {World Atom : Type*} (m : Model World Atom) (w : World) :
-    theory m w = ParamModelClass.theory (M := m.toBundledModel) w := by
-  simp [theory, ParamModelClass.theory]
+    theory m w = ParamModels.theory (M := m.toBundledModel) w := by
+  simp [theory, ParamModels.theory]
   rfl
 
 end Modal
@@ -138,7 +138,7 @@ def HeytingModel.interp (M : HeytingModel Atom) : Proposition Atom → M.H
   | Proposition.or A B => M.interp A ⊔ M.interp B
   | Proposition.impl A B => M.interp A ⇨ M.interp B
 
-instance : InterpModelClass (Proposition Atom) (HeytingModel Atom) where
+instance : InterpModels (Proposition Atom) (HeytingModel Atom) where
   Ground M := M.H
   interp := HeytingModel.interp
   filter _ := {⊤}

--- a/Cslib/Foundations/Logic/Model.lean
+++ b/Cslib/Foundations/Logic/Model.lean
@@ -9,20 +9,23 @@ module
 public import Cslib.Foundations.Logic.Connectives
 public import Cslib.Foundations.Logic.InferenceSystem
 public import Cslib.Logics.Modal.Basic
+public import Cslib.Logics.Propositional.NaturalDeduction.Basic
+
+/-! # Semantics for logical systems -/
 
 public section
 
 namespace Cslib.Logic
 
 /-- Objects of type `β` carry a forcing relation with the proposition type `α`. -/
-class ModelClass (α : outParam (Type*)) (β : Type*) where
+class ModelClass (α : outParam Type*) (β : Type*) where
   /-- `Forces b a` has the intended semantics "`a` is valid in the model `b`". -/
   Forces : β → α → Prop
 
 scoped notation "⊨[" b "] " a => ModelClass.Forces b a
 
 /-- Objects of type `β` carry a forcing relation worlds of type `γ` and the proposition type `α`. -/
-class ParamModelClass (α : outParam (Type*)) (β : Type*) where
+class ParamModelClass (α : outParam Type*) (β : Type*) where
   Param : β → Type*
   /-- Forcing relation associated to each parameter. -/
   ForcesAt (b : β) : (Param b) → α → Prop
@@ -33,42 +36,55 @@ instance ParamModelClass.toModelClass {α β : Type*} [ParamModelClass α β] : 
   Forces M A := ∀ w : ParamModelClass.Param M, w ⊨[M] A
 
 /-- Bundled interpretation function. -/
-structure Interp (α β : Type*) where
+class HasInterp (α : outParam Type*) (β : Type*) where
+  /-- Type carrying interpretation. -/
+  Ground : β → Type*
   /-- Interpret a proposition in a model. -/
-  interp : α → β
+  interp : (b : β) → α → Ground b
 
 /-- An `InterpModel` consists of an interpretation function, and a set specifying which
   interpretations are considered valid. -/
-structure InterpModel (α β : Type*) extends Interp α β where
+class InterpModelClass (α : outParam (Type*)) (β : Type*) extends HasInterp α β where
   /-- The set of valid interpretations. -/
-  filter : Set β
+  filter (b : β) : Set (Ground b)
 
-instance {α β : Type*} : ModelClass α (InterpModel α β) where
-  Forces M a := M.interp a ∈ M.filter
+instance InterpModelClass.instModelClass {α β : Type*} [InterpModelClass α β] : ModelClass α β where
+  Forces b a := HasInterp.interp b a ∈ filter b
 
-namespace Interp
+namespace HasInterp
 
-class AlgebraicAnd {α β : Type*} [HasAnd α] [Min β] (M : Interp α β) where
-  interp_and_eq (x y : α) : M.interp (x ∧ y) = M.interp x ⊓ M.interp y
+class AlgebraicAnd (α β : Type*) [HasInterp α β] [HasAnd α] [∀ b : β, Min (Ground b)] where
+  interp_and_eq (M : β) (x y : α) : interp M (x ∧ y) = interp M x ⊓ interp M y
 
-class AlgebraicOr {α β : Type*} [HasOr α] [Max β] (M : Interp α β) where
-  interp_or_eq (x y : α) : M.interp (x ∨ y) = M.interp x ⊔ M.interp y
+class AlgebraicOr (α β : Type*) [HasInterp α β] [HasOr α] [∀ b : β, Max (Ground b)] where
+  interp_or_eq (M : β) (x y : α) : interp M (x ∨ y) = interp M x ⊔ interp M y
 
-class AlgebraicImpl {α β : Type*} [HasImpl α] [HImp β] (M : Interp α β) where
-  interp_impl_eq (x y : α) : M.interp (x → y) = M.interp x ⇨ M.interp y
+class AlgebraicImpl (α β : Type*) [HasInterp α β] [HasImpl α] [∀ b : β, HImp (Ground b)] where
+  interp_impl_eq (M : β) (x y : α) : interp M (x → y) = interp M x ⇨ interp M y
 
-class AlgebraicNot {α β : Type*} [HasNot α] [Compl β] (M : Interp α β) where
-  interp_not_eq (x : α) : M.interp (¬ x) = (M.interp x)ᶜ
+class AlgebraicNot (α β : Type*) [HasInterp α β] [HasNot α] [∀ b : β, Compl (Ground b)] where
+  interp_not_eq (M : β) (x y : α) : interp M (¬ x) = (interp M x)ᶜ
 
-end Interp
+end HasInterp
 
 open ModelClass ParamModelClass InferenceSystem
 
-def Sound {α β S : Type*} [ModelClass α β] [InferenceSystem S α] : Prop :=
-  ∀ (A : α) (b : β) , DerivableIn S A → ⊨[b] A
+variable {α β T} [ModelClass α β] [InferenceSystem T α]
 
-def Complete {α β S : Type*} [ModelClass α β] [InferenceSystem S α] : Prop :=
-  ∀ A : α, (∀ b : β, ⊨[b] A) → DerivableIn S A
+def SoundFor (α β T) [ModelClass α β] [InferenceSystem T α] (S : Set β) : Prop :=
+  ∀ (A : α), DerivableIn T A → ∀ M ∈ S, ⊨[M] A
+
+lemma SoundFor.subset {S S' : Set β} (hS : S ⊆ S') : SoundFor α β T S' → SoundFor α β T S :=
+  fun h A hA M hM => h A hA M (hS hM)
+
+def CompleteFor (α β T : Type*) [ModelClass α β] [InferenceSystem T α] (S : Set β) : Prop :=
+  ∀ A : α, (∀ M ∈ S, ⊨[M] A) → DerivableIn T A
+
+lemma CompleteFor.supset {S S' : Set β} (hS : S ⊆ S') :
+    CompleteFor α β T S → CompleteFor α β T S' := fun h A hA => h A (fun M hM => hA M (hS hM))
+
+def IsCompleteModel (α β T) [ModelClass α β] [InferenceSystem T α] (M : β) : Prop :=
+  ∀ (A : α), (⊨[M] A) → DerivableIn T A
 
 def ParamModelClass.theory {α β : Type*} [ParamModelClass α β] {M : β} (w : Param M) : Set α :=
   {A : α | w ⊨[M] A}
@@ -93,6 +109,62 @@ example {World Atom : Type*} (S : Set (Model World Atom)) :
   simp [ModelClass.logic]
   rfl
 
+example {World Atom : Type*} (m : Model World Atom) (w : World) :
+    theory m w = ParamModelClass.theory (M := m.toBundledModel) w := by
+  simp [theory, ParamModelClass.theory]
+  rfl
+
 end Modal
+
+namespace PL
+
+variable {Atom : Type*}
+
+instance : HasAnd (Proposition Atom) := ⟨Proposition.and⟩
+instance : HasOr (Proposition Atom) := ⟨Proposition.or⟩
+instance : HasImpl (Proposition Atom) := ⟨Proposition.impl⟩
+instance [Bot Atom] : HasNot (Proposition Atom) := ⟨Proposition.neg⟩
+
+structure HeytingModel (Atom : Type*) where
+  H : Type*
+  [inst : GeneralizedHeytingAlgebra H]
+  v : Atom → H
+
+instance (M : HeytingModel Atom) : GeneralizedHeytingAlgebra M.H := M.inst
+
+def HeytingModel.interp (M : HeytingModel Atom) : Proposition Atom → M.H
+  | Proposition.atom x => M.v x
+  | Proposition.and A B => M.interp A ⊓ M.interp B
+  | Proposition.or A B => M.interp A ⊔ M.interp B
+  | Proposition.impl A B => M.interp A ⇨ M.interp B
+
+instance : InterpModelClass (Proposition Atom) (HeytingModel Atom) where
+  Ground M := M.H
+  interp := HeytingModel.interp
+  filter _ := {⊤}
+
+instance (M : HeytingModel Atom) : GeneralizedHeytingAlgebra (HasInterp.Ground M) := M.inst
+
+instance : HasInterp.AlgebraicAnd (Proposition Atom) (HeytingModel Atom) where
+  interp_and_eq _ _ _ := rfl
+
+instance : HasInterp.AlgebraicOr (Proposition Atom) (HeytingModel Atom) where
+  interp_or_eq _ _ _ := rfl
+
+instance : HasInterp.AlgebraicImpl (Proposition Atom) (HeytingModel Atom) where
+  interp_impl_eq _ _ _ := rfl
+
+theorem HeytingModel.sound [DecidableEq Atom] {T : Theory Atom} :
+    SoundFor (Proposition Atom) (HeytingModel Atom) T {M | ∀ A ∈ T, interp M A = ⊤} :=
+  sorry -- i have this in a branch
+
+def Theory.lindenbaum [DecidableEq Atom] (T : Theory Atom) : HeytingModel Atom :=
+  sorry -- usual Heyting-algebra of propositions modulo equivalence
+
+theorem Theory.lindenbaum_complete [DecidableEq Atom] {T : Theory Atom} :
+    IsCompleteModel (Proposition Atom) (HeytingModel Atom) T T.lindenbaum :=
+  sorry -- also in a branch
+
+end PL
 
 end Cslib.Logic

--- a/Cslib/Foundations/Logic/Model.lean
+++ b/Cslib/Foundations/Logic/Model.lean
@@ -10,8 +10,24 @@ public import Cslib.Foundations.Logic.Connectives
 public import Cslib.Foundations.Logic.InferenceSystem
 public import Cslib.Logics.Modal.Basic
 public import Cslib.Logics.Propositional.NaturalDeduction.Basic
+public import Cslib.Logics.HML.Basic
 
-/-! # Semantics for logical systems -/
+/-! # Semantics for logical systems
+
+This file is a **draft** proposal for how CSLib might factor out useful semantic concepts across
+different logics, in order to share notation and basic results. Some concepts we aim to unify are:
+
+- A satisfaction relation: `Models α β` (resp. `ParamModels α β`) indicates that a "model" `M : β`
+carries a satisfaction relation `Satisfies : β → α → Prop` over the "proposition" type α (resp.
+a local `SatisfiesAt : (b : β) → (Param b) → α → Prop`). Examples are `Modal.Satisfies` and
+`HML.Satisfies`.
+- Soundness and completeness wrt an inference system.
+- The `theory` associated to a parameter, and the `logic` associated to a class of models. This
+captures `HML.theory`, `Modal.theory` and `Modal.logic`.
+
+Further developments could include relating different models of a given logic, models of
+higher-order logics (once they exist in CSLib), and ...
+-/
 
 public section
 
@@ -91,30 +107,26 @@ def ParamModels.theory {α β : Type*} [ParamModels α β] {M : β} (w : Param M
 
 def Models.logic {α β : Type*} [Models α β] (S : Set β) : Set α := {A | ∀ b ∈ S, ⊨[b] A}
 
-namespace Modal
-
 structure BundledModel (Atom : Type*) where
   World : Type*
-  model : Model World Atom
+  model : Modal.Model World Atom
 
-def Model.toBundledModel {World Atom : Type*} (M : Model World Atom) : BundledModel Atom :=
-  {World := World, model := M}
+def Modal.Model.toBundledModel {World Atom : Type*} (M : Modal.Model World Atom) :
+  BundledModel Atom := {World := World, model := M}
 
-instance {Atom : Type*} : ParamModels (Proposition Atom) (BundledModel Atom) where
+instance {Atom : Type*} : ParamModels (Modal.Proposition Atom) (BundledModel Atom) where
   Param M := M.World
-  SatisfiesAt M w A := Satisfies M.model w A
+  SatisfiesAt M w A := Modal.Satisfies M.model w A
 
-example {World Atom : Type*} (S : Set (Model World Atom)) :
-    logic S = Models.logic (Model.toBundledModel '' S) := by
+example {World Atom : Type*} (S : Set (Modal.Model World Atom)) :
+    Modal.logic S = Models.logic (Modal.Model.toBundledModel '' S) := by
   simp [Models.logic]
   rfl
 
-example {World Atom : Type*} (m : Model World Atom) (w : World) :
-    theory m w = ParamModels.theory (M := m.toBundledModel) w := by
+example {World Atom : Type*} (m : Modal.Model World Atom) (w : World) :
+    Modal.theory m w = ParamModels.theory (M := m.toBundledModel) w := by
   simp [theory, ParamModels.theory]
   rfl
-
-end Modal
 
 namespace PL
 
@@ -179,5 +191,16 @@ instance : InterpModels (Proposition Atom) (Valuation Atom) where
   filter _ := {True}
 
 end PL
+
+variable {State Label : Type*}
+
+instance : ParamModels (HML.Proposition Label) (LTS State Label) where
+  Param _ := State
+  SatisfiesAt := HML.Satisfies
+
+example (lts : LTS State Label) (s : State) :
+    HML.theory lts s = ParamModels.theory (M := lts) s := by
+  simp [theory, HML.theory]
+  rfl
 
 end Cslib.Logic

--- a/Cslib/Foundations/Logic/ModelOld.lean
+++ b/Cslib/Foundations/Logic/ModelOld.lean
@@ -1,0 +1,223 @@
+/-
+Copyright (c) 2025 Thomas Waring. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Thomas Waring
+-/
+
+module
+
+public import Cslib.Foundations.Logic.Connectives
+public import Cslib.Foundations.Logic.InferenceSystem
+public import Cslib.Logics.Modal.Basic
+public import Cslib.Logics.Propositional.NaturalDeduction.Basic
+public import Cslib.Logics.HML.Basic
+
+/-! # Semantics for logical systems
+
+This file is a **draft** proposal for how CSLib might factor out useful semantic concepts across
+different logics, in order to share notation and basic results. Some concepts we aim to unify are:
+
+- A satisfaction relation: `Models α β` (resp. `ParamModels α β`) indicates that a "model" `M : β`
+carries a satisfaction relation `Satisfies : β → α → Prop` over the "proposition" type α (resp.
+a local `SatisfiesAt : (b : β) → (Param b) → α → Prop`). Examples are `Modal.Satisfies` and
+`HML.Satisfies`.
+- Soundness and completeness wrt an inference system.
+- The `theory` associated to a parameter, and the `logic` associated to a class of models. This
+captures `HML.theory`, `Modal.theory` and `Modal.logic`.
+
+Further developments could include relating different models of a given logic, models of
+higher-order logics (once they exist in CSLib), and ...
+-/
+
+public section
+
+namespace Cslib.Logic
+
+/-- Objects of type `β` carry a forcing relation with the proposition type `α`. -/
+class Models (α : outParam Type*) (β : Type*) where
+  /-- `Satisfies b a` has the intended semantics "`a` is valid in the model `b`". -/
+  Satisfies : β → α → Prop
+
+scoped notation "⊨[" b "] " a => Models.Satisfies b a
+
+/-- Objects of type `β` carry a forcing relation worlds of type `γ` and the proposition type `α`. -/
+class ParamModels (α : outParam Type*) (β : Type*) where
+  Param : β → Type*
+  /-- Forcing relation associated to each parameter. -/
+  SatisfiesAt (b : β) : (Param b) → α → Prop
+
+scoped notation w " ⊨[" b "] " a => ParamModels.SatisfiesAt b w a
+
+instance ParamModels.toModels {α β : Type*} [ParamModels α β] : Models α β where
+  Satisfies M A := ∀ w : ParamModels.Param M, w ⊨[M] A
+
+/-- Bundled interpretation function. -/
+class HasInterp (α : outParam Type*) (β : Type*) where
+  /-- Type carrying interpretation. -/
+  Ground : β → Type*
+  /-- Interpret a proposition in a model. -/
+  interp : (b : β) → α → Ground b
+
+/-- An `InterpModel` consists of an interpretation function, and a set specifying which
+  interpretations are considered valid. -/
+class InterpModels (α : outParam (Type*)) (β : Type*) extends HasInterp α β where
+  /-- The set of valid interpretations. -/
+  filter (b : β) : Set (Ground b)
+
+instance InterpModels.instModels {α β : Type*} [InterpModels α β] : Models α β where
+  Satisfies b a := HasInterp.interp b a ∈ filter b
+
+namespace HasInterp
+
+class AlgebraicAnd (α β : Type*) [HasInterp α β] [HasAnd α] [∀ b : β, Min (Ground b)] where
+  interp_and_eq (M : β) (x y : α) : interp M (x ∧ y) = interp M x ⊓ interp M y
+
+class AlgebraicOr (α β : Type*) [HasInterp α β] [HasOr α] [∀ b : β, Max (Ground b)] where
+  interp_or_eq (M : β) (x y : α) : interp M (x ∨ y) = interp M x ⊔ interp M y
+
+class AlgebraicImpl (α β : Type*) [HasInterp α β] [HasImpl α] [∀ b : β, HImp (Ground b)] where
+  interp_impl_eq (M : β) (x y : α) : interp M (x → y) = interp M x ⇨ interp M y
+
+class AlgebraicNot (α β : Type*) [HasInterp α β] [HasNot α] [∀ b : β, Compl (Ground b)] where
+  interp_not_eq (M : β) (x y : α) : interp M (¬ x) = (interp M x)ᶜ
+
+end HasInterp
+
+open Models ParamModels InferenceSystem
+
+variable {α β T} [Models α β] [InferenceSystem T α]
+
+def SoundFor (α β T) [Models α β] [InferenceSystem T α] (S : Set β) : Prop :=
+  ∀ (A : α), DerivableIn T A → ∀ M ∈ S, ⊨[M] A
+
+lemma SoundFor.subset {S S' : Set β} (hS : S ⊆ S') : SoundFor α β T S' → SoundFor α β T S :=
+  fun h A hA M hM => h A hA M (hS hM)
+
+def CompleteFor (α β T : Type*) [Models α β] [InferenceSystem T α] (S : Set β) : Prop :=
+  ∀ A : α, (∀ M ∈ S, ⊨[M] A) → DerivableIn T A
+
+lemma CompleteFor.supset {S S' : Set β} (hS : S ⊆ S') :
+    CompleteFor α β T S → CompleteFor α β T S' := fun h A hA => h A (fun M hM => hA M (hS hM))
+
+def IsCompleteModel (α β T) [Models α β] [InferenceSystem T α] (M : β) : Prop :=
+  ∀ (A : α), (⊨[M] A) → DerivableIn T A
+
+def ParamModels.theory {α β : Type*} [ParamModels α β] {M : β} (w : Param M) : Set α :=
+  {A : α | w ⊨[M] A}
+
+def Models.logic {α β : Type*} [Models α β] (S : Set β) : Set α := {A | ∀ b ∈ S, ⊨[b] A}
+
+structure BundledModel (Atom : Type*) where
+  World : Type*
+  model : Modal.Model World Atom
+
+def Modal.Model.toBundledModel {World Atom : Type*} (M : Modal.Model World Atom) :
+  BundledModel Atom := {World := World, model := M}
+
+/-- Instance using the bundled design. -/
+instance {Atom : Type*} : ParamModels (Modal.Proposition Atom) (BundledModel Atom) where
+  Param M := M.World
+  SatisfiesAt M w A := Modal.Satisfies M.model w A
+
+example {World Atom : Type*} (S : Set (Modal.Model World Atom)) :
+    Modal.logic S = Models.logic (Modal.Model.toBundledModel '' S) := by
+  simp [Models.logic]
+  rfl
+
+example {World Atom : Type*} (m : Modal.Model World Atom) (w : World) :
+    Modal.theory m w = ParamModels.theory (M := m.toBundledModel) w := rfl
+
+/-- Instance for "local forcing" (ie at the specific world) using unbundled design. -/
+instance {Atom World : Type*} :
+    Models (Modal.Proposition Atom) (Modal.Model World Atom × World) where
+  Satisfies M A := Modal.Satisfies M.1 M.2 A
+
+/-- Global forcing in the unbundled design. -/
+instance {Atom World : Type*} :
+    Models (Modal.Proposition Atom) (Modal.Model World Atom) where
+  Satisfies M A := ∀ w : World, Modal.Satisfies M w A
+
+example {World Atom : Type*} (M : Modal.Model World Atom) (w : World) :
+    Modal.theory M w = Models.logic {(M, w)} := by
+  simp [Modal.theory, logic]
+  rfl
+
+example {World Atom : Type*} (S : Set (Modal.Model World Atom)) :
+    Modal.logic S = Models.logic S := rfl
+
+namespace PL
+
+variable {Atom : Type*}
+
+instance : HasAnd (Proposition Atom) := ⟨Proposition.and⟩
+instance : HasOr (Proposition Atom) := ⟨Proposition.or⟩
+instance : HasImpl (Proposition Atom) := ⟨Proposition.impl⟩
+instance [Bot Atom] : HasNot (Proposition Atom) := ⟨Proposition.neg⟩
+
+structure HeytingModel (Atom : Type*) where
+  H : Type*
+  [inst : GeneralizedHeytingAlgebra H]
+  v : Atom → H
+
+instance (M : HeytingModel Atom) : GeneralizedHeytingAlgebra M.H := M.inst
+
+def HeytingModel.interp (M : HeytingModel Atom) : Proposition Atom → M.H
+  | Proposition.atom x => M.v x
+  | Proposition.and A B => M.interp A ⊓ M.interp B
+  | Proposition.or A B => M.interp A ⊔ M.interp B
+  | Proposition.impl A B => M.interp A ⇨ M.interp B
+
+instance : InterpModels (Proposition Atom) (HeytingModel Atom) where
+  Ground M := M.H
+  interp := HeytingModel.interp
+  filter _ := {⊤}
+
+instance (M : HeytingModel Atom) : GeneralizedHeytingAlgebra (HasInterp.Ground M) := M.inst
+
+instance : HasInterp.AlgebraicAnd (Proposition Atom) (HeytingModel Atom) where
+  interp_and_eq _ _ _ := rfl
+
+instance : HasInterp.AlgebraicOr (Proposition Atom) (HeytingModel Atom) where
+  interp_or_eq _ _ _ := rfl
+
+instance : HasInterp.AlgebraicImpl (Proposition Atom) (HeytingModel Atom) where
+  interp_impl_eq _ _ _ := rfl
+
+theorem HeytingModel.sound [DecidableEq Atom] {T : Theory Atom} :
+    SoundFor (Proposition Atom) (HeytingModel Atom) T {M | ∀ A ∈ T, interp M A = ⊤} :=
+  sorry -- i have this in a branch
+
+def Theory.lindenbaum [DecidableEq Atom] (T : Theory Atom) : HeytingModel Atom :=
+  sorry -- usual Heyting-algebra of propositions modulo equivalence
+
+theorem Theory.lindenbaum_complete [DecidableEq Atom] {T : Theory Atom} :
+    IsCompleteModel (Proposition Atom) (HeytingModel Atom) T T.lindenbaum :=
+  sorry -- also in a branch
+
+abbrev Valuation (Atom : Type*) := Atom → Prop
+
+def Valuation.interp (v : Valuation Atom) : Proposition Atom → Prop
+  | .atom x => v x
+  | .and A B => v.interp A ∧ v.interp B
+  | .or A B => v.interp A ∨ v.interp B
+  | .impl A B => v.interp A → v.interp B
+
+instance : InterpModels (Proposition Atom) (Valuation Atom) where
+  Ground _ := Prop
+  interp v A := v.interp A
+  filter _ := {True}
+
+end PL
+
+variable {State Label : Type*}
+
+instance : ParamModels (HML.Proposition Label) (LTS State Label) where
+  Param _ := State
+  SatisfiesAt := HML.Satisfies
+
+example (lts : LTS State Label) (s : State) :
+    HML.theory lts s = ParamModels.theory (M := lts) s := by
+  simp [theory, HML.theory]
+  rfl
+
+end Cslib.Logic


### PR DESCRIPTION
A proposal for typeclasses expressing that a type of "propositions" has semantics in a type of "models".

## Main definitions

- `Models α β` : objects of type `β` carry a predicate `Satisfies` on objects of type `α`.
- `ParamModels α β` : objects `M : β` carry a satisfaction relation parametrised over some auxiliary `Param M : Type*`
- `InterpModels α β` : each `M : β` has an associated ground type `Ground M`, an interpretation `interp  : α → Ground M` and a `filter : Set (Ground β)`, which induces a forcing relation as `Satisfies M a := interp a ∈ filter M`.
- Soundness and completeness wrt an inference system

I've tried to add enough examples to show how this might be used, but the design ought to be discussed before we settle on anything this general.