### PR TITLE
test: use `leanOptions` to unset `linter.style.header` in `CslibTests`

### DIFF
--- a/lakefile.toml
+++ b/lakefile.toml
@@ -27,7 +27,7 @@ globs = ["Cslib.*"]
 [[lean_lib]]
 name = "CslibTests"
 globs = ["CslibTests.+"]
-moreLeanArgs = ["-Dweak.linter.style.header=false"]
+leanOptions = {weak.linter.style.header = false}
 
 [[lean_exe]]
 name = "checkInitImports"


### PR DESCRIPTION
The way this was set previously meant this linter was (correctly) turned off while running `lake test`, but would run while editing files.