### PR TITLE
feat(Control/Monad): Weakest preconditions and mcvgen for free monads

### DIFF
--- a/Cslib.lean
+++ b/Cslib.lean
@@ -53,6 +53,7 @@ public import Cslib.Foundations.Combinatorics.InfiniteGraphRamsey
 public import Cslib.Foundations.Control.Monad.Free
 public import Cslib.Foundations.Control.Monad.Free.Effects
 public import Cslib.Foundations.Control.Monad.Free.Fold
+public import Cslib.Foundations.Control.Monad.Free.WP
 public import Cslib.Foundations.Data.BiTape
 public import Cslib.Foundations.Data.DecidableEqZero
 public import Cslib.Foundations.Data.FinFun.Basic

--- a/Cslib/Foundations/Control/Monad/Free/Effects.lean
+++ b/Cslib/Foundations/Control/Monad/Free/Effects.lean
@@ -7,6 +7,7 @@ Authors: Tanner Duve
 module
 
 public import Cslib.Foundations.Control.Monad.Free
+public import Cslib.Foundations.Control.Monad.Free.WP
 public import Mathlib.Control.Monad.Cont
 
 /-!
@@ -39,9 +40,13 @@ Free monad, state monad, writer monad, continuation monad
 
 @[expose] public section
 
+set_option mvcgen.warning false
+
 namespace Cslib
 
 namespace FreeM
+
+open Std.Do
 
 universe u v w w' w''
 
@@ -156,6 +161,32 @@ lemma run'_bind (x : FreeState σ α) (f : α → FreeState σ β) (s₀ : σ) :
   congr_arg Prod.fst <| run_bind _ _ _
 
 end FreeState
+
+/-- Logical handler for the state effect, induced by `Std.Do`'s `WP (StateM σ)`. -/
+def StateF.handler {σ : Type u} : LHandler (StateF σ) (.arg σ .pure) :=
+  LHandler.ofInterp (m := StateM σ) (fun _ op => FreeState.stateInterp op)
+
+instance StateF.instHasHandler {σ : Type u} :
+    HasHandler (StateF σ) (.arg σ .pure) where
+  handler := StateF.handler
+
+/-- WP of a `FreeState` program matches WP of its `StateM` interpretation. -/
+theorem StateF.wp_FreeState_eq_wp_toStateM {σ α : Type u} (comp : FreeState σ α) :
+    wp comp = wp (FreeState.toStateM comp) :=
+  wpH_ofInterp_eq_wp_liftM (m := StateM σ)
+    (fun _ op => FreeState.stateInterp op) comp
+
+/-- Hoare spec for `get` on `FreeState`. -/
+@[spec]
+theorem Spec.get_FreeState {σ : Type u} {Q : PostCond σ (.arg σ .pure)} :
+    Triple (MonadStateOf.get : FreeState σ σ) (spred(fun s => Q.1 s s)) Q := by
+  mvcgen
+
+/-- Hoare spec for `set` on `FreeState`. -/
+@[spec]
+theorem Spec.set_FreeState {σ : Type u} (s : σ) {Q : PostCond PUnit (.arg σ .pure)} :
+    Triple (MonadStateOf.set s : FreeState σ PUnit) (spred(fun _ => Q.1 ⟨⟩ s)) Q := by
+  mvcgen
 
 /-! ### Writer Monad via `FreeM` -/
 
@@ -452,6 +483,26 @@ instance instMonadWithReaderOf : MonadWithReaderOf σ (FreeReader σ) where
     simpa [withTheReader, instMonadWithReaderOf, run] using! (ih (f s) s)
 
 end FreeReader
+
+/-- Logical handler for the reader effect, induced by `Std.Do`'s `WP (ReaderM σ)`. -/
+def ReaderF.handler {σ : Type u} : LHandler (ReaderF σ) (.arg σ .pure) :=
+  LHandler.ofInterp (m := ReaderM σ) (fun _ op => FreeReader.readInterp op)
+
+instance ReaderF.instHasHandler {σ : Type u} :
+    HasHandler (ReaderF σ) (.arg σ .pure) where
+  handler := ReaderF.handler
+
+/-- WP of a `FreeReader` program matches WP of its `ReaderM` interpretation. -/
+theorem ReaderF.wp_FreeReader_eq_wp_toReaderM {σ α : Type u} (comp : FreeReader σ α) :
+    wp comp = wp (FreeReader.toReaderM comp) :=
+  wpH_ofInterp_eq_wp_liftM (m := ReaderM σ)
+    (fun _ op => FreeReader.readInterp op) comp
+
+/-- Hoare spec for `read` on `FreeReader`. -/
+@[spec]
+theorem Spec.read_FreeReader {ρ : Type u} {Q : PostCond ρ (.arg ρ .pure)} :
+    Triple (MonadReaderOf.read : FreeReader ρ ρ) (spred(fun r => Q.1 r r)) Q := by
+  mvcgen
 
 end FreeM
 

--- a/Cslib/Foundations/Control/Monad/Free/Effects.lean
+++ b/Cslib/Foundations/Control/Monad/Free/Effects.lean
@@ -163,17 +163,18 @@ lemma run'_bind (x : FreeState σ α) (f : α → FreeState σ β) (s₀ : σ) :
 end FreeState
 
 /-- Logical handler for the state effect, induced by `Std.Do`'s `WP (StateM σ)`. -/
-def StateF.handler {σ : Type u} : LHandler (StateF σ) (.arg σ .pure) :=
-  LHandler.ofInterp (m := StateM σ) (fun _ op => FreeState.stateInterp op)
+def StateF.handler {σ : Type u} :
+    {ι : Type u} → StateF σ ι → PredTrans (.arg σ .pure) ι :=
+  fun {ι} op => wp (FreeState.stateInterp (σ := σ) (α := ι) op)
 
-instance StateF.instHasHandler {σ : Type u} :
-    HasHandler (StateF σ) (.arg σ .pure) where
+instance StateF.instWP {σ : Type u} :
+    FreeM.WP (StateF σ) (.arg σ .pure) where
   handler := StateF.handler
 
 /-- WP of a `FreeState` program matches WP of its `StateM` interpretation. -/
 theorem StateF.wp_FreeState_eq_wp_toStateM {σ α : Type u} (comp : FreeState σ α) :
     wp comp = wp (FreeState.toStateM comp) :=
-  wpH_ofInterp_eq_wp_liftM (m := StateM σ)
+  liftM_wp_eq_wp_liftM (m := StateM σ)
     (fun _ op => FreeState.stateInterp op) comp
 
 /-- Hoare spec for `get` on `FreeState`. -/
@@ -485,17 +486,18 @@ instance instMonadWithReaderOf : MonadWithReaderOf σ (FreeReader σ) where
 end FreeReader
 
 /-- Logical handler for the reader effect, induced by `Std.Do`'s `WP (ReaderM σ)`. -/
-def ReaderF.handler {σ : Type u} : LHandler (ReaderF σ) (.arg σ .pure) :=
-  LHandler.ofInterp (m := ReaderM σ) (fun _ op => FreeReader.readInterp op)
+def ReaderF.handler {σ : Type u} :
+    {ι : Type u} → ReaderF σ ι → PredTrans (.arg σ .pure) ι :=
+  fun {ι} op => wp (FreeReader.readInterp (σ := σ) (α := ι) op)
 
-instance ReaderF.instHasHandler {σ : Type u} :
-    HasHandler (ReaderF σ) (.arg σ .pure) where
+instance ReaderF.instWP {σ : Type u} :
+    FreeM.WP (ReaderF σ) (.arg σ .pure) where
   handler := ReaderF.handler
 
 /-- WP of a `FreeReader` program matches WP of its `ReaderM` interpretation. -/
 theorem ReaderF.wp_FreeReader_eq_wp_toReaderM {σ α : Type u} (comp : FreeReader σ α) :
     wp comp = wp (FreeReader.toReaderM comp) :=
-  wpH_ofInterp_eq_wp_liftM (m := ReaderM σ)
+  liftM_wp_eq_wp_liftM (m := ReaderM σ)
     (fun _ op => FreeReader.readInterp op) comp
 
 /-- Hoare spec for `read` on `FreeReader`. -/

--- a/Cslib/Foundations/Control/Monad/Free/Effects.lean
+++ b/Cslib/Foundations/Control/Monad/Free/Effects.lean
@@ -163,16 +163,12 @@ lemma run'_bind (x : FreeState σ α) (f : α → FreeState σ β) (s₀ : σ) :
 end FreeState
 
 /-- Logical handler for the state effect, induced by `Std.Do`'s `WP (StateM σ)`. -/
-def StateF.handler {σ : Type u} :
-    {ι : Type u} → StateF σ ι → PredTrans (.arg σ .pure) ι :=
-  fun {ι} op => wp (FreeState.stateInterp (σ := σ) (α := ι) op)
-
 instance StateF.instWP {σ : Type u} :
     FreeM.WP (StateF σ) (.arg σ .pure) where
-  handler := StateF.handler
+  handler op := wp (FreeState.stateInterp op)
 
 /-- WP of a `FreeState` program matches WP of its `StateM` interpretation. -/
