### PR TITLE
feat(Algorithms/Lean/MergeSort): relate mergeSort to List.mergeSort

### DIFF
--- a/Cslib/Algorithms/Lean/MergeSort/MergeSort.lean
+++ b/Cslib/Algorithms/Lean/MergeSort/MergeSort.lean
@@ -7,6 +7,7 @@ Authors: Sorrachai Yingchareonthawornhcai
 module
 
 public import Cslib.Algorithms.Lean.TimeM
+public import Mathlib.Data.List.Sort
 public import Mathlib.Data.Nat.Cast.Order.Ring
 public import Mathlib.Data.Nat.Lattice
 public import Mathlib.Data.Nat.Log
@@ -109,6 +110,16 @@ theorem mergeSort_perm (xs : List α) : ⟪mergeSort xs⟫ ~ xs := by
 /-- MergeSort is functionally correct. -/
 theorem mergeSort_correct (xs : List α) : IsSorted ⟪mergeSort xs⟫ ∧ ⟪mergeSort xs⟫ ~ xs :=
   ⟨mergeSort_sorted xs, mergeSort_perm xs⟩
+
+/-- the timed merge sort computes the same sorted list as list merge sort -/
+@[simp, grind =]
+theorem ret_mergeSort (xs : List α) :
+    ⟪mergeSort xs⟫ = xs.mergeSort (· ≤ ·) := by
+  have hsorted₁ : (⟪mergeSort xs⟫).SortedLE := by
+    simpa [List.sortedLE_iff_pairwise] using mergeSort_sorted xs
+  have hsorted₂ : (xs.mergeSort (· ≤ ·)).SortedLE := List.sortedLE_mergeSort
+  exact List.Perm.eq_of_sortedLE hsorted₁ hsorted₂
+    ((mergeSort_perm xs).trans (List.mergeSort_perm xs (· ≤ ·)).symm)
 
 end Correctness
 


### PR DESCRIPTION
This adds a theorem showing that CSLib's timed `mergeSort` returns the same list as Mathlib's `List.mergeSort` for the linear order comparator.

The theorem gives downstream users a bridge from the timed algorithm to existing `List.mergeSort` facts, while keeping the PR deliberately narrower than the open stability issue.

Validation:
- `lake build Cslib.Algorithms.Lean.MergeSort.MergeSort`
- `lake build --wfail --iofail`
- `lake exe mk_all --check --module`
- `lake test`
- `lake lint`
- `lake exe lint-style`