### PR TITLE
feat: basic defs of collections of labelled transition systems

### DIFF
--- a/Cslib.lean
+++ b/Cslib.lean
@@ -94,6 +94,7 @@ public import Cslib.Foundations.Semantics.LTS.Termination
 public import Cslib.Foundations.Semantics.LTS.Total
 public import Cslib.Foundations.Semantics.LTS.TraceEq
 public import Cslib.Foundations.Semantics.LTS.Union
+public import Cslib.Foundations.Semantics.LTS.VectorLTS
 public import Cslib.Foundations.Syntax.Congruence
 public import Cslib.Foundations.Syntax.Context
 public import Cslib.Foundations.Syntax.HasAlphaEquiv

--- a/Cslib/Foundations/Semantics/LTS/VectorLTS.lean
+++ b/Cslib/Foundations/Semantics/LTS/VectorLTS.lean
@@ -37,7 +37,7 @@ namespace Cslib
 An indexed collection of LTSes. Each component LTS represents
 the local view of an entity.
 -/
-abbrev LTSVec (Entity : Type u) (State Label : Entity → Type*) :=
+def LTSVec (Entity : Type u) (State Label : Entity → Type*) :=
   (e : Entity) → LTS (State e) (Label e)
 
 /--
@@ -46,7 +46,7 @@ which represents the global view of a collection of LTSes, collectively
 transition for each input vector label to their next states. This
 matches how synchronous distributed systems behave
 -/
-abbrev SynchronousVecLTS (Entity : Type*) (State Label : Entity → Type*) :=
+def SynchronousVecLTS (Entity : Type*) (State Label : Entity → Type*) :=
   LTS ((e : Entity) → State e) ((e : Entity) → Label e)
 
 
@@ -71,7 +71,7 @@ def AsynchronousVecLTS (Entity) (State Label : Entity → Type*) :=
 A model of an asynchronously advancing collection of LTSes. This abstracts
 the behaviour of asynchronous distributed systems.
 -/
-abbrev LTSVec.toAsynchronousVecLTS {Entity}
+def LTSVec.toAsynchronousVecLTS {Entity}
     (State Label : Entity → Type*)
     (l : LTSVec Entity State Label) :
     AsynchronousVecLTS Entity State Label where

--- a/Cslib/Foundations/Semantics/LTS/VectorLTS.lean
+++ b/Cslib/Foundations/Semantics/LTS/VectorLTS.lean
@@ -55,7 +55,7 @@ The LTS that represents the global execution state machine of a
 collection of processes when events arrive in parallel, and
 each process updates its state simultaneously
 -/
-def LTSVec.toSynchronousVecLTS {Entity} {State Label : Entity → Type*}
+def LTSVec.toSynchronousVecLTS (Entity) {State Label : Entity → Type*}
     (l : LTSVec Entity State Label) : SynchronousVecLTS Entity State Label  where
   Tr s μ s' := ∀ e, (l e).Tr (s e) (μ e) (s' e)
 
@@ -64,7 +64,7 @@ The LTS representing the global execution state machine of a collection
 of an asynchronous collection of machines. Here each label arrives
 one at a time at some LTS in the collection of LTSes
 -/
-def AsynchronousVecLTS (Entity : Type*) (State Label : Entity → Type*) :=
+def AsynchronousVecLTS (Entity) (State Label : Entity → Type*) :=
   LTS ((e : Entity) → State e) (Σ (e : Entity), Label e)
 
 /--