-theorem StateF.wp_FreeState_eq_wp_toStateM {σ α : Type u} (comp : FreeState σ α) :
+theorem StateF.wp_freeState_eq_wp_toStateM {σ α : Type u} (comp : FreeState σ α) :
     wp comp = wp (FreeState.toStateM comp) :=
   liftM_wp_eq_wp_liftM (m := StateM σ)
     (fun _ op => FreeState.stateInterp op) comp
@@ -486,16 +482,12 @@ instance instMonadWithReaderOf : MonadWithReaderOf σ (FreeReader σ) where
 end FreeReader
 
 /-- Logical handler for the reader effect, induced by `Std.Do`'s `WP (ReaderM σ)`. -/
-def ReaderF.handler {σ : Type u} :
-    {ι : Type u} → ReaderF σ ι → PredTrans (.arg σ .pure) ι :=
-  fun {ι} op => wp (FreeReader.readInterp (σ := σ) (α := ι) op)
-
 instance ReaderF.instWP {σ : Type u} :
     FreeM.WP (ReaderF σ) (.arg σ .pure) where
-  handler := ReaderF.handler
+  handler op := wp (FreeReader.readInterp op)
 
 /-- WP of a `FreeReader` program matches WP of its `ReaderM` interpretation. -/
-theorem ReaderF.wp_FreeReader_eq_wp_toReaderM {σ α : Type u} (comp : FreeReader σ α) :
+theorem ReaderF.wp_freeReader_eq_wp_toReaderM {σ α : Type u} (comp : FreeReader σ α) :
     wp comp = wp (FreeReader.toReaderM comp) :=
   liftM_wp_eq_wp_liftM (m := ReaderM σ)
     (fun _ op => FreeReader.readInterp op) comp

--- a/Cslib/Foundations/Control/Monad/Free/WP.lean
+++ b/Cslib/Foundations/Control/Monad/Free/WP.lean
@@ -10,6 +10,7 @@ public import Cslib.Foundations.Control.Monad.Free
 public import Std.Do.PredTrans
 public import Std.Do.WP.Basic
 public import Std.Do.WP.Monad
+public import Std.Do.WP.Adequate
 public import Std.Do.Triple
 
 /-!
@@ -22,12 +23,26 @@ so weakest preconditions are compositional in `FreeM`'s monadic structure. A
 `[FreeM.WP F ps]` instance plugs `FreeM F` into `Std.Do`'s `WP`/`WPMonad`/`Triple`
 infrastructure.
 
-The WP's structural rules are immediate from `liftM` being a monad morphism; the
-adequacy theorem `liftM_wp_eq_wp_liftM` — that WP-via-handler agrees with
-`Std.Do`'s WP of the `liftM` interpretation — is the same statement of uniqueness.
+The WP's structural rules are immediate from `liftM` being a monad morphism. The
+coherence lemma `liftM_wp_eq_wp_liftM` states that WP-via-handler agrees with `Std.Do`'s WP of the
+`liftM` interpretation, i.e. uniqueness of the lifted monad morphism. From it we derive
+`ensures_liftM_of_wp`: a `wp`-provable postcondition holds for the program's interpretation into
+any `WPAdequate` monad.
 
-The design follows [Vistrup, Sammler, Jung. *Program Logics à la Carte.* POPL 2025], adapted
-from coinductive ITrees to inductive `FreeM` and from Iris to `Std.Do`.
+The design follows [VistrupSammlerJung2025], adapted from coinductive ITrees to inductive `FreeM`
+and from Iris to `Std.Do`.
+
+## Main results
+
+- `liftM_wp_eq_wp_liftM`: WP-via-handler coincides with `Std.Do`'s WP of the `liftM`
+  interpretation (uniqueness/coherence of the lifted monad morphism).
+- `ensures_liftM_of_wp`: a `wp`-provable postcondition holds (as `Internal.Ensures`) for the
+  program's interpretation into a `WPAdequate` monad.
+- `wp_lift`: `wp` of a single lifted operation is the handler applied to it.
+
+## References
+
+See [VistrupSammlerJung2025] for the original account on ITree program logics.
 -/
 
 @[expose] public section
@@ -44,9 +59,10 @@ universe u v w
 
 variable {F : Type u → Type v} {ps : PostShape.{u}} {α β : Type u}
 
-/-- Adequacy theorem: WP via `FreeM` against a WP-derived handler agrees with
+/-- Coherence/uniqueness lemma: WP via `FreeM` against a WP-derived handler agrees with
 `Std.Do`'s WP of the `liftM` interpretation. Equivalently, two monad morphisms
-`FreeM F → PredTrans ps` extending the same handler are equal. -/
+`FreeM F → PredTrans ps` extending the same handler are equal. This is the bridge from which the
+entails-style adequacy lemma `ensures_liftM_of_wp` is derived. -/
 theorem liftM_wp_eq_wp_liftM
     {m : Type u → Type w} [Monad m] [WPMonad m ps]
     (interp : ∀ ι : Type u, F ι → m ι) (x : FreeM F α) :
@@ -59,16 +75,32 @@ theorem liftM_wp_eq_wp_liftM
 
 /-- Records a default logical handler for `F` at shape `ps`, enabling the global
 `WP (FreeM F) ps` instance and any `Triple`/`mvcgen` reasoning over `FreeM F`. -/
-class WP (F : Type u → Type v) (ps : outParam (PostShape.{u})) where
+protected class WP (F : Type u → Type v) (ps : outParam (PostShape.{u})) where
   /-- The default logical handler for `F`. -/
   handler {ι : Type u} : F ι → PredTrans ps ι
 
-instance instStdDoWP [WP F ps] : Std.Do.WP (FreeM F) ps where
-  wp x := x.liftM WP.handler
+instance WP.toDoWP [FreeM.WP F ps] : WP (FreeM F) ps where
+  wp x := x.liftM FreeM.WP.handler
 
-instance instWPMonadFreeM [WP F ps] : WPMonad (FreeM F) ps where
+instance [FreeM.WP F ps] : WPMonad (FreeM F) ps where
   wp_pure _ := rfl
   wp_bind x f := liftM_bind _ x f
+
+/-- `wp` of a single lifted operation is the handler applied to that operation. -/
+@[simp]
+theorem wp_lift [FreeM.WP F ps] (op : F α) :
+    wp (lift op : FreeM F α) = FreeM.WP.handler op :=
+  liftM_lift (m := PredTrans ps) FreeM.WP.handler op
+
+/-- If `wp⟦x⟧` proves postcondition `P`, then `x` interpreted into any `WPAdequate` monad `m`
+via `interp` satisfies `Internal.Ensures P`. Follows from `liftM_wp_eq_wp_liftM` and `m`'s
+adequacy. -/
+theorem ensures_liftM_of_wp
+    {m : Type u → Type w} [Monad m] [WPMonad m ps] [WPAdequate m ps]
+    (interp : ∀ ι : Type u, F ι → m ι) (x : FreeM F α) {P : α → Prop}
+    (hwp : ⊢ₛ (x.liftM (fun {ι} op => wp (interp ι op))).apply (⇓? a => ⌜P a⌝)) :
+    Internal.Ensures P (x.liftM (fun {_} => interp _)) :=
+  WPAdequate.ensures_of_wp (liftM_wp_eq_wp_liftM interp x ▸ hwp)
 
 end FreeM
 

--- a/Cslib/Foundations/Control/Monad/Free/WP.lean
+++ b/Cslib/Foundations/Control/Monad/Free/WP.lean
@@ -1,0 +1,175 @@
+/-
+Copyright (c) 2025 Tanner Duve (Logical Intelligence). All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Tanner Duve
+-/
+
+module
+
+public import Cslib.Foundations.Control.Monad.Free
+public import Cslib.Foundations.Control.Monad.Free.Effects
+public import Std.Do.PredTrans
+public import Std.Do.WP.Basic
+public import Std.Do.WP.Monad
+public import Std.Do.Triple
+
+/-!
+# Weakest preconditions for `FreeM` programs
+
+Weakest-precondition interpretation of `FreeM F` programs through `Std.Do`'s
+predicate-transformer monad `PredTrans ps`. The universal property of `FreeM` lifts any
+effect handler `F ι → PredTrans ps ι` to a unique monad morphism `wpH H = liftM H.run`,
+so weakest preconditions are compositional in `FreeM`'s monadic structure. An
+`[LHandler F ps]` instance plugs `FreeM F` into `Std.Do`'s `WP`/`WPMonad`/`Triple`
+infrastructure.
+
+The WP's structural rules (`wpH_pure`, `wpH_bind`, …) are immediate from `liftM` being a monad
+morphism; the adequacy theorem `wpH_ofInterp_eq_wp_liftM` — that WP-via-handler agrees with
+`Std.Do`'s WP of the `liftM` interpretation — is the same statement of uniqueness.
+
+The design follows [Vistrup, Sammler, Jung. *Program Logics à la Carte.* POPL 2025], adapted
+from coinductive ITrees to inductive `FreeM` and from Iris to `Std.Do`.
+-/
+
+@[expose] public section
+
+set_option mvcgen.warning false
+
+namespace Cslib
+
+open Std.Do
+
+namespace FreeM
+
+universe u v w
+
+variable {F G : Type u → Type v} {ps : PostShape.{u}} {α β : Type u}
+
+/-- A logical handler: an effect handler from `F` into the predicate-transformer monad
+`PredTrans ps`. -/
+structure LHandler (F : Type u → Type v) (ps : PostShape.{u}) : Type (max (u + 1) v) where
+  /-- The assignment from operations to predicate transformers. -/
+  run {ι : Type u} : F ι → PredTrans ps ι
+
+namespace LHandler
+
+/-- Sum of handlers; the counterpart of the paper's `H₁ ⊕ H₂`. -/
+def sum (H₁ : LHandler F ps) (H₂ : LHandler G ps) :
+    LHandler (fun α => F α ⊕ G α) ps where
+  run := Sum.elim H₁.run H₂.run
+
+@[simp] theorem sum_run_inl (H₁ : LHandler F ps) (H₂ : LHandler G ps)
+    {ι : Type u} (x : F ι) :
+    (LHandler.sum H₁ H₂).run (Sum.inl x : F ι ⊕ G ι) = H₁.run x := rfl
+
+@[simp] theorem sum_run_inr (H₁ : LHandler F ps) (H₂ : LHandler G ps)
+    {ι : Type u} (y : G ι) :
+    (LHandler.sum H₁ H₂).run (Sum.inr y : F ι ⊕ G ι) = H₂.run y := rfl
+
+/-- Derive a logical handler from an effect handler into any `[WP m ps]` monad, by composing
+with `m`'s WP. -/
+def ofInterp {m : Type u → Type w} [WP m ps]
+    (interp : ∀ ι : Type u, F ι → m ι) : LHandler F ps where
+  run {ι} op := wp (interp ι op)
+
+@[simp] theorem ofInterp_run {m : Type u → Type w} [WP m ps]
+    (interp : ∀ ι : Type u, F ι → m ι) {ι : Type u} (op : F ι) :
+    (LHandler.ofInterp interp).run op = wp (interp ι op) := rfl
+
+end LHandler
+
+/-- Weakest-precondition interpretation of a `FreeM F α` program against a logical handler `H`.
+Defined as `FreeM.liftM` instantiated at `PredTrans ps`, the unique monad morphism
+`FreeM F → PredTrans ps` extending `H` per the universal property of `FreeM`. -/
+def wpH (H : LHandler F ps) (x : FreeM F α) : PredTrans ps α :=
+  x.liftM (fun {_} => H.run)
+
+@[simp] theorem wpH_pure (H : LHandler F ps) (a : α) :
+    wpH H (pure a : FreeM F α) = Pure.pure a := rfl
+
+@[simp] theorem wpH_liftBind (H : LHandler F ps) {ι : Type u}
+    (op : F ι) (k : ι → FreeM F α) :
+    wpH H (lift op >>= k) = H.run op >>= fun x => wpH H (k x) := rfl
+
+@[simp] theorem wpH_lift (H : LHandler F ps) {ι : Type u} (op : F ι) :
+    wpH H (lift op : FreeM F ι) = H.run op :=
+  liftM_lift _ op
+
+@[simp] theorem wpH_bind (H : LHandler F ps) (x : FreeM F α) (f : α → FreeM F β) :
+    wpH H (x >>= f) = wpH H x >>= fun a => wpH H (f a) :=
+  liftM_bind _ x f
+
+/-- Adequacy theorem: WP via `FreeM` against an `ofInterp`-derived handler agrees with
+`Std.Do`'s WP of the `liftM` interpretation. Equivalently, two monad morphisms
+`FreeM F → PredTrans ps` extending the same handler are equal. -/
+theorem wpH_ofInterp_eq_wp_liftM
+    {m : Type u → Type w} [Monad m] [LawfulMonad m] [WPMonad m ps]
+    (interp : ∀ ι : Type u, F ι → m ι) (x : FreeM F α) :
+    wpH (LHandler.ofInterp interp) x = wp (x.liftM (fun {_} => interp _)) := by
+  induction x with
+  | pure a => simp [wpH, FreeM.liftM, WPMonad.wp_pure]
+  | lift_bind op k ih =>
+    simp [WPMonad.wp_bind, ih]
+
+/-- Records a default logical handler for `F` at shape `ps`, enabling the global
+`WP (FreeM F) ps` instance and any `Triple`/`mvcgen` reasoning over `FreeM F`. -/
+class HasHandler (F : Type u → Type v) (ps : outParam (PostShape.{u})) where
+  /-- The default logical handler for `F`. -/
+  handler : LHandler F ps
+
+instance instWPFreeM [HasHandler F ps] : WP (FreeM F) ps where
+  wp := wpH HasHandler.handler
+
+instance instWPMonadFreeM [HasHandler F ps] : WPMonad (FreeM F) ps where
+  wp_pure _ := rfl
+  wp_bind x f := wpH_bind _ x f
+
+/-- Logical handler for the state effect, induced by `Std.Do`'s `WP (StateM σ)`. -/
+def StateF.handler {σ : Type u} : LHandler (StateF σ) (.arg σ .pure) :=
+  LHandler.ofInterp (m := StateM σ) (fun _ op => FreeState.stateInterp op)
+
+instance StateF.instHasHandler {σ : Type u} :
+    HasHandler (StateF σ) (.arg σ .pure) where
+  handler := StateF.handler
+
+/-- WP of a `FreeState` program matches WP of its `StateM` interpretation. -/
+theorem StateF.wp_FreeState_eq_wp_toStateM {σ : Type u} (comp : FreeState σ α) :
+    wp comp = wp (FreeState.toStateM comp) :=
+  wpH_ofInterp_eq_wp_liftM (m := StateM σ)
+    (fun _ op => FreeState.stateInterp op) comp
+
+/-- Hoare spec for `get` on `FreeState`. -/
+@[spec]
+theorem Spec.get_FreeState {σ : Type u} {Q : PostCond σ (.arg σ .pure)} :
+    Triple (MonadStateOf.get : FreeState σ σ) (spred(fun s => Q.1 s s)) Q := by
+  mvcgen
+
+/-- Hoare spec for `set` on `FreeState`. -/
+@[spec]
+theorem Spec.set_FreeState {σ : Type u} (s : σ) {Q : PostCond PUnit (.arg σ .pure)} :
+    Triple (MonadStateOf.set s : FreeState σ PUnit) (spred(fun _ => Q.1 ⟨⟩ s)) Q := by
+  mvcgen
+
+/-- Logical handler for the reader effect, induced by `Std.Do`'s `WP (ReaderM σ)`. -/
+def ReaderF.handler {σ : Type u} : LHandler (ReaderF σ) (.arg σ .pure) :=
+  LHandler.ofInterp (m := ReaderM σ) (fun _ op => FreeReader.readInterp op)
+
+instance ReaderF.instHasHandler {σ : Type u} :
+    HasHandler (ReaderF σ) (.arg σ .pure) where
+  handler := ReaderF.handler
+
+/-- WP of a `FreeReader` program matches WP of its `ReaderM` interpretation. -/
+theorem ReaderF.wp_FreeReader_eq_wp_toReaderM {σ : Type u} (comp : FreeReader σ α) :
+    wp comp = wp (FreeReader.toReaderM comp) :=
+  wpH_ofInterp_eq_wp_liftM (m := ReaderM σ)
+    (fun _ op => FreeReader.readInterp op) comp
+
+/-- Hoare spec for `read` on `FreeReader`. -/
+@[spec]
+theorem Spec.read_FreeReader {ρ : Type u} {Q : PostCond ρ (.arg ρ .pure)} :
+    Triple (MonadReaderOf.read : FreeReader ρ ρ) (spred(fun r => Q.1 r r)) Q := by
+  mvcgen
+
+end FreeM
+
+end Cslib

--- a/Cslib/Foundations/Control/Monad/Free/WP.lean
+++ b/Cslib/Foundations/Control/Monad/Free/WP.lean
@@ -7,7 +7,6 @@ Authors: Tanner Duve
 module
 
 public import Cslib.Foundations.Control.Monad.Free
-public import Cslib.Foundations.Control.Monad.Free.Effects
 public import Std.Do.PredTrans
 public import Std.Do.WP.Basic
 public import Std.Do.WP.Monad
@@ -18,9 +17,9 @@ public import Std.Do.Triple
 
 Weakest-precondition interpretation of `FreeM F` programs through `Std.Do`'s
 predicate-transformer monad `PredTrans ps`. The universal property of `FreeM` lifts any
-effect handler `F ι → PredTrans ps ι` to a unique monad morphism `wpH H = liftM H.run`,
-so weakest preconditions are compositional in `FreeM`'s monadic structure. An
-`[LHandler F ps]` instance plugs `FreeM F` into `Std.Do`'s `WP`/`WPMonad`/`Triple`
+effect handler `F ι → PredTrans ps ι` to a unique monad morphism `wpH H = liftM H`,
+so weakest preconditions are compositional in `FreeM`'s monadic structure. A
+`[HasHandler F ps]` instance plugs `FreeM F` into `Std.Do`'s `WP`/`WPMonad`/`Triple`
 infrastructure.
 
 The WP's structural rules (`wpH_pure`, `wpH_bind`, …) are immediate from `liftM` being a monad
