### PR TITLE
feat(Logics/Modal): semantics for the modal metalogic, compatible with constructive modal theories

### DIFF
--- a/Cslib/Logics/Modal/Basic.lean
+++ b/Cslib/Logics/Modal/Basic.lean
@@ -8,19 +8,41 @@ module
 
 public import Cslib.Init
 public import Cslib.Foundations.Logic.InferenceSystem
-public import Mathlib.Data.Set.Basic
 public import Mathlib.Order.Defs.Unbundled
-public import Cslib.Foundations.Relation.Euclidean
 public import Mathlib.Logic.Nonempty
+public import Cslib.Foundations.Relation.Defs
+public import Mathlib.Data.Finset.Attr
+public import Mathlib.Data.Set.Operations
+public import Mathlib.Tactic.Attr.Core
+public import Mathlib.Tactic.Finiteness.Attr
+public import Mathlib.Tactic.SetLike
+public import Mathlib.Tactic.ToAdditive
 
 /-! # Modal Logic
 
 Modal logic is a logic for reasoning about relational structures, studying statements about
 necessity (`□φ`) and possibility `◇φ`.
 
+## Primitives
+
+The formula type uses `{atom, bot, imp, and, or, box, diamond}` as native constructors,
+mirroring `Cslib.Logic.PL.Proposition`'s native `and`/`or`. Negation and verum remain derived
+connectives via the Łukasiewicz convention: `¬φ := φ → ⊥`, `⊤ := ⊥ → ⊥`.
+
+**Why is diamond primitive here (unlike the historical CSLib presentation)?** Classically,
+diamond can be derived from box as `◇φ := ¬□¬φ`, and box alone suffices for necessitation and
+the K axiom. However, `diamond` is kept as a native constructor (alongside `and`/`or`) so that:
+(1) the tableau and truth-lemma machinery get one decomposition rule per connective (structural
+induction, no Łukasiewicz-bridge lemmas), and (2) future non-classical modal logics
+(intuitionistic, minimal — see [Simpson1994]) can reuse this same datatype, since `□` and `◇`
+become independent operators in those settings. Classically, the duality `◇φ ↔ ¬□¬φ` is
+recovered as a genuine *theorem* (`Satisfies.dual`, proved semantically) rather than holding
+definitionally.
+
 ## References
 
 * [P. Blackburn, M. de Rijke, Y. Venema, *Modal Logic*][Blackburn2001]
+* [A. K. Simpson, *The Proof Theory and Semantics of Intuitionistic Modal Logic*][Simpson1994]
 * The definitions of theory equivalence and the denotational semantics of worlds are inspired by
   the development of `Cslib.Logic.HML`.
 -/
@@ -36,48 +58,60 @@ structure Model (World : Type*) (Atom : Type*) where
   /-- Valuation of atoms at a world. -/
   v : World → Atom → Prop
 
-/-- Propositions. -/
+/-- Propositions. Primitives are atoms, falsum, implication, conjunction, disjunction,
+necessity (box), and possibility (diamond). -/
 inductive Proposition (Atom : Type u) : Type u where
   /-- Atomic proposition. -/
   | atom (p : Atom)
-  /-- Negation. -/
-  | not (φ : Proposition Atom)
+  /-- Falsum / bottom. -/
+  | bot
+  /-- Implication. -/
+  | imp (φ₁ φ₂ : Proposition Atom)
   /-- Conjunction. -/
   | and (φ₁ φ₂ : Proposition Atom)
+  /-- Disjunction. -/
+  | or (φ₁ φ₂ : Proposition Atom)
+  /-- Necessity. -/
+  | box (φ : Proposition Atom)
   /-- Possibility. -/
   | diamond (φ : Proposition Atom)
+  deriving DecidableEq
 
-@[inherit_doc] scoped prefix:40 "¬" => Proposition.not
 @[inherit_doc] scoped infix:36 " ∧ " => Proposition.and
+@[inherit_doc] scoped infix:35 " ∨ " => Proposition.or
+@[inherit_doc] scoped infix:30 " → " => Proposition.imp
+@[inherit_doc] scoped prefix:40 "□" => Proposition.box
 @[inherit_doc] scoped prefix:40 "◇" => Proposition.diamond
 
