### PR TITLE
feat: FullEta.step_lc_l

### DIFF
--- a/Cslib/Languages/LambdaCalculus/LocallyNameless/Untyped/Basic.lean
+++ b/Cslib/Languages/LambdaCalculus/LocallyNameless/Untyped/Basic.lean
@@ -111,18 +111,6 @@ def fv : Term Var → Finset Var
 | abs e1 => e1.fv
 | app l r => l.fv ∪ r.fv
 
-/-- Locally closed terms. -/
-inductive LC : Term Var → Prop
-| fvar (x : Var)  : LC (fvar x)
-| abs (L : Finset Var) (e : Term Var) : (∀ x ∉ L, LC (e ^ fvar x)) → LC (abs e)
-| app {l r} : l.LC → r.LC → LC (app l r)
-
-attribute [scoped grind .] LC.fvar LC.app
-
-/-- Values are irreducible terms. -/
-inductive Value : Term Var → Prop
-| abs (e : Term Var) : e.abs.LC → e.abs.Value
-
 section
 
 omit [HasFresh Var]

--- a/Cslib/Languages/LambdaCalculus/LocallyNameless/Untyped/FullEta.lean
+++ b/Cslib/Languages/LambdaCalculus/LocallyNameless/Untyped/FullEta.lean
@@ -8,7 +8,6 @@ module
 
 public import Cslib.Foundations.Data.Relation
 public import Cslib.Languages.LambdaCalculus.LocallyNameless.Untyped.Properties
-public import Cslib.Languages.LambdaCalculus.LocallyNameless.Untyped.LcAt
 public import Cslib.Languages.LambdaCalculus.LocallyNameless.Untyped.Congruence
 
 /-! # η-reduction for the λ-calculus -/

--- a/Cslib/Languages/LambdaCalculus/LocallyNameless/Untyped/FullEta.lean
+++ b/Cslib/Languages/LambdaCalculus/LocallyNameless/Untyped/FullEta.lean
@@ -8,6 +8,7 @@ module
 
 public import Cslib.Foundations.Data.Relation
 public import Cslib.Languages.LambdaCalculus.LocallyNameless.Untyped.Properties
+public import Cslib.Languages.LambdaCalculus.LocallyNameless.Untyped.LcAt
 public import Cslib.Languages.LambdaCalculus.LocallyNameless.Untyped.Congruence
 
 /-! # η-reduction for the λ-calculus -/
@@ -43,6 +44,22 @@ variable {M M' N N' : Term Var}
 lemma step_lc_r (step : M ⭢ηᶠ M') : LC M' := by
   refine Xi.step_lc_r ?_ step
   grind
+
+/-- The left side of an η-reduction is locally closed. -/
+lemma step_lc_l [HasFresh Var] (step : M ⭢ηᶠ M') : LC M := by
+  induction step with
+  | base h_e => cases h_e with
+                | eta lc_A => apply LC.abs ∅
+                              intros _ _
+                              refine LC.app (?_) (LC.fvar _)
+                              rw [lcAt_openRec_above_lcAt _ _ 0 0]
+                              · assumption
+                              · omega
+                              · rw [lcAt_iff_LC]
+                                assumption
+  | appL lc_Z _ ih => exact LC.app lc_Z ih
+  | appR lc_Z _ ih => exact LC.app ih lc_Z
+  | @abs M' _ xs _ ih => exact LC.abs xs M' ih
 
 /-- Left congruence rule for application in multiple reduction. -/
 theorem redex_app_l_cong (redex : M ↠ηᶠ M') (lc_N : LC N) : app M N ↠ηᶠ app M' N := by

--- a/Cslib/Languages/LambdaCalculus/LocallyNameless/Untyped/FullEta.lean
+++ b/Cslib/Languages/LambdaCalculus/LocallyNameless/Untyped/FullEta.lean
@@ -47,15 +47,7 @@ lemma step_lc_r (step : M ⭢ηᶠ M') : LC M' := by
 /-- The left side of an η-reduction is locally closed. -/
 lemma step_lc_l [HasFresh Var] (step : M ⭢ηᶠ M') : LC M := by
   induction step with
-  | base h_e => cases h_e with
-                | eta lc_A => apply LC.abs ∅
-                              intros _ _
-                              refine LC.app (?_) (LC.fvar _)
-                              rw [lcAt_openRec_above_lcAt _ _ 0 0]
-                              · assumption
-                              · omega
-                              · rw [lcAt_iff_LC]
-                                assumption
+  | base h_e => cases h_e with | eta => apply LC.abs ∅; grind
   | appL lc_Z _ ih => exact LC.app lc_Z ih
   | appR lc_Z _ ih => exact LC.app ih lc_Z
   | @abs M' _ xs _ ih => exact LC.abs xs M' ih

--- a/Cslib/Languages/LambdaCalculus/LocallyNameless/Untyped/LcAt.lean
+++ b/Cslib/Languages/LambdaCalculus/LocallyNameless/Untyped/LcAt.lean
@@ -72,6 +72,18 @@ theorem lcAt_openRec_fvar_iff_lcAt (M : Term Var) (x : Var) (i : ℕ) :
 theorem lcAt_open_fvar_iff_lcAt (M : Term Var) (x : Var) : LcAt 0 (M ^ fvar x) ↔ LcAt 1 M :=
   lcAt_openRec_fvar_iff_lcAt M x 0
 
+/-- Locally closed terms. -/
+inductive LC : Term Var → Prop
+| fvar (x : Var)  : LC (fvar x)
+| abs (L : Finset Var) (e : Term Var) : (∀ x ∉ L, LC (e ^ fvar x)) → LC (abs e)
+| app {l r} : l.LC → r.LC → LC (app l r)
+
+attribute [scoped grind .] LC.fvar LC.app
+
+/-- Values are irreducible terms. -/
+inductive Value : Term Var → Prop
+| abs (e : Term Var) : e.abs.LC → e.abs.Value
+
 /-- `M` is `LcAt 0` if and only if `M` is locally closed. -/
 theorem lcAt_iff_LC (M : Term Var) [HasFresh Var] : LcAt 0 M ↔ M.LC := by
   induction M using LambdaCalculus.LocallyNameless.Untyped.Term.ind_on_depth with
@@ -98,7 +110,8 @@ lemma open_abs_lc [HasFresh Var] {M N : Term Var} (hlc : LC (M ^ N)) : LC (M.abs
   rw [← lcAt_iff_LC] at *
   exact lcAt_openRec_lcAt _ _ _ hlc
 
-lemma lcAt_openRec_above_lcAt (M N : Term Var) (i j : ℕ) : j >= i -> LcAt i M  → M⟦j ↝ N⟧ = M := by
+lemma lcAt_openRec_above_lcAt (M N : Term Var) (i j : ℕ) (h : i ≤ j) (lc : LcAt i M) :
+    M⟦j ↝ N⟧ = M := by
   induction M generalizing i j <;> grind
 
 end Cslib.LambdaCalculus.LocallyNameless.Untyped.Term

--- a/Cslib/Languages/LambdaCalculus/LocallyNameless/Untyped/LcAt.lean
+++ b/Cslib/Languages/LambdaCalculus/LocallyNameless/Untyped/LcAt.lean
@@ -98,4 +98,7 @@ lemma open_abs_lc [HasFresh Var] {M N : Term Var} (hlc : LC (M ^ N)) : LC (M.abs
   rw [← lcAt_iff_LC] at *
   exact lcAt_openRec_lcAt _ _ _ hlc
 
+lemma lcAt_openRec_above_lcAt (M N : Term Var) (i j : ℕ) : j >= i -> LcAt i M  → M⟦j ↝ N⟧ = M := by
+  induction M generalizing i j <;> grind
+
 end Cslib.LambdaCalculus.LocallyNameless.Untyped.Term

--- a/Cslib/Languages/LambdaCalculus/LocallyNameless/Untyped/Properties.lean
+++ b/Cslib/Languages/LambdaCalculus/LocallyNameless/Untyped/Properties.lean
@@ -6,7 +6,7 @@ Authors: Chris Henson
 
 module
 
-public import Cslib.Languages.LambdaCalculus.LocallyNameless.Untyped.Basic
+public import Cslib.Languages.LambdaCalculus.LocallyNameless.Untyped.LcAt
 
 /-! General properties of opening and substitution in untyped lambda calculus terms. -/
 
@@ -21,11 +21,6 @@ variable {Var : Type u}
 namespace LambdaCalculus.LocallyNameless.Untyped.Term
 
 attribute [grind =] Finset.union_singleton
-
-/-- An opening appearing in both sides of an equality of terms can be removed. -/
-lemma open_lc_aux (e : Term Var) (j v i u) (neq : i ≠ j) (eq : e⟦j ↝ v⟧ = e⟦j ↝ v⟧⟦i ↝ u⟧) :
-    e = e ⟦i ↝ u⟧ := by
-  induction e generalizing j i <;> grind
 
 variable [DecidableEq Var]
 
@@ -77,11 +72,9 @@ variable [HasFresh Var]
 
 omit [DecidableEq Var] in
 /-- A locally closed term is unchanged by opening. -/
-@[scoped grind =_]
-lemma open_lc (k t) (e : Term Var) (e_lc : e.LC) : e = e⟦k ↝ t⟧ := by
-  induction e_lc generalizing k with
-  | abs xs e _ _ => grind [open_lc_aux e 0 (fvar (fresh xs)) (k+1) t]
-  | _ => grind
+@[scoped grind =]
+lemma open_lc (k t) (e : Term Var) (e_lc : e.LC) : e⟦k ↝ t⟧ = e :=
+  lcAt_openRec_above_lcAt e t 0 k k.zero_le ((lcAt_iff_LC e).mpr e_lc)
 
 omit [DecidableEq Var] in
 /-- Opening is associative for nonclashing locally closed terms. -/


### PR DESCRIPTION
This PR adds a missing lemma to the `FullEta` development in the locally nameless untyped λ‑calculus:  
a proof that **the source term of a single‑step η‑reduction is locally closed**. It also moves the definition of `LcAt` earlier to avoid some duplication of proofs about `LC`.

#### New Lemmas

`FullEta.step_lc_l` : Proves that the left side of an η-reduction `step (M ⭢ηᶠ M')` is locally closed.
Uses induction on the reduction step and the grind tactic.

`lcAt_openRec_above_lcAt` : Shows that opening a term at a higher index than its locally closed level leaves it unchanged.

#### Refactored Lemmas

open_lc : Simplified proof using `lcAt_openRec_above_lcAt` and `lcAt_iff_LC`.

PR description is generated by AI