@@ -47,34 +46,33 @@ variable {F G : Type u → Type v} {ps : PostShape.{u}} {α β : Type u}
 
 /-- A logical handler: an effect handler from `F` into the predicate-transformer monad
 `PredTrans ps`. -/
-structure LHandler (F : Type u → Type v) (ps : PostShape.{u}) : Type (max (u + 1) v) where
-  /-- The assignment from operations to predicate transformers. -/
-  run {ι : Type u} : F ι → PredTrans ps ι
+abbrev LHandler (F : Type u → Type v) (ps : PostShape.{u}) : Type (max (u + 1) v) :=
+  ∀ {ι : Type u}, F ι → PredTrans ps ι
 
 namespace LHandler
 
 /-- Sum of handlers; the counterpart of the paper's `H₁ ⊕ H₂`. -/
 def sum (H₁ : LHandler F ps) (H₂ : LHandler G ps) :
-    LHandler (fun α => F α ⊕ G α) ps where
-  run := Sum.elim H₁.run H₂.run
+    LHandler (fun α => F α ⊕ G α) ps :=
+  fun op => Sum.elim H₁ H₂ op
 
-@[simp] theorem sum_run_inl (H₁ : LHandler F ps) (H₂ : LHandler G ps)
+@[simp] theorem sum_inl (H₁ : LHandler F ps) (H₂ : LHandler G ps)
     {ι : Type u} (x : F ι) :
-    (LHandler.sum H₁ H₂).run (Sum.inl x : F ι ⊕ G ι) = H₁.run x := rfl
+    LHandler.sum H₁ H₂ (Sum.inl x : F ι ⊕ G ι) = H₁ x := rfl
 
-@[simp] theorem sum_run_inr (H₁ : LHandler F ps) (H₂ : LHandler G ps)
+@[simp] theorem sum_inr (H₁ : LHandler F ps) (H₂ : LHandler G ps)
     {ι : Type u} (y : G ι) :
-    (LHandler.sum H₁ H₂).run (Sum.inr y : F ι ⊕ G ι) = H₂.run y := rfl
+    LHandler.sum H₁ H₂ (Sum.inr y : F ι ⊕ G ι) = H₂ y := rfl
 
 /-- Derive a logical handler from an effect handler into any `[WP m ps]` monad, by composing
 with `m`'s WP. -/
 def ofInterp {m : Type u → Type w} [WP m ps]
-    (interp : ∀ ι : Type u, F ι → m ι) : LHandler F ps where
-  run {ι} op := wp (interp ι op)
+    (interp : ∀ ι : Type u, F ι → m ι) : LHandler F ps :=
+  fun {ι} op => wp (interp ι op)
 
-@[simp] theorem ofInterp_run {m : Type u → Type w} [WP m ps]
+@[simp] theorem ofInterp_apply {m : Type u → Type w} [WP m ps]
     (interp : ∀ ι : Type u, F ι → m ι) {ι : Type u} (op : F ι) :
-    (LHandler.ofInterp interp).run op = wp (interp ι op) := rfl
+    LHandler.ofInterp interp op = wp (interp ι op) := rfl
 
 end LHandler
 
@@ -82,17 +80,17 @@ end LHandler
 Defined as `FreeM.liftM` instantiated at `PredTrans ps`, the unique monad morphism
 `FreeM F → PredTrans ps` extending `H` per the universal property of `FreeM`. -/
 def wpH (H : LHandler F ps) (x : FreeM F α) : PredTrans ps α :=
-  x.liftM (fun {_} => H.run)
+  x.liftM H
 
 @[simp] theorem wpH_pure (H : LHandler F ps) (a : α) :
     wpH H (pure a : FreeM F α) = Pure.pure a := rfl
 
 @[simp] theorem wpH_liftBind (H : LHandler F ps) {ι : Type u}
     (op : F ι) (k : ι → FreeM F α) :
-    wpH H (lift op >>= k) = H.run op >>= fun x => wpH H (k x) := rfl
+    wpH H (lift op >>= k) = H op >>= fun x => wpH H (k x) := rfl
 
 @[simp] theorem wpH_lift (H : LHandler F ps) {ι : Type u} (op : F ι) :
-    wpH H (lift op : FreeM F ι) = H.run op :=
+    wpH H (lift op : FreeM F ι) = H op :=
   liftM_lift _ op
 
 @[simp] theorem wpH_bind (H : LHandler F ps) (x : FreeM F α) (f : α → FreeM F β) :
@@ -115,7 +113,7 @@ theorem wpH_ofInterp_eq_wp_liftM
 `WP (FreeM F) ps` instance and any `Triple`/`mvcgen` reasoning over `FreeM F`. -/
 class HasHandler (F : Type u → Type v) (ps : outParam (PostShape.{u})) where
   /-- The default logical handler for `F`. -/
-  handler : LHandler F ps
+  handler {ι : Type u} : F ι → PredTrans ps ι
 
 instance instWPFreeM [HasHandler F ps] : WP (FreeM F) ps where
   wp := wpH HasHandler.handler
@@ -123,52 +121,6 @@ instance instWPFreeM [HasHandler F ps] : WP (FreeM F) ps where
 instance instWPMonadFreeM [HasHandler F ps] : WPMonad (FreeM F) ps where
   wp_pure _ := rfl
   wp_bind x f := wpH_bind _ x f
-
-/-- Logical handler for the state effect, induced by `Std.Do`'s `WP (StateM σ)`. -/
-def StateF.handler {σ : Type u} : LHandler (StateF σ) (.arg σ .pure) :=
-  LHandler.ofInterp (m := StateM σ) (fun _ op => FreeState.stateInterp op)
-
-instance StateF.instHasHandler {σ : Type u} :
-    HasHandler (StateF σ) (.arg σ .pure) where
-  handler := StateF.handler
-
-/-- WP of a `FreeState` program matches WP of its `StateM` interpretation. -/
-theorem StateF.wp_FreeState_eq_wp_toStateM {σ : Type u} (comp : FreeState σ α) :
-    wp comp = wp (FreeState.toStateM comp) :=
-  wpH_ofInterp_eq_wp_liftM (m := StateM σ)
-    (fun _ op => FreeState.stateInterp op) comp
-
-/-- Hoare spec for `get` on `FreeState`. -/
-@[spec]
-theorem Spec.get_FreeState {σ : Type u} {Q : PostCond σ (.arg σ .pure)} :
-    Triple (MonadStateOf.get : FreeState σ σ) (spred(fun s => Q.1 s s)) Q := by
-  mvcgen
-
-/-- Hoare spec for `set` on `FreeState`. -/
-@[spec]
-theorem Spec.set_FreeState {σ : Type u} (s : σ) {Q : PostCond PUnit (.arg σ .pure)} :
-    Triple (MonadStateOf.set s : FreeState σ PUnit) (spred(fun _ => Q.1 ⟨⟩ s)) Q := by
-  mvcgen
-
-/-- Logical handler for the reader effect, induced by `Std.Do`'s `WP (ReaderM σ)`. -/
-def ReaderF.handler {σ : Type u} : LHandler (ReaderF σ) (.arg σ .pure) :=
-  LHandler.ofInterp (m := ReaderM σ) (fun _ op => FreeReader.readInterp op)
-
-instance ReaderF.instHasHandler {σ : Type u} :
-    HasHandler (ReaderF σ) (.arg σ .pure) where
-  handler := ReaderF.handler
-
-/-- WP of a `FreeReader` program matches WP of its `ReaderM` interpretation. -/
-theorem ReaderF.wp_FreeReader_eq_wp_toReaderM {σ : Type u} (comp : FreeReader σ α) :
-    wp comp = wp (FreeReader.toReaderM comp) :=
-  wpH_ofInterp_eq_wp_liftM (m := ReaderM σ)
-    (fun _ op => FreeReader.readInterp op) comp
-
-/-- Hoare spec for `read` on `FreeReader`. -/
-@[spec]
-theorem Spec.read_FreeReader {ρ : Type u} {Q : PostCond ρ (.arg ρ .pure)} :
-    Triple (MonadReaderOf.read : FreeReader ρ ρ) (spred(fun r => Q.1 r r)) Q := by
-  mvcgen
 
 end FreeM
 

--- a/Cslib/Foundations/Control/Monad/Free/WP.lean
+++ b/Cslib/Foundations/Control/Monad/Free/WP.lean
@@ -26,8 +26,8 @@ The WP's structural rules are immediate from `liftM` being a monad morphism. The
 coherence lemma `liftM_wp_eq_wp_liftM` states that WP-via-handler agrees with `Std.Do`'s WP of the
 `liftM` interpretation, i.e. uniqueness of the lifted monad morphism.
 
-The design follows [VistrupSammlerJung2025], adapted from coinductive ITrees to inductive `FreeM`
-and from Iris to `Std.Do`.
+The design follows [Program Logics à la Carte][VistrupSammlerJung2025], adapted from coinductive
+ITrees to inductive `FreeM` and from Iris to `Std.Do`.
 
 ## Main results
 
@@ -37,12 +37,11 @@ and from Iris to `Std.Do`.
 
 ## References
 
-See [VistrupSammlerJung2025] for the original account on ITree program logics.
+See [Program Logics à la Carte][VistrupSammlerJung2025] for the original account on ITree
+program logics.
 -/
 
 @[expose] public section
-
-set_option mvcgen.warning false
 
 namespace Cslib
 

--- a/Cslib/Foundations/Control/Monad/Free/WP.lean
+++ b/Cslib/Foundations/Control/Monad/Free/WP.lean
@@ -10,7 +10,6 @@ public import Cslib.Foundations.Control.Monad.Free
 public import Std.Do.PredTrans
 public import Std.Do.WP.Basic
 public import Std.Do.WP.Monad
-public import Std.Do.WP.Adequate
 public import Std.Do.Triple
 
 /-!
@@ -25,9 +24,7 @@ infrastructure.
 
 The WP's structural rules are immediate from `liftM` being a monad morphism. The
 coherence lemma `liftM_wp_eq_wp_liftM` states that WP-via-handler agrees with `Std.Do`'s WP of the
-`liftM` interpretation, i.e. uniqueness of the lifted monad morphism. From it we derive
-`ensures_liftM_of_wp`: a `wp`-provable postcondition holds for the program's interpretation into
-any `WPAdequate` monad.
+`liftM` interpretation, i.e. uniqueness of the lifted monad morphism.
 
 The design follows [VistrupSammlerJung2025], adapted from coinductive ITrees to inductive `FreeM`
 and from Iris to `Std.Do`.
@@ -36,8 +33,6 @@ and from Iris to `Std.Do`.
 
 - `liftM_wp_eq_wp_liftM`: WP-via-handler coincides with `Std.Do`'s WP of the `liftM`
   interpretation (uniqueness/coherence of the lifted monad morphism).
-- `ensures_liftM_of_wp`: a `wp`-provable postcondition holds (as `Internal.Ensures`) for the
-  program's interpretation into a `WPAdequate` monad.
 - `wp_lift`: `wp` of a single lifted operation is the handler applied to it.
 
 ## References
@@ -61,8 +56,7 @@ variable {F : Type u → Type v} {ps : PostShape.{u}} {α β : Type u}
 
 /-- Coherence/uniqueness lemma: WP via `FreeM` against a WP-derived handler agrees with
 `Std.Do`'s WP of the `liftM` interpretation. Equivalently, two monad morphisms
-`FreeM F → PredTrans ps` extending the same handler are equal. This is the bridge from which the
-entails-style adequacy lemma `ensures_liftM_of_wp` is derived. -/
+`FreeM F → PredTrans ps` extending the same handler are equal. -/
 theorem liftM_wp_eq_wp_liftM
     {m : Type u → Type w} [Monad m] [WPMonad m ps]
     (interp : ∀ ι : Type u, F ι → m ι) (x : FreeM F α) :
@@ -91,16 +85,6 @@ instance [FreeM.WP F ps] : WPMonad (FreeM F) ps where
 theorem wp_lift [FreeM.WP F ps] (op : F α) :
     wp (lift op : FreeM F α) = FreeM.WP.handler op :=
   liftM_lift (m := PredTrans ps) FreeM.WP.handler op
-
-/-- If `wp⟦x⟧` proves postcondition `P`, then `x` interpreted into any `WPAdequate` monad `m`
-via `interp` satisfies `Internal.Ensures P`. Follows from `liftM_wp_eq_wp_liftM` and `m`'s
-adequacy. -/
-theorem ensures_liftM_of_wp
-    {m : Type u → Type w} [Monad m] [WPMonad m ps] [WPAdequate m ps]
-    (interp : ∀ ι : Type u, F ι → m ι) (x : FreeM F α) {P : α → Prop}
-    (hwp : ⊢ₛ (x.liftM (fun {ι} op => wp (interp ι op))).apply (⇓? a => ⌜P a⌝)) :
-    Internal.Ensures P (x.liftM (fun {_} => interp _)) :=
-  WPAdequate.ensures_of_wp (liftM_wp_eq_wp_liftM interp x ▸ hwp)
 
 end FreeM
 

--- a/Cslib/Foundations/Control/Monad/Free/WP.lean
+++ b/Cslib/Foundations/Control/Monad/Free/WP.lean
@@ -17,13 +17,13 @@ public import Std.Do.Triple
 
 Weakest-precondition interpretation of `FreeM F` programs through `Std.Do`'s
 predicate-transformer monad `PredTrans ps`. The universal property of `FreeM` lifts any
-effect handler `F ι → PredTrans ps ι` to a unique monad morphism `wpH H = liftM H`,
+effect handler `F ι → PredTrans ps ι` to a unique monad morphism `liftM H`,
 so weakest preconditions are compositional in `FreeM`'s monadic structure. A
-`[HasHandler F ps]` instance plugs `FreeM F` into `Std.Do`'s `WP`/`WPMonad`/`Triple`
+`[FreeM.WP F ps]` instance plugs `FreeM F` into `Std.Do`'s `WP`/`WPMonad`/`Triple`
 infrastructure.
 
-The WP's structural rules (`wpH_pure`, `wpH_bind`, …) are immediate from `liftM` being a monad
-morphism; the adequacy theorem `wpH_ofInterp_eq_wp_liftM` — that WP-via-handler agrees with
+The WP's structural rules are immediate from `liftM` being a monad morphism; the
+adequacy theorem `liftM_wp_eq_wp_liftM` — that WP-via-handler agrees with
 `Std.Do`'s WP of the `liftM` interpretation — is the same statement of uniqueness.
 
 The design follows [Vistrup, Sammler, Jung. *Program Logics à la Carte.* POPL 2025], adapted
@@ -42,85 +42,33 @@ namespace FreeM
 
 universe u v w
 
-variable {F G : Type u → Type v} {ps : PostShape.{u}} {α β : Type u}
+variable {F : Type u → Type v} {ps : PostShape.{u}} {α β : Type u}
 
-/-- A logical handler: an effect handler from `F` into the predicate-transformer monad
-`PredTrans ps`. -/
-abbrev LHandler (F : Type u → Type v) (ps : PostShape.{u}) : Type (max (u + 1) v) :=
-  ∀ {ι : Type u}, F ι → PredTrans ps ι
-
-namespace LHandler
-
-/-- Sum of handlers; the counterpart of the paper's `H₁ ⊕ H₂`. -/
-def sum (H₁ : LHandler F ps) (H₂ : LHandler G ps) :
-    LHandler (fun α => F α ⊕ G α) ps :=
-  fun op => Sum.elim H₁ H₂ op
-
-@[simp] theorem sum_inl (H₁ : LHandler F ps) (H₂ : LHandler G ps)
-    {ι : Type u} (x : F ι) :
-    LHandler.sum H₁ H₂ (Sum.inl x : F ι ⊕ G ι) = H₁ x := rfl
-
-@[simp] theorem sum_inr (H₁ : LHandler F ps) (H₂ : LHandler G ps)
-    {ι : Type u} (y : G ι) :
-    LHandler.sum H₁ H₂ (Sum.inr y : F ι ⊕ G ι) = H₂ y := rfl
-
-/-- Derive a logical handler from an effect handler into any `[WP m ps]` monad, by composing
-with `m`'s WP. -/
-def ofInterp {m : Type u → Type w} [WP m ps]
-    (interp : ∀ ι : Type u, F ι → m ι) : LHandler F ps :=
-  fun {ι} op => wp (interp ι op)
-
-@[simp] theorem ofInterp_apply {m : Type u → Type w} [WP m ps]
-    (interp : ∀ ι : Type u, F ι → m ι) {ι : Type u} (op : F ι) :
-    LHandler.ofInterp interp op = wp (interp ι op) := rfl
-
-end LHandler
-
-/-- Weakest-precondition interpretation of a `FreeM F α` program against a logical handler `H`.
-Defined as `FreeM.liftM` instantiated at `PredTrans ps`, the unique monad morphism
-`FreeM F → PredTrans ps` extending `H` per the universal property of `FreeM`. -/
-def wpH (H : LHandler F ps) (x : FreeM F α) : PredTrans ps α :=
-  x.liftM H
-
-@[simp] theorem wpH_pure (H : LHandler F ps) (a : α) :
-    wpH H (pure a : FreeM F α) = Pure.pure a := rfl
-
-@[simp] theorem wpH_liftBind (H : LHandler F ps) {ι : Type u}
-    (op : F ι) (k : ι → FreeM F α) :
-    wpH H (lift op >>= k) = H op >>= fun x => wpH H (k x) := rfl
-
-@[simp] theorem wpH_lift (H : LHandler F ps) {ι : Type u} (op : F ι) :
-    wpH H (lift op : FreeM F ι) = H op :=
-  liftM_lift _ op
-
-@[simp] theorem wpH_bind (H : LHandler F ps) (x : FreeM F α) (f : α → FreeM F β) :
-    wpH H (x >>= f) = wpH H x >>= fun a => wpH H (f a) :=
-  liftM_bind _ x f
-
-/-- Adequacy theorem: WP via `FreeM` against an `ofInterp`-derived handler agrees with
+/-- Adequacy theorem: WP via `FreeM` against a WP-derived handler agrees with
 `Std.Do`'s WP of the `liftM` interpretation. Equivalently, two monad morphisms
 `FreeM F → PredTrans ps` extending the same handler are equal. -/
-theorem wpH_ofInterp_eq_wp_liftM
-    {m : Type u → Type w} [Monad m] [LawfulMonad m] [WPMonad m ps]
+theorem liftM_wp_eq_wp_liftM
+    {m : Type u → Type w} [Monad m] [WPMonad m ps]
     (interp : ∀ ι : Type u, F ι → m ι) (x : FreeM F α) :
-    wpH (LHandler.ofInterp interp) x = wp (x.liftM (fun {_} => interp _)) := by
+    x.liftM (fun {ι} op => wp (interp ι op)) =
+      wp (x.liftM (fun {_} => interp _)) := by
   induction x with
-  | pure a => simp [wpH, FreeM.liftM, WPMonad.wp_pure]
+  | pure a => simp [WPMonad.wp_pure]
   | lift_bind op k ih =>
     simp [WPMonad.wp_bind, ih]
 
 /-- Records a default logical handler for `F` at shape `ps`, enabling the global
 `WP (FreeM F) ps` instance and any `Triple`/`mvcgen` reasoning over `FreeM F`. -/
-class HasHandler (F : Type u → Type v) (ps : outParam (PostShape.{u})) where
+class WP (F : Type u → Type v) (ps : outParam (PostShape.{u})) where
   /-- The default logical handler for `F`. -/
   handler {ι : Type u} : F ι → PredTrans ps ι
 
-instance instWPFreeM [HasHandler F ps] : WP (FreeM F) ps where
-  wp := wpH HasHandler.handler
+instance instStdDoWP [WP F ps] : Std.Do.WP (FreeM F) ps where
+  wp x := x.liftM WP.handler
 
-instance instWPMonadFreeM [HasHandler F ps] : WPMonad (FreeM F) ps where
+instance instWPMonadFreeM [WP F ps] : WPMonad (FreeM F) ps where
   wp_pure _ := rfl
-  wp_bind x f := wpH_bind _ x f
+  wp_bind x f := liftM_bind _ x f
 
 end FreeM
 

--- a/CslibTests.lean
+++ b/CslibTests.lean
@@ -3,6 +3,7 @@ import CslibTests.CCS
 import CslibTests.CLL
 import CslibTests.DFA
 import CslibTests.FreeMonad
+import CslibTests.FreeMonadWP
 import CslibTests.GrindLint
 import CslibTests.HML
 import CslibTests.HasFresh

--- a/CslibTests/FreeMonadWP.lean
+++ b/CslibTests/FreeMonadWP.lean
@@ -19,10 +19,10 @@ namespace CslibTests.FreeMonadWP
 
 open Cslib Cslib.FreeM Std.Do
 
-example : WP (FreeState Nat) (.arg Nat .pure) := inferInstance
+example : Std.Do.WP (FreeState Nat) (.arg Nat .pure) := inferInstance
 example : WPMonad (FreeState Nat) (.arg Nat .pure) := inferInstance
-example : WP (FreeReader Nat) (.arg Nat .pure) := inferInstance
-example : HasHandler (StateF Nat) (.arg Nat .pure) := inferInstance
+example : Std.Do.WP (FreeReader Nat) (.arg Nat .pure) := inferInstance
+example : FreeM.WP (StateF Nat) (.arg Nat .pure) := inferInstance
 
 /-- Increment the natural-number state by 1. -/
 def incr : FreeState Nat Unit := do
@@ -61,10 +61,10 @@ def interp : ∀ ι : Type, CounterF ι → StateM Nat ι
 
 /-- Logical handler for `CounterF` induced by `interp` and `Std.Do`'s `WP (StateM Nat)`
 instance. -/
-def handler : LHandler CounterF (.arg Nat .pure) :=
-  LHandler.ofInterp CounterF.interp
+def handler : {ι : Type} → CounterF ι → PredTrans (.arg Nat .pure) ι :=
+  fun {ι} op => wp (CounterF.interp ι op)
 
-instance : HasHandler CounterF (.arg Nat .pure) where
+instance : FreeM.WP CounterF (.arg Nat .pure) where
   handler := CounterF.handler
 
 /-- Interpret counter programs as `StateM Nat` programs. -/
@@ -74,7 +74,7 @@ abbrev toStateM {α : Type} (comp : FreeCounter α) : StateM Nat α :=
 /-- Adequacy theorem specialized to `CounterF`. -/
 theorem wp_FreeCounter_eq_wp_toStateM {α : Type} (comp : FreeCounter α) :
     wp comp = wp (CounterF.toStateM comp) :=
-  wpH_ofInterp_eq_wp_liftM (m := StateM Nat) CounterF.interp comp
+  liftM_wp_eq_wp_liftM (m := StateM Nat) CounterF.interp comp
 
 end CounterF
 
@@ -107,7 +107,7 @@ inductive FailF : Type → Type where
 
 /-- Logical handler for `FailF`: `fail` has precondition `⌜False⌝`, so it is only provable in
 unreachable branches. -/
-def FailF.handler {ps : PostShape} : LHandler FailF ps :=
+def FailF.handler {ps : PostShape} : {ι : Type} → FailF ι → PredTrans ps ι :=
   fun op => match op with
     | .fail => PredTrans.const spred(⌜False⌝)
 
@@ -116,8 +116,8 @@ abbrev StateFail := fun α => StateF Nat α ⊕ FailF α
 
 /-- Handler for the combined signature: the sum of the component handlers — the paper's
 `H₁ ⊕ H₂` composition. -/
-instance : HasHandler StateFail (.arg Nat .pure) where
-  handler := StateF.handler.sum FailF.handler
+instance : FreeM.WP StateFail (.arg Nat .pure) where
+  handler := fun op => Sum.elim StateF.handler FailF.handler op
 
 /-- Smart constructor for state-read in the combined signature. -/
 abbrev sfGet : FreeM StateFail Nat := lift (Sum.inl StateF.get)
@@ -186,7 +186,7 @@ inductive DemonicF : Type → Type 1 where
 /-- Logical handler for `DemonicF`: the predicate transformer for `choice α` is universal
 quantification over `α`. Conjunctivity of `∀` (i.e. `∀ a, P a ∧ Q a ⊣⊢ (∀ a, P a) ∧ (∀ a, Q a)`)
 is what makes this admissible in `PredTrans`. -/
-def DemonicF.handler {ps : PostShape} : LHandler DemonicF ps :=
+def DemonicF.handler {ps : PostShape} : {ι : Type} → DemonicF ι → PredTrans ps ι :=
   fun op => match op with
     | .choice _ =>
       { trans := fun Q => SPred.forall (fun a => Q.1 a)
@@ -207,7 +207,7 @@ def DemonicF.handler {ps : PostShape} : LHandler DemonicF ps :=
             · exact SPred.and_elim_l.trans (SPred.forall_elim a)
             · exact SPred.and_elim_r.trans (SPred.forall_elim a) }
 
-instance : HasHandler DemonicF .pure where
+instance : FreeM.WP DemonicF .pure where
   handler := DemonicF.handler
 
 /-- Smart constructor for demonic choice over `α`. -/

--- a/CslibTests/FreeMonadWP.lean
+++ b/CslibTests/FreeMonadWP.lean
@@ -4,7 +4,7 @@ Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Tanner Duve
 -/
 
-import Cslib.Foundations.Control.Monad.Free.WP
+import Cslib.Foundations.Control.Monad.Free.Effects
 import Std.Tactic.Do
 
 /-!
@@ -107,8 +107,8 @@ inductive FailF : Type → Type where
 
 /-- Logical handler for `FailF`: `fail` has precondition `⌜False⌝`, so it is only provable in
 unreachable branches. -/
-def FailF.handler {ps : PostShape} : LHandler FailF ps where
-  run {_} op := match op with
+def FailF.handler {ps : PostShape} : LHandler FailF ps :=
+  fun op => match op with
     | .fail => PredTrans.const spred(⌜False⌝)
 
 /-- A combined state + failure signature, sequencing `StateF Nat` with `FailF`. -/
@@ -186,8 +186,8 @@ inductive DemonicF : Type → Type 1 where
 /-- Logical handler for `DemonicF`: the predicate transformer for `choice α` is universal
 quantification over `α`. Conjunctivity of `∀` (i.e. `∀ a, P a ∧ Q a ⊣⊢ (∀ a, P a) ∧ (∀ a, Q a)`)
 is what makes this admissible in `PredTrans`. -/
-def DemonicF.handler {ps : PostShape} : LHandler DemonicF ps where
-  run {_} op := match op with
+def DemonicF.handler {ps : PostShape} : LHandler DemonicF ps :=
+  fun op => match op with
     | .choice _ =>
       { trans := fun Q => SPred.forall (fun a => Q.1 a)
         conjunctiveRaw := by

--- a/CslibTests/FreeMonadWP.lean
+++ b/CslibTests/FreeMonadWP.lean
@@ -30,7 +30,7 @@ def incr : FreeState Nat Unit := do
   MonadStateOf.set (n + 1)
 
 example : wp incr = wp (FreeState.toStateM incr) :=
-  StateF.wp_FreeState_eq_wp_toStateM incr
+  StateF.wp_freeState_eq_wp_toStateM incr
 
 /-- Starting in state `n`, `incr` ends in state `n + 1`. `mvcgen` picks up the `@[spec]` lemmas
 for `MonadStateOf.get`/`set` on `FreeState` and discharges the resulting arithmetic VC. -/
@@ -108,7 +108,7 @@ inductive FailF : Type → Type where
 /-- Logical handler for `FailF`: `fail` has precondition `⌜False⌝`, so it is only provable in
 unreachable branches. -/
 def FailF.handler {ps : PostShape} : {ι : Type} → FailF ι → PredTrans ps ι :=
-  fun op => match op with
+  fun
     | .fail => PredTrans.const spred(⌜False⌝)
 
 /-- A combined state + failure signature, sequencing `StateF Nat` with `FailF`. -/
@@ -117,7 +117,7 @@ abbrev StateFail := fun α => StateF Nat α ⊕ FailF α
 /-- Handler for the combined signature: the sum of the component handlers — the paper's
 `H₁ ⊕ H₂` composition. -/
 instance : FreeM.WP StateFail (.arg Nat .pure) where
-  handler := fun op => Sum.elim StateF.handler FailF.handler op
+  handler := fun op => Sum.elim FreeM.WP.handler FailF.handler op
 
 /-- Smart constructor for state-read in the combined signature. -/
 abbrev sfGet : FreeM StateFail Nat := lift (Sum.inl StateF.get)
@@ -187,7 +187,7 @@ inductive DemonicF : Type → Type 1 where
 quantification over `α`. Conjunctivity of `∀` (i.e. `∀ a, P a ∧ Q a ⊣⊢ (∀ a, P a) ∧ (∀ a, Q a)`)
 is what makes this admissible in `PredTrans`. -/
 def DemonicF.handler {ps : PostShape} : {ι : Type} → DemonicF ι → PredTrans ps ι :=
-  fun op => match op with
+  fun
     | .choice _ =>
       { trans := fun Q => SPred.forall (fun a => Q.1 a)
         conjunctiveRaw := by

--- a/CslibTests/FreeMonadWP.lean
+++ b/CslibTests/FreeMonadWP.lean
@@ -59,13 +59,8 @@ def interp : ∀ ι : Type, CounterF ι → StateM Nat ι
   | _, .tick => modify (· + 1)
   | _, .read => MonadStateOf.get
 
-/-- Logical handler for `CounterF` induced by `interp` and `Std.Do`'s `WP (StateM Nat)`
-instance. -/
-def handler : {ι : Type} → CounterF ι → PredTrans (.arg Nat .pure) ι :=
-  fun {ι} op => wp (CounterF.interp ι op)
-
 instance : FreeM.WP CounterF (.arg Nat .pure) where
-  handler := CounterF.handler
+  handler := fun {ι} op => wp (CounterF.interp ι op)
 
 /-- Interpret counter programs as `StateM Nat` programs. -/
 abbrev toStateM {α : Type} (comp : FreeCounter α) : StateM Nat α :=
@@ -186,26 +181,25 @@ inductive DemonicF : Type → Type 1 where
 /-- Logical handler for `DemonicF`: the predicate transformer for `choice α` is universal
 quantification over `α`. Conjunctivity of `∀` (i.e. `∀ a, P a ∧ Q a ⊣⊢ (∀ a, P a) ∧ (∀ a, Q a)`)
 is what makes this admissible in `PredTrans`. -/
-def DemonicF.handler {ps : PostShape} : {ι : Type} → DemonicF ι → PredTrans ps ι :=
-  fun
-    | .choice _ =>
-      { trans := fun Q => SPred.forall (fun a => Q.1 a)
-        conjunctiveRaw := by
-          intro Q₁ Q₂
-          apply SPred.bientails.iff.mpr
-          refine ⟨?_, ?_⟩
-          · apply SPred.and_intro
-            · apply SPred.forall_intro
-              intro a
-              exact (SPred.forall_elim a).trans SPred.and_elim_l
-            · apply SPred.forall_intro
-              intro a
-              exact (SPred.forall_elim a).trans SPred.and_elim_r
+def DemonicF.handler {ps : PostShape} : {ι : Type} → DemonicF ι → PredTrans ps ι
+  | _, .choice _ =>
+    { trans := fun Q => SPred.forall (fun a => Q.1 a)
+      conjunctiveRaw := by
+        intro Q₁ Q₂
+        apply SPred.bientails.iff.mpr
+        refine ⟨?_, ?_⟩
+        · apply SPred.and_intro
           · apply SPred.forall_intro
             intro a
-            apply SPred.and_intro
-            · exact SPred.and_elim_l.trans (SPred.forall_elim a)
-            · exact SPred.and_elim_r.trans (SPred.forall_elim a) }
+            exact (SPred.forall_elim a).trans SPred.and_elim_l
+          · apply SPred.forall_intro
+            intro a
+            exact (SPred.forall_elim a).trans SPred.and_elim_r
+        · apply SPred.forall_intro
+          intro a
+          apply SPred.and_intro
+          · exact SPred.and_elim_l.trans (SPred.forall_elim a)
+          · exact SPred.and_elim_r.trans (SPred.forall_elim a) }
 
 instance : FreeM.WP DemonicF .pure where
   handler := DemonicF.handler

--- a/CslibTests/FreeMonadWP.lean
+++ b/CslibTests/FreeMonadWP.lean
@@ -1,0 +1,230 @@
+/-
+Copyright (c) 2025 Tanner Duve (Logical Intelligence). All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Tanner Duve
+-/
+
+import Cslib.Foundations.Control.Monad.Free.WP
+import Std.Tactic.Do
+
+/-!
+Examples for WP in `Cslib.Foundations.Control.Monad.Free.WP`: instance resolution,
+a `Triple` on a `FreeState` program discharged by `mvcgen`, and a custom `CounterF` effect with
+its own logical handler.
+-/
+
+set_option mvcgen.warning false
+
+namespace CslibTests.FreeMonadWP
+
+open Cslib Cslib.FreeM Std.Do
+
+example : WP (FreeState Nat) (.arg Nat .pure) := inferInstance
+example : WPMonad (FreeState Nat) (.arg Nat .pure) := inferInstance
+example : WP (FreeReader Nat) (.arg Nat .pure) := inferInstance
+example : HasHandler (StateF Nat) (.arg Nat .pure) := inferInstance
+
+/-- Increment the natural-number state by 1. -/
+def incr : FreeState Nat Unit := do
+  let n ← MonadStateOf.get
+  MonadStateOf.set (n + 1)
+
+example : wp incr = wp (FreeState.toStateM incr) :=
+  StateF.wp_FreeState_eq_wp_toStateM incr
+
+/-- Starting in state `n`, `incr` ends in state `n + 1`. `mvcgen` picks up the `@[spec]` lemmas
+for `MonadStateOf.get`/`set` on `FreeState` and discharges the resulting arithmetic VC. -/
+example (n : Nat) :
+    ⦃fun s => ⌜s = n⌝⦄ (incr : FreeState Nat Unit) ⦃⇓ _ s' => ⌜s' = n + 1⌝⦄ := by
+  mvcgen
+  intro s heq
+  subst heq
+  rfl
+
+/-- A counter effect with two operations. -/
+inductive CounterF : Type → Type where
+  /-- Increment the counter by one. -/
+  | tick : CounterF Unit
+  /-- Read the counter's value. -/
+  | read : CounterF Nat
+
+/-- Counter programs built from `CounterF`. -/
+abbrev FreeCounter := FreeM CounterF
+
+namespace CounterF
+
+/-- Effect handler for `CounterF` into `StateM Nat`, used to seed both the executable
+semantics and the logical handler. -/
+def interp : ∀ ι : Type, CounterF ι → StateM Nat ι
+  | _, .tick => modify (· + 1)
+  | _, .read => MonadStateOf.get
+
+/-- Logical handler for `CounterF` induced by `interp` and `Std.Do`'s `WP (StateM Nat)`
+instance. -/
+def handler : LHandler CounterF (.arg Nat .pure) :=
+  LHandler.ofInterp CounterF.interp
+
+instance : HasHandler CounterF (.arg Nat .pure) where
+  handler := CounterF.handler
+
+/-- Interpret counter programs as `StateM Nat` programs. -/
+abbrev toStateM {α : Type} (comp : FreeCounter α) : StateM Nat α :=
+  comp.liftM (fun {ι} => CounterF.interp ι)
+
+/-- Adequacy theorem specialized to `CounterF`. -/
+theorem wp_FreeCounter_eq_wp_toStateM {α : Type} (comp : FreeCounter α) :
+    wp comp = wp (CounterF.toStateM comp) :=
+  wpH_ofInterp_eq_wp_liftM (m := StateM Nat) CounterF.interp comp
+
+end CounterF
+
+/-- Smart constructor: tick the counter as a `FreeCounter` action. -/
+abbrev tick : FreeCounter Unit := lift CounterF.tick
+
+/-- Smart constructor: read the counter as a `FreeCounter` action. -/
+abbrev readCounter : FreeCounter Nat := lift CounterF.read
+
+/-- Tick three times, then read out the counter. -/
+def threeTicks : FreeCounter Nat := do
+  tick; tick; tick
+  readCounter
+
+/--
+Triple about the counter program: starting at `0`, the final value is `3` and the final state
+is `3`. Proven by the same bridge-then-`mvcgen` pattern as `incr`.
+-/
+example :
+    ⦃fun s => ⌜s = 0⌝⦄ threeTicks ⦃⇓ v s => ⌜v = 3 ∧ s = 3⌝⦄ := by
+  mvcgen
+  intro s seq0
+  subst seq0
+  exact ⟨rfl, rfl⟩
+
+/-- A failure effect with one operation `fail` of empty answer type. -/
+inductive FailF : Type → Type where
+  /-- Abort the computation. -/
+  | fail : FailF PEmpty.{1}
+
+/-- Logical handler for `FailF`: `fail` has precondition `⌜False⌝`, so it is only provable in
+unreachable branches. -/
+def FailF.handler {ps : PostShape} : LHandler FailF ps where
+  run {_} op := match op with
+    | .fail => PredTrans.const spred(⌜False⌝)
+
+/-- A combined state + failure signature, sequencing `StateF Nat` with `FailF`. -/
+abbrev StateFail := fun α => StateF Nat α ⊕ FailF α
+
+/-- Handler for the combined signature: the sum of the component handlers — the paper's
+`H₁ ⊕ H₂` composition. -/
+instance : HasHandler StateFail (.arg Nat .pure) where
+  handler := StateF.handler.sum FailF.handler
+
+/-- Smart constructor for state-read in the combined signature. -/
+abbrev sfGet : FreeM StateFail Nat := lift (Sum.inl StateF.get)
+
+/-- Smart constructor for state-write in the combined signature. -/
+abbrev sfSet (n : Nat) : FreeM StateFail PUnit := lift (Sum.inl (StateF.set n))
+
+/-- Smart constructor for failure in the combined signature, eliminated to any return type via
+`PEmpty.elim`. -/
+abbrev sfFail {α : Type} : FreeM StateFail α :=
+  lift (Sum.inr FailF.fail) >>= PEmpty.elim
+
+/-- Hoare spec for the sum-lifted state-read. -/
+@[spec]
+theorem Spec.sfGet {Q : PostCond Nat (.arg Nat .pure)} :
+    Triple sfGet (spred(fun s => Q.1 s s)) Q := by
+  mvcgen
+
+/-- Hoare spec for the sum-lifted state-write. -/
+@[spec]
+theorem Spec.sfSet (n : Nat) {Q : PostCond PUnit (.arg Nat .pure)} :
+    Triple (sfSet n) (spred(fun _ => Q.1 ⟨⟩ n)) Q := by
+  mvcgen
+
+/-- Hoare spec for sum-lifted failure: requires `False` to verify. -/
+@[spec]
+theorem Spec.sfFail {α : Type} {Q : PostCond α (.arg Nat .pure)} :
+    Triple (sfFail : FreeM StateFail α) (spred(⌜False⌝)) Q := by
+  mvcgen
+
+/-- A non-branching program in the combined signature: read the state, then write
+`state + 1`. Shows that the sum handler composes the StateF and FailF specs cleanly. -/
+def getAndBump : FreeM StateFail Unit := do
+  let n ← sfGet
+  sfSet (n + 1)
+
+/-- `getAndBump` advances the state by 1, proven through the sum handler. -/
+example (n : Nat) :
+    ⦃fun s => ⌜s = n⌝⦄ (getAndBump : FreeM StateFail Unit)
+      ⦃⇓ _ s => ⌜s = n + 1⌝⦄ := by
+  mvcgen
+  intro s a
+  subst a
+  rfl
+
+/-- Increment the state if it's strictly below `limit`, otherwise fail. Branches on the state's
+value and uses `sfFail` in the else branch. -/
+def bumpUnder (limit : Nat) : FreeM StateFail Unit := do
+  let n ← sfGet
+  if n < limit then sfSet (n + 1) else sfFail
+
+/-- Starting in a state below `limit`, `bumpUnder` increments without failing — the failure
+branch is unreachable because the precondition rules it out. -/
+example (limit n : Nat) (hlt : n < limit) :
+    ⦃fun s => ⌜s = n⌝⦄ (bumpUnder limit : FreeM StateFail Unit)
+      ⦃⇓ _ s => ⌜s = n + 1⌝⦄ := by
+  unfold bumpUnder
+  mvcgen <;> aesop
+
+/-- Demonic non-determinism: a single operation `choice α` that abstractly returns an arbitrary
+`a : α`. Verification must consider all possible values of `a`. -/
+inductive DemonicF : Type → Type 1 where
+  /-- Choose an element of `α`. -/
+  | choice (α : Type) : DemonicF α
+
+/-- Logical handler for `DemonicF`: the predicate transformer for `choice α` is universal
+quantification over `α`. Conjunctivity of `∀` (i.e. `∀ a, P a ∧ Q a ⊣⊢ (∀ a, P a) ∧ (∀ a, Q a)`)
+is what makes this admissible in `PredTrans`. -/
+def DemonicF.handler {ps : PostShape} : LHandler DemonicF ps where
+  run {_} op := match op with
+    | .choice _ =>
+      { trans := fun Q => SPred.forall (fun a => Q.1 a)
+        conjunctiveRaw := by
+          intro Q₁ Q₂
+          apply SPred.bientails.iff.mpr
+          refine ⟨?_, ?_⟩
+          · apply SPred.and_intro
+            · apply SPred.forall_intro
+              intro a
+              exact (SPred.forall_elim a).trans SPred.and_elim_l
+            · apply SPred.forall_intro
+              intro a
+              exact (SPred.forall_elim a).trans SPred.and_elim_r
+          · apply SPred.forall_intro
+            intro a
+            apply SPred.and_intro
+            · exact SPred.and_elim_l.trans (SPred.forall_elim a)
+            · exact SPred.and_elim_r.trans (SPred.forall_elim a) }
+
+instance : HasHandler DemonicF .pure where
+  handler := DemonicF.handler
+
+/-- Smart constructor for demonic choice over `α`. -/
+abbrev demonic (α : Type) : FreeM DemonicF α := lift (DemonicF.choice α)
+
+/-- Triple for `demonic α`: the precondition must imply the postcondition for *every* `a : α`. -/
+@[spec]
+theorem Spec.demonic {α : Type} {Q : PostCond α .pure} :
+    Triple (demonic α) (SPred.forall (fun a : α => Q.1 a)) Q :=
+  Triple.iff.mpr SPred.entails.rfl
+
+/-- A demonic Bool: the precondition must hold for both `true` and `false`. -/
+example {Q : PostCond Bool .pure} :
+    Triple (demonic Bool) (SPred.and (Q.1 true) (Q.1 false)) Q :=
+    fun ⟨ht, hf⟩ b =>
+    match b with
+    | true => ht
+    | false => hf
+
+end CslibTests.FreeMonadWP

--- a/references.bib
+++ b/references.bib
@@ -470,3 +470,17 @@ address = {USA}
   publisher    = {McGraw-Hill},
   isbn         = {0070428077}
 }
+
+@article{VistrupSammlerJung2025,
+  author       = {Max Vistrup and
+                  Michael Sammler and
+                  Ralf Jung},
+  title        = {Program Logics {\`a} la Carte},
+  journal      = {Proc. {ACM} Program. Lang.},
+  volume       = {9},
+  number       = {POPL},
+  pages        = {300--331},
+  year         = {2025},
+  url          = {https://doi.org/10.1145/3704847},
+  doi          = {10.1145/3704847}
+}


### PR DESCRIPTION
This PR adds `Cslib/Foundations/Control/Monad/Free/WP.lean`, which gives `FreeM` programs a `Std.Do.WP` interpretation by lifting logical handlers into the predicate-transformer monad `PredTrans`.

A logical handler `{ι : Type u} → F ι → PredTrans ps ι` assigns each operation of the effect signature `F` a `PredTrans ps` specification. Since `PredTrans ps` is a monad and `FreeM` is free, `FreeM.liftM` extends such a handler to a monad morphism `FreeM F → PredTrans ps`; this is the weakest precondition and is compositional wrt the monadic structure.

A `FreeM.WP F ps` typeclass selects a default handler for `F` and induces `WP (FreeM F) ps` and `WPMonad (FreeM F) ps` instances, so that `Std.Do.Triple` and `mvcgen` apply to `FreeM F` programs. The main coherence lemma is `FreeM.liftM_wp_eq_wp_liftM`, and `FreeM.wp_lift` exposes the one-operation case.

Handlers are provided for cslib's existing `FreeState` and `FreeReader`, along with `@[spec]` lemmas `Spec.get_FreeState`, `Spec.set_FreeState`, and `Spec.read_FreeReader` that let `mvcgen` step through state and reader programs.

`CslibTests/FreeMonadWP.lean` contains example `Triple`s discharged by `mvcgen`, covering the supplied state and reader handlers, custom effects, combined effects, and demonic choice.

The design follows Vistrup, Sammler, Jung, *Program Logics à la Carte* (POPL 2025), which uses coinductive free monads (ITrees) and Iris separation logic. Here we use inductive free monads and `Std.Do` program logic.