--- a/Cslib/Foundations/Semantics/LTS/VectorLTS.lean
+++ b/Cslib/Foundations/Semantics/LTS/VectorLTS.lean
@@ -1,0 +1,67 @@
+/-
+Copyright (c) 2026 Shreyas Srinivas. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Shreyas Srinivas
+-/
+
+module
+
+public import Cslib.Foundations.Semantics.LTS.Basic
+
+/-!
+# Vectors Labelled Transition System (LTS)
+
+Defined vectors of labelled transition systems, an abstraction that frequently
+pops up in the semantics of cryptography, distributed computing, game theory,and concurrency theory.
+
+In particular, there are two "views" of a vector LTSes,
+1. As a vector of many `Entity → LTS State Label` representing multiple
+labelled transition systems, each of which corresponds to the local view
+of a node/entity `e : Entity`.
+
+2. As a single LTS with a state vector `LTS (Fin n → State) (Fin n → Label)`.
+This is the global view of the system in operation
+
+We prove theorems to transition between these two views. This is a common
+theme that occurs in all the aforementioned areas where such labelled transition
+systems are used. Further we provide notions of fair executions, step
+transitions of individual nodes, scheduling, and fairness.
+
+-/
+
+@[expose] public section
+
+namespace Cslib
+
+/--
+An indexed collection of LTSes. Each component LTS represents
+the local view of an entity.
+-/
+abbrev LTSVec (Entity : Type u) (State Label : Entity → Type*) :=
+  (e : Entity) → LTS (State e) (Label e)
+
+/--
+An LTS of vector states and vector labels. A labelled transition system
+which represents the global view of a collection of LTSes, collectively
+transition for each input vector label to their next states. This
+matches how synchronous distributed systems behave
+-/
+abbrev SynchronousVecLTS (Entity : Type u) (State Label : Entity → Type*) :=
+  LTS ((e : Entity) → State e) ((e : Entity) → Label e)
+
+def LTSVec.toSynchronousVecLTS {Entity} {State Label : Entity → Type*}
+    (l : LTSVec Entity State Label) : SynchronousVecLTS Entity State Label  where
+  Tr s μ s' := ∀ e, (l e).Tr (s e) (μ e) (s' e)
+
+/--
+A model of an asynchronously advancing collection of LTSes. This abstracts
+the behaviour of asynchronous distributed systems.
+-/
+abbrev AsynchronousVecLTS (Entity : Type u)
+    (State Label : Entity → Type*)
+    (l : LTSVec Entity State Label) :
+    LTS ((e : Entity) → State e) (Σ (e : Entity), Label e) where
+  Tr := fun s ⟨e, μe⟩ s' =>
+    (l e).Tr (s e) μe (s' e) ∧ ∀ e' ≠ e, s e = s' e
+
+end Cslib

--- a/Cslib/Foundations/Semantics/LTS/VectorLTS.lean
+++ b/Cslib/Foundations/Semantics/LTS/VectorLTS.lean
@@ -49,12 +49,24 @@ matches how synchronous distributed systems behave
 abbrev SynchronousVecLTS (Entity : Type u) (State Label : Entity → Type*) :=
   LTS ((e : Entity) → State e) ((e : Entity) → Label e)
 
+
+/--
+The LTS that represents the global execution state machine of a
+collection of processes when events arrive in parallel, and
+each process updates its state simultaneously
+-/
 def LTSVec.toSynchronousVecLTS {Entity} {State Label : Entity → Type*}
     (l : LTSVec Entity State Label) : SynchronousVecLTS Entity State Label  where
   Tr s μ s' := ∀ e, (l e).Tr (s e) (μ e) (s' e)
 
+/--
+The LTS representing the global execution state machine of a collection
+of an asynchronous collection of machines. Here each label arrives
+one at a time at some LTS in the collection of LTSes
+-/
 def AsynchronousVecLTS (Entity : Type u) (State Label : Entity → Type*) :=
   LTS ((e : Entity) → State e) (Σ (e : Entity), Label e)
+
 /--
 A model of an asynchronously advancing collection of LTSes. This abstracts
 the behaviour of asynchronous distributed systems.

--- a/Cslib/Foundations/Semantics/LTS/VectorLTS.lean
+++ b/Cslib/Foundations/Semantics/LTS/VectorLTS.lean
@@ -53,14 +53,16 @@ def LTSVec.toSynchronousVecLTS {Entity} {State Label : Entity → Type*}
     (l : LTSVec Entity State Label) : SynchronousVecLTS Entity State Label  where
   Tr s μ s' := ∀ e, (l e).Tr (s e) (μ e) (s' e)
 
+def AsynchronousVecLTS (Entity : Type u) (State Label : Entity → Type*) :=
+  LTS ((e : Entity) → State e) (Σ (e : Entity), Label e)
 /--
 A model of an asynchronously advancing collection of LTSes. This abstracts
 the behaviour of asynchronous distributed systems.
 -/
-abbrev AsynchronousVecLTS (Entity : Type u)
+abbrev LTSVec.toAsynchronousVecLTS (Entity : Type u)
     (State Label : Entity → Type*)
     (l : LTSVec Entity State Label) :
-    LTS ((e : Entity) → State e) (Σ (e : Entity), Label e) where
+    AsynchronousVecLTS Entity State Label where
   Tr := fun s ⟨e, μe⟩ s' =>
     (l e).Tr (s e) μe (s' e) ∧ ∀ e' ≠ e, s e = s' e
 

--- a/Cslib/Foundations/Semantics/LTS/VectorLTS.lean
+++ b/Cslib/Foundations/Semantics/LTS/VectorLTS.lean
@@ -46,7 +46,7 @@ which represents the global view of a collection of LTSes, collectively
 transition for each input vector label to their next states. This
 matches how synchronous distributed systems behave
 -/
-abbrev SynchronousVecLTS (Entity : Type u) (State Label : Entity → Type*) :=
+abbrev SynchronousVecLTS (Entity : Type*) (State Label : Entity → Type*) :=
   LTS ((e : Entity) → State e) ((e : Entity) → Label e)
 
 
@@ -64,14 +64,14 @@ The LTS representing the global execution state machine of a collection
 of an asynchronous collection of machines. Here each label arrives
 one at a time at some LTS in the collection of LTSes
 -/
-def AsynchronousVecLTS (Entity : Type u) (State Label : Entity → Type*) :=
+def AsynchronousVecLTS (Entity : Type*) (State Label : Entity → Type*) :=
   LTS ((e : Entity) → State e) (Σ (e : Entity), Label e)
 
 /--
 A model of an asynchronously advancing collection of LTSes. This abstracts
 the behaviour of asynchronous distributed systems.
 -/
-abbrev LTSVec.toAsynchronousVecLTS (Entity : Type u)
+abbrev LTSVec.toAsynchronousVecLTS {Entity}
     (State Label : Entity → Type*)
     (l : LTSVec Entity State Label) :
     AsynchronousVecLTS Entity State Label where

--- a/CslibTests.lean
+++ b/CslibTests.lean
@@ -1,15 +1,13 @@
-module  -- shake: keep-all --deprecated_module: ignore
-
-public import CslibTests.Bisimulation
-public import CslibTests.CCS
-public import CslibTests.CLL
-public import CslibTests.DFA
-public import CslibTests.FreeMonad
-public import CslibTests.GrindLint
-public import CslibTests.HML
-public import CslibTests.HasFresh
-public import CslibTests.ImportWithMathlib
-public import CslibTests.LTS
-public import CslibTests.LambdaCalculus
-public import CslibTests.MLL
-public import CslibTests.Reduction
+import CslibTests.Bisimulation
+import CslibTests.CCS
+import CslibTests.CLL
+import CslibTests.DFA
+import CslibTests.FreeMonad
+import CslibTests.GrindLint
+import CslibTests.HML
+import CslibTests.HasFresh
+import CslibTests.ImportWithMathlib
+import CslibTests.LTS
+import CslibTests.LambdaCalculus
+import CslibTests.MLL
+import CslibTests.Reduction

--- a/CslibTests.lean
+++ b/CslibTests.lean
@@ -1,13 +1,15 @@
-import CslibTests.Bisimulation
-import CslibTests.CCS
-import CslibTests.CLL
-import CslibTests.DFA
-import CslibTests.FreeMonad
-import CslibTests.GrindLint
-import CslibTests.HML
-import CslibTests.HasFresh
-import CslibTests.ImportWithMathlib
-import CslibTests.LTS
-import CslibTests.LambdaCalculus
-import CslibTests.MLL
-import CslibTests.Reduction
+module  -- shake: keep-all --deprecated_module: ignore
+
+public import CslibTests.Bisimulation
+public import CslibTests.CCS
+public import CslibTests.CLL
+public import CslibTests.DFA
+public import CslibTests.FreeMonad
+public import CslibTests.GrindLint
+public import CslibTests.HML
+public import CslibTests.HasFresh
+public import CslibTests.ImportWithMathlib
+public import CslibTests.LTS
+public import CslibTests.LambdaCalculus
+public import CslibTests.MLL
+public import CslibTests.Reduction


### PR DESCRIPTION
I introduce a general framework for reasoning about collections of labelled transition systems. Such systems arise in a number of models of concurrent and distributed systems as semantic models. Here, we don't aim to provide a specific semantic model. We instead provide LTS API that can be used for manipulating collections of LTSes when defining such models in subsequent PRs.

Context : This was discussed in the online CSLib meeting on 18th June 2026. 