-/-- Disjunction. -/
-def Proposition.or (φ₁ φ₂ : Proposition Atom) : Proposition Atom := ¬(¬φ₁ ∧ ¬φ₂)
+/-- Negation, derived via the Łukasiewicz convention: `¬φ := φ → ⊥`. -/
+def Proposition.neg (φ : Proposition Atom) : Proposition Atom := .imp φ .bot
 
-@[inherit_doc] scoped infix:35 " ∨ " => Proposition.or
+@[inherit_doc] scoped prefix:40 "¬" => Proposition.neg
 
-/-- Implication. -/
-def Proposition.impl (φ₁ φ₂ : Proposition Atom) : Proposition Atom := ¬φ₁ ∨ φ₂
+/-- Verum, derived via the Łukasiewicz convention: `⊤ := ⊥ → ⊥`. -/
+def Proposition.top : Proposition Atom := .imp .bot .bot
 
-@[inherit_doc] scoped infix:30 " → " => Proposition.impl
+/-- Reduction lemma: `¬φ` unfolds to `.imp φ .bot`. -/
+@[simp] theorem Proposition.neg_def (φ : Proposition Atom) : Proposition.neg φ = .imp φ .bot := rfl
+
+/-- Reduction lemma: `top` unfolds to `.imp .bot .bot`. -/
+@[simp] theorem Proposition.top_def : (Proposition.top : Proposition Atom) = .imp .bot .bot := rfl
 
 /-- Bi-implication. -/
 def Proposition.iff (φ₁ φ₂ : Proposition Atom) : Proposition Atom := (φ₁ → φ₂) ∧ (φ₂ → φ₁)
 
 @[inherit_doc] scoped infix:30 " ↔ " => Proposition.iff
 
-/-- Necessity. -/
-def Proposition.box (φ : Proposition Atom) : Proposition Atom := ¬◇¬φ
-
-@[inherit_doc] scoped prefix:40 "□" => Proposition.box
-
 /-- Satisfaction relation. `Satisfies m w φ` means that, in the model `m`, the world `w` satisfies
 the proposition `φ`. -/
 @[scoped grind]
 def Satisfies (m : Model World Atom) (w : World) : Proposition Atom → Prop
   | .atom p => m.v w p
-  | .not φ => ¬Satisfies m w φ
+  | .bot => False
+  | .imp φ₁ φ₂ => Satisfies m w φ₁ → Satisfies m w φ₂
   | .and φ₁ φ₂ => Satisfies m w φ₁ ∧ Satisfies m w φ₂
+  | .or φ₁ φ₂ => Satisfies m w φ₁ ∨ Satisfies m w φ₂
+  | .box φ => ∀ w', m.r w w' → Satisfies m w' φ
   | .diamond φ => ∃ w', m.r w w' ∧ Satisfies m w' φ
 
 /-- Judgement, representing the conclusions one reaches in modal logic. -/
@@ -107,25 +141,23 @@ theorem derivation_def {m : Model World Atom} {w : World} {φ : Proposition Atom
 
 /-- A world satisfies a proposition iff it does not satisfy the negation of the proposition. -/
 @[scoped grind =]
-theorem not_satisfies : ⇓Modal[m,w ⊨ ¬φ] ↔ ¬⇓Modal[m,w ⊨ φ] := by
-  induction φ generalizing w <;> grind
+theorem not_satisfies : ⇓Modal[m,w ⊨ ¬φ] ↔ ¬⇓Modal[m,w ⊨ φ] := Iff.rfl
 
 /-- Characterisation of the `∨` connective.
 
-Disjunction is defined in terms of the more primitive connectives given in `Proposition`.
-This result proves that the definition is correct. -/
+Disjunction is a native connective given directly by `Satisfies`; this result records the
+characterisation for use by `grind`. -/
 @[scoped grind =]
 theorem Satisfies.or_iff_or {m : Model World Atom} :
-    ⇓Modal[m,w ⊨ φ₁ ∨ φ₂] ↔ ⇓Modal[m,w ⊨ φ₁] ∨ ⇓Modal[m,w ⊨ φ₂] := by grind [Proposition.or]
+    ⇓Modal[m,w ⊨ φ₁ ∨ φ₂] ↔ ⇓Modal[m,w ⊨ φ₁] ∨ ⇓Modal[m,w ⊨ φ₂] := Iff.rfl
 
 /-- Characterisation of the `→` connective.
 
-Implication is defined in terms of the more primitive connectives given in `Proposition`.
-This result proves that the definition is correct.
--/
+Implication is a native connective given directly by `Satisfies`; this result records the
+characterisation for use by `grind`. -/
 @[scoped grind =]
 theorem Satisfies.impl_iff_impl {m : Model World Atom} :
-    ⇓Modal[m,w ⊨ φ₁ → φ₂] ↔ (⇓Modal[m,w ⊨ φ₁] → ⇓Modal[m,w ⊨ φ₂]) := by grind [Proposition.impl]
+    ⇓Modal[m,w ⊨ φ₁ → φ₂] ↔ (⇓Modal[m,w ⊨ φ₁] → ⇓Modal[m,w ⊨ φ₂]) := Iff.rfl
 
 /-- Characterisation of the `↔` connective.
 
@@ -139,11 +171,27 @@ theorem Satisfies.iff_iff_iff {m : Model World Atom} :
 
 /-- Characterisation of the `□` modality.
 
-Necessity is defined in terms of the more primitive connectives given in `Proposition`.
-This result proves that the definition is correct. -/
+Necessity is a native connective given directly by `Satisfies`; this result records the
+characterisation for use by `grind`. -/
 @[scoped grind =]
 theorem Satisfies.box_iff_forall {m : Model World Atom} :
-    ⇓Modal[m,w ⊨ □φ] ↔ ∀ w', m.r w w' → ⇓Modal[m,w' ⊨ φ] := by grind [Proposition.box]
+    ⇓Modal[m,w ⊨ □φ] ↔ ∀ w', m.r w w' → ⇓Modal[m,w' ⊨ φ] := Iff.rfl
+
+/-- Characterisation of the `◇` modality.
+
+Possibility is a native connective given directly by `Satisfies`; this result records the
+characterisation for use by `grind`. -/
+@[scoped grind =]
+theorem Satisfies.diamond_iff_exists {m : Model World Atom} :
+    ⇓Modal[m,w ⊨ ◇φ] ↔ ∃ w', m.r w w' ∧ ⇓Modal[m,w' ⊨ φ] := Iff.rfl
+
+/-- Characterisation of the `∧` connective.
+
+Conjunction is a native connective given directly by `Satisfies`; this result records the
+characterisation for use by `grind`. -/
+@[scoped grind =]
+theorem Satisfies.and_iff_and {m : Model World Atom} :
+    ⇓Modal[m,w ⊨ φ₁ ∧ φ₂] ↔ ⇓Modal[m,w ⊨ φ₁] ∧ ⇓Modal[m,w ⊨ φ₂] := Iff.rfl
 
 /-- The theory of a world in a model is the set of all propositions that it satifies. -/
 abbrev theory (m : Model World Atom) (w : World) : Set (Proposition Atom) :=
@@ -175,10 +223,19 @@ theorem theoryEq_satisfies {m : Model World Atom} (h : TheoryEq m w₁ w₂)
 theorem Satisfies.k : ⇓Modal[m,w ⊨ □(φ₁ → φ₂) → (□φ₁ → □φ₂)] := by grind
 
 set_option linter.tacticAnalysis.verifyGrindOnly false in
-/-- The dual axiom, valid for all models. -/
+/-- The dual axiom, valid for all models.
+
+Since `diamond` is a native constructor, this is no longer a definitional unfolding: it is proved
+as a genuine semantic theorem using excluded middle. -/
 theorem Satisfies.dual : ⇓Modal[m,w ⊨ ◇φ ↔ ¬□¬φ] := by
-  grind only [Satisfies.iff_iff_iff.mpr, → satisfies_theory, usr Set.mem_setOf_eq, = impl_iff_impl,
-    =_ derivation_def, = not_satisfies, Satisfies, = box_iff_forall, = Set.setOf_true]
+  simp only [← derivation_def, Proposition.iff, Proposition.neg_def, Satisfies]
+  constructor
+  · rintro ⟨w', hr, hs⟩ hbox
+    exact hbox w' hr hs
+  · intro h
+    by_contra hc
+    push Not at hc
+    exact h fun w' hr hs => hc w' hr hs
 
 /-- The T axiom, valid for all reflexive models. -/
 theorem Satisfies.t {m : Model World Atom} [instRefl : Std.Refl m.r] {w : World}

--- a/Cslib/Logics/Modal/Cube.lean
+++ b/Cslib/Logics/Modal/Cube.lean
@@ -7,6 +7,7 @@ Authors: Fabrizio Montesi, Marianna Girlando
 module
 
 public import Cslib.Logics.Modal.Basic
+public import Cslib.Foundations.Relation.Euclidean
 
 /-! # Modal Logic Cube
 

--- a/Cslib/Logics/Modal/Denotation.lean
+++ b/Cslib/Logics/Modal/Denotation.lean
@@ -7,6 +7,7 @@ Authors: Fabrizio Montesi
 module
 
 public import Cslib.Logics.Modal.Basic
+public import Mathlib.Data.Set.Basic
 
 /-! # Denotational semantics for Modal Logic
 
@@ -25,27 +26,66 @@ open scoped Proposition InferenceSystem
 def Proposition.denotation (m : Model World Atom) :
     Proposition Atom → Set World
   | .atom p => {w | m.v w p}
-  | .not φ => (φ.denotation m)ᶜ
+  | .bot => ∅
+  | .imp φ₁ φ₂ => (φ₁.denotation m)ᶜ ∪ φ₂.denotation m
   | .and φ₁ φ₂ => φ₁.denotation m ∩ φ₂.denotation m
+  | .or φ₁ φ₂ => φ₁.denotation m ∪ φ₂.denotation m
+  | .box φ => {w | ∀ w', m.r w w' → w' ∈ φ.denotation m}
   | .diamond φ => {w | ∃ w', m.r w w' ∧ w' ∈ φ.denotation m}
 
 /-- Characterisation theorem for the denotational semantics. -/
 @[scoped grind =]
 theorem satisfies_mem_denotation {m : Model World Atom} {φ : Proposition Atom} :
     w ∈ φ.denotation m ↔ ⇓Modal[m,w ⊨ φ] := by
-  induction φ generalizing w <;> grind
+  induction φ generalizing w with
+  | atom p => simp [Proposition.denotation, ← derivation_def, Satisfies]
+  | bot => simp [Proposition.denotation, ← derivation_def, Satisfies]
+  | imp φ₁ φ₂ ih₁ ih₂ =>
+    simp only [Proposition.denotation, Set.mem_union, Set.mem_compl_iff, ← derivation_def,
+      Satisfies]
+    constructor
+    · intro h hs₁
+      rcases h with h | h
+      · exact absurd (ih₁.mpr hs₁) h
+      · exact ih₂.mp h
+    · intro h
+      by_cases hs : w ∈ φ₁.denotation m
+      · exact Or.inr (ih₂.mpr (h (ih₁.mp hs)))
+      · exact Or.inl hs
+  | and φ₁ φ₂ ih₁ ih₂ =>
+    simp only [Proposition.denotation, Set.mem_inter_iff, ← derivation_def, Satisfies]
+    exact ⟨fun ⟨h1, h2⟩ => ⟨ih₁.mp h1, ih₂.mp h2⟩, fun ⟨h1, h2⟩ => ⟨ih₁.mpr h1, ih₂.mpr h2⟩⟩
+  | or φ₁ φ₂ ih₁ ih₂ =>
+    simp only [Proposition.denotation, Set.mem_union, ← derivation_def, Satisfies]
+    exact ⟨fun h => h.imp ih₁.mp ih₂.mp, fun h => h.imp ih₁.mpr ih₂.mpr⟩
+  | box φ ih =>
+    simp only [Proposition.denotation, Set.mem_setOf_eq, ← derivation_def, Satisfies]
+    exact ⟨fun h w' hr => ih.mp (h w' hr), fun h w' hr => ih.mpr (h w' hr)⟩
+  | diamond φ ih =>
+    simp only [Proposition.denotation, Set.mem_setOf_eq, ← derivation_def, Satisfies]
+    exact ⟨fun ⟨w', hr, hs⟩ => ⟨w', hr, ih.mp hs⟩, fun ⟨w', hr, hs⟩ => ⟨w', hr, ih.mpr hs⟩⟩
 
 /-- A world is in the denotation of a proposition iff it is not in the denotation of the negation
 of the proposition. -/
 @[scoped grind =]
 theorem not_denotation {m : Model World Atom} (φ : Proposition Atom) :
     w ∉ (¬φ).denotation m ↔ w ∈ φ.denotation m := by
-  grind [_=_ satisfies_mem_denotation]
+  simp [Proposition.neg_def, Proposition.denotation]
 
 /-- Two worlds are theory-equivalent iff they are denotationally equivalent. -/
 theorem theoryEq_denotation_eq {m : Model World Atom} {w₁ w₂ : World} :
     (TheoryEq m w₁ w₂) ↔
     (∀ (φ : Proposition Atom), w₁ ∈ (φ.denotation m) ↔ w₂ ∈ (φ.denotation m)) := by
-  apply Iff.intro <;> grind [_=_ satisfies_mem_denotation]
+  constructor
+  · intro h φ
+    have hext := TheoryEq.ext_iff.mp h φ
+    exact ⟨fun h₁ => satisfies_mem_denotation.mpr (hext.mp (satisfies_mem_denotation.mp h₁)),
+           fun h₂ => satisfies_mem_denotation.mpr (hext.mpr (satisfies_mem_denotation.mp h₂))⟩
+  · intro h
+    apply TheoryEq.ext_iff.mpr
+    intro φ
+    have hd := h φ
+    exact ⟨fun h₁ => satisfies_mem_denotation.mp (hd.mp (satisfies_mem_denotation.mpr h₁)),
+           fun h₂ => satisfies_mem_denotation.mp (hd.mpr (satisfies_mem_denotation.mpr h₂))⟩
 
 end Cslib.Logic.Modal

--- a/Cslib/Logics/Modal/LogicalEquivalence.lean
+++ b/Cslib/Logics/Modal/LogicalEquivalence.lean
@@ -54,7 +54,7 @@ theorem Proposition.equiv_valid (S : Set (Model World Atom))
 /-- Propositional contexts. -/
 inductive Proposition.Context (Atom : Type u) : Type u where
   | hole
-  | not (c : Context Atom)
+  | neg (c : Context Atom)
   | andL (c : Context Atom) (φ : Proposition Atom)
   | andR (φ : Proposition Atom) (c : Context Atom)
   | diamond (c : Context Atom)
@@ -64,7 +64,7 @@ inductive Proposition.Context (Atom : Type u) : Type u where
 def Proposition.Context.fill (c : Context Atom) (φ : Proposition Atom) :=
   match c with
   | hole => φ
-  | not c => .not (c.fill φ)
+  | neg c => Proposition.neg (c.fill φ)
   | andL c φ' => (c.fill φ).and φ'
   | andR φ' c => φ'.and (c.fill φ)
   | diamond c => .diamond (c.fill φ)
@@ -89,7 +89,7 @@ instance {World Atom} (S : Set (Model World Atom)) :
   elim ctx φ₁ φ₂ heqv m hₘ w := by
     induction ctx generalizing w
     case hole => grind
-    case not c ih | andL c ih | andR c ih =>
+    case neg c ih | andL c ih | andR c ih =>
       specialize ih w
       grind
     case diamond c ih =>

--- a/references.bib
+++ b/references.bib
@@ -477,6 +477,13 @@ address = {USA}
   year         = {2022}
 }
 
+@phdthesis{Simpson1994,
+  author = {Simpson, Alex K.},
+  title  = {The Proof Theory and Semantics of Intuitionistic Modal Logic},
+  school = {University of Edinburgh},
+  year   = {1994}
+}
+
 @book{Sipser2013,
   author    = {Sipser, Michael},
   title     = {Introduction to the Theory of Computation},


### PR DESCRIPTION
Contributes a foundational **semantic layer for the modal metalogic**, designed to be compatible with the intuitionistic and constructive modal systems (IK, CK). This is the substantive ambition of the PR; the native `Proposition` datatype it is built on is the enabling foundation.

## The semantic layer

Built on a native 7-primitive `Proposition`:

```
Proposition {atom, bot, imp, and, or, box, diamond}
```

(negation and verum stay derived via the Łukasiewicz convention `¬φ := φ → ⊥`, `⊤ := ⊥ → ⊥`, mirroring `Cslib.Logic.PL.Proposition`'s native `and`/`or`), it provides:

- **`Satisfies`** — the satisfaction relation, defined natively over all 7 constructors.
- **Denotational semantics** — `Denotation.lean` extended to every constructor, with `satisfies_mem_denotation`, `not_denotation`, and `theoryEq_denotation_eq`.
- **The duality theorem** `◇φ ↔ ¬□¬φ` — recovered as a *proved* semantic theorem (`Satisfies.dual`, via excluded middle) rather than baked in as a definition.
- **One decomposition lemma per connective** — now `Iff.rfl`, since every connective is structural (no Łukasiewicz-bridge lemmas).
- **K-axiom validity**, and the T/B/4/5/D frame-correspondence results and their converses, all preserved.

## Why both `box` and `diamond` primitive?

Classically `◇φ := ¬□¬φ` suffices, but in IK/CK `□` and `◇` are **not** interdefinable ([Simpson 1994]). Keeping both native means the same datatype carries unchanged into those systems, and the semantic/tableau layer gets one clean decomposition rule per connective. Classically nothing is lost — the duality is recovered as the theorem above.

## Relationship to #607 (rebase plan)

The native primitive-constructor design — `{atom, bot, imp, and, or, box, diamond}` with `box`/`diamond` both primitive — is the subject of #607, where the operator layer is being standardised. **This PR is intended to be rebased onto #607 once it lands**, so that the primitive constructors come from #607 and this PR carries only the semantic layer on top.

Until then it is based on `main` and self-contained, so it builds and can be reviewed independently. Coordination on the native primitive set is ongoing on #607 and the CSLib > Modal Logic Zulip thread.

## Changes (5 files, +145 / −40 against `main`; the base will move to #607 on rebase)

- **`Cslib/Logics/Modal/Basic.lean`** — 7-primitive `Proposition`; native `Satisfies`; derived `neg`/`top`/`iff`; per-connective characterisation lemmas (now `Iff.rfl`); `Satisfies.dual` as a semantic theorem. All existing theorems preserved — including the T/B/4/5/D frame-correspondence results and their converses.
- **`Cslib/Logics/Modal/Denotation.lean`** — denotation extended to all 7 constructors; `satisfies_mem_denotation`, `not_denotation`, `theoryEq_denotation_eq` preserved.
- **`Cslib/Logics/Modal/Cube.lean`** — unchanged except an import; the Modal Cube (K…S5) and its validities carry over.
- **`Cslib/Logics/Modal/LogicalEquivalence.lean`** — one-hole `Context` `not`→`neg` former; congruence/`LogicalEquivalence` instances preserved.
- **`references.bib`** — adds the Simpson 1994 reference.

Notation (`¬ ∧ ∨ → □ ◇ ↔`) and every theorem name are preserved. Two derived definitions are renamed to match the native constructors — `Proposition.not` → `Proposition.neg` and `Proposition.impl` → `Proposition.imp` — and `box`/`or` move from derived definitions to native constructors under the same names (`Proposition.Context.not` is likewise renamed to `neg`). Sorry-free; axioms limited to `propext` / `Classical.choice` / `Quot.sound`. Full `lake build`, `checkInitImports`, `lake lint`, `lint-style`, `lake test`, and `shake` pass.

## AI Disclosure

This work was drafted with the assistance of an AI coding agent (Claude, Anthropic) under the contributor's direction. All proofs were machine-checked by `lake build`/`lake lint` and the full CSLib CI, and reviewed before submission. Design decisions and review are the contributor's.
