### PR TITLE
feat: `Set.ReflOn`, `Set.SymmOn`

### DIFF
--- a/Cslib.lean
+++ b/Cslib.lean
@@ -76,6 +76,7 @@ public import Cslib.Foundations.Relation.Confluence
 public import Cslib.Foundations.Relation.Defs
 public import Cslib.Foundations.Relation.Domain
 public import Cslib.Foundations.Relation.Euclidean
+public import Cslib.Foundations.Relation.Restriction
 public import Cslib.Foundations.Semantics.FLTS.Basic
 public import Cslib.Foundations.Semantics.FLTS.FLTSToLTS
 public import Cslib.Foundations.Semantics.FLTS.LTSToFLTS

--- a/Cslib/Foundations/Relation/Defs.lean
+++ b/Cslib/Foundations/Relation/Defs.lean
@@ -138,15 +138,19 @@ namespace Set
 
 open Relation
 
+/-- `ReflOn s r` is true when a relation `r` is reflexive on its restriction to a set `s`. -/
 def ReflOn (s : Set α) (r : α → α → Prop) : Prop :=
   ∀ a ∈ s, r a a
 
 -- these names are used in the literature, so we provide them as `abbrev`
 
+/-- `LeftQuasiRefl r` is true when a relation `r` is reflexive on its domain. -/
 abbrev LeftQuasiRefl (r : α → α → Prop) := (dom r).ReflOn r
 
+/-- `RightQuasiRefl r` is true when a relation `r` is reflexive on its codomain. -/
 abbrev RightQuasiRefl (r : α → α → Prop) := (cod r).ReflOn r
 
+/-- `SymmOn s r` ts true when a relation `r` is symmetric on its restriction to a set `s`. -/
 def SymmOn (s : Set α) (r : α → α → Prop) : Prop :=
   ∀ a ∈ s, ∀ b ∈ s, r a b → r b a
 

--- a/Cslib/Foundations/Relation/Defs.lean
+++ b/Cslib/Foundations/Relation/Defs.lean
@@ -132,16 +132,22 @@ def transLeft (s r : α → α → Prop) [IsTrans α r] (h : s ≤ r) : Trans s 
 def transRight (s r : α → α → Prop) [IsTrans α r] (h : s ≤ r) : Trans r s r where
   trans hab hbc := _root_.trans hab (h _ _ hbc)
 
-def ReflOn (r : α → α → Prop) (s : Set α) : Prop :=
+end Relation
+
+namespace Set
+
+open Relation
+
+def ReflOn (s : Set α) (r : α → α → Prop) : Prop :=
   ∀ a ∈ s, r a a
 
 -- these names are used in the literature, so we provide them as `abbrev`
 
-abbrev LeftQuasiRefl (r : α → α → Prop) := ReflOn r (dom r)
+abbrev LeftQuasiRefl (r : α → α → Prop) := (dom r).ReflOn r
 
-abbrev RightQuasiRefl (r : α → α → Prop) := ReflOn r (cod r)
+abbrev RightQuasiRefl (r : α → α → Prop) := (cod r).ReflOn r
 
-def SymmOn (r : α → α → Prop) (s : Set α) : Prop :=
+def SymmOn (s : Set α) (r : α → α → Prop) : Prop :=
   ∀ a ∈ s, ∀ b ∈ s, r a b → r b a
 
-end Relation
+end Set

--- a/Cslib/Foundations/Relation/Defs.lean
+++ b/Cslib/Foundations/Relation/Defs.lean
@@ -150,7 +150,7 @@ abbrev LeftQuasiRefl (r : α → α → Prop) := (dom r).ReflOn r
 /-- `RightQuasiRefl r` is true when a relation `r` is reflexive on its codomain. -/
 abbrev RightQuasiRefl (r : α → α → Prop) := (cod r).ReflOn r
 
-/-- `SymmOn s r` ts true when a relation `r` is symmetric on its restriction to a set `s`. -/
+/-- `SymmOn s r` is true when a relation `r` is symmetric on its restriction to a set `s`. -/
 def SymmOn (s : Set α) (r : α → α → Prop) : Prop :=
   ∀ a ∈ s, ∀ b ∈ s, r a b → r b a
 

--- a/Cslib/Foundations/Relation/Defs.lean
+++ b/Cslib/Foundations/Relation/Defs.lean
@@ -132,4 +132,16 @@ def transLeft (s r : α → α → Prop) [IsTrans α r] (h : s ≤ r) : Trans s 
 def transRight (s r : α → α → Prop) [IsTrans α r] (h : s ≤ r) : Trans r s r where
   trans hab hbc := _root_.trans hab (h _ _ hbc)
 
+def ReflOn (r : α → α → Prop) (s : Set α) : Prop :=
+  ∀ a ∈ s, r a a
+
+-- these names are used in the literature, so we provide them as `abbrev`
+
+abbrev LeftQuasiRefl (r : α → α → Prop) := ReflOn r (dom r)
+
+abbrev RightQuasiRefl (r : α → α → Prop) := ReflOn r (cod r)
+
+def SymmOn (r : α → α → Prop) (s : Set α) : Prop :=
+  ∀ a ∈ s, ∀ b ∈ s, r a b → r b a
+
 end Relation

--- a/Cslib/Foundations/Relation/Domain.lean
+++ b/Cslib/Foundations/Relation/Domain.lean
@@ -34,8 +34,8 @@ variable {β : Type*} {r : α → β → Prop}
 @[simp, grind =] lemma mem_dom : a ∈ dom r ↔ ∃ b, r a b := .rfl
 @[simp, grind =] lemma mem_cod : b ∈ cod r ↔ ∃ a, r a b := .rfl
 
-theorem dom_of (hab : r a b) : a ∈ dom r := by grind
-theorem cod_of (hab : r a b) : b ∈ cod r := by grind
+theorem of_dom (hab : r a b) : a ∈ dom r := by grind
+theorem of_cod (hab : r a b) : b ∈ cod r := by grind
 
 @[gcongr] lemma dom_mono (h : r₁ ≤ r₂) : dom r₁ ⊆ dom r₂ := fun a ⟨b, hab⟩ => ⟨b, h a b hab⟩
 @[gcongr] lemma cod_mono (h : r₁ ≤ r₂) : cod r₁ ⊆ cod r₂ := fun b ⟨a, hab⟩ => ⟨a, h a b hab⟩

--- a/Cslib/Foundations/Relation/Domain.lean
+++ b/Cslib/Foundations/Relation/Domain.lean
@@ -34,6 +34,9 @@ variable {β : Type*} {r : α → β → Prop}
 @[simp, grind =] lemma mem_dom : a ∈ dom r ↔ ∃ b, r a b := .rfl
 @[simp, grind =] lemma mem_cod : b ∈ cod r ↔ ∃ a, r a b := .rfl
 
+theorem dom_of (hab : r a b) : a ∈ dom r := by grind
+theorem cod_of (hab : r a b) : b ∈ cod r := by grind
+
 @[gcongr] lemma dom_mono (h : r₁ ≤ r₂) : dom r₁ ⊆ dom r₂ := fun a ⟨b, hab⟩ => ⟨b, h a b hab⟩
 @[gcongr] lemma cod_mono (h : r₁ ≤ r₂) : cod r₁ ⊆ cod r₂ := fun b ⟨a, hab⟩ => ⟨a, h a b hab⟩
 

--- a/Cslib/Foundations/Relation/Euclidean.lean
+++ b/Cslib/Foundations/Relation/Euclidean.lean
@@ -48,7 +48,7 @@ namespace RightEuclidean
 variable [RightEuclidean r]
 
 /-- A `RightEuclidean` relation is reflexive on its codomain -/
-theorem reflOn_cod : ReflOn r (cod r) := fun _ ⟨_, ab⟩ ↦ rightEuclidean ab ab
+theorem reflOn_cod : (cod r).ReflOn r := fun _ ⟨_, ab⟩ ↦ rightEuclidean ab ab
 
 /-- The converse of a `RightEuclidean` relation is `LeftEuclidean` -/
 theorem leftEuclidean_swap : LeftEuclidean (fun a b => r b a) where
@@ -97,7 +97,7 @@ private theorem three_contra [Std.Trichotomous r] [Std.Antisymm r] :
   have := @Std.Trichotomous.rel_or_eq_or_rel_swap _ r _ b c
   have := antisymm_rightUnique (r := r)
   have := @reflOn_cod (r := r)
-  simp [ReflOn] at this
+  simp [Set.ReflOn] at this
   grind [Relator.RightUnique]
 
 theorem trichotomous_antisymm_finite [Std.Trichotomous r] [Std.Antisymm r] : Finite α := by
@@ -129,7 +129,7 @@ namespace LeftEuclidean
 variable [LeftEuclidean r]
 
 /-- A `LeftEuclidean` relation is reflexive on its domain -/
-theorem reflOn_dom : ReflOn r (dom r) := fun _ ⟨_, ab⟩ ↦ leftEuclidean ab ab
+theorem reflOn_dom : (dom r).ReflOn r := fun _ ⟨_, ab⟩ ↦ leftEuclidean ab ab
 
 /-- The converse of a `LeftEuclidean` relation is `RightEuclidean` -/
 theorem rightEuclidean_swap : RightEuclidean (fun a b => r b a) where
@@ -178,7 +178,7 @@ private theorem three_contra [Std.Trichotomous r] [Std.Antisymm r] :
   have := @Std.Trichotomous.rel_or_eq_or_rel_swap _ r _ b c
   have := antisymm_leftUnique (r := r)
   have := @reflOn_dom (r := r)
-  simp [ReflOn] at this
+  simp [Set.ReflOn] at this
   grind [Relator.LeftUnique]
 
 theorem trichotomous_antisymm_finite [Std.Trichotomous r] [Std.Antisymm r] : Finite α := by

--- a/Cslib/Foundations/Relation/Euclidean.lean
+++ b/Cslib/Foundations/Relation/Euclidean.lean
@@ -6,7 +6,7 @@ Authors: Fabrizio Montesi, Thomas Waring, Chris Henson
 
 module
 
-public import Cslib.Foundations.Relation.Domain
+public import Cslib.Foundations.Relation.Restriction
 public import Mathlib.Data.Fintype.EquivFin
 public import Mathlib.Tactic.TFAE
 
@@ -31,6 +31,12 @@ namespace Relation
 
 variable {α : Type*} {r : α → α → Prop}
 
+instance [RightEuclidean r] (s : Set α) : RightEuclidean (α := s) r :=
+  ⟨RightEuclidean.rightEuclidean⟩
+
+instance [LeftEuclidean r] (s : Set α) : LeftEuclidean (α := s) r :=
+  ⟨LeftEuclidean.leftEuclidean⟩
+
 @[scoped grind →]
 lemma refl_serial (r : α → α → Prop) (h : Std.Refl r) : Serial r where
   serial a := ⟨a, h.refl a⟩
@@ -41,10 +47,8 @@ namespace RightEuclidean
 
 variable [RightEuclidean r]
 
-/-- A `RightEuclidean` relation is reflexive on its range -/
-theorem refl_cod (ab : r a b) : r b b := rightEuclidean ab ab
-
-theorem refl_cod' : b ∈ cod r → r b b := fun ⟨_, ab⟩ ↦ refl_cod ab
+/-- A `RightEuclidean` relation is reflexive on its codomain -/
+theorem reflOn_cod : ReflOn r (cod r) := fun _ ⟨_, ab⟩ ↦ rightEuclidean ab ab
 
 /-- The converse of a `RightEuclidean` relation is `LeftEuclidean` -/
 theorem leftEuclidean_swap : LeftEuclidean (fun a b => r b a) where
@@ -56,7 +60,7 @@ instance [Std.Refl r] : Std.Symm r where
 theorem trichotomous_trans [Std.Trichotomous r] : IsTrans α r where
   trans a b c ab bc := by
     have := Std.Trichotomous.trichotomous (r := r) a c
-    have cc := refl_cod bc
+    have cc := reflOn_cod.of_cod bc
     have (ca : r c a) := rightEuclidean ca cc
     grind
 
@@ -65,15 +69,15 @@ theorem antisymm_rightUnique [Std.Antisymm r] : Relator.RightUnique r := by
   exact antisymm (rightEuclidean ab ac) (rightEuclidean ac ab)
 
 theorem rightUnique_antisymm (h : Relator.RightUnique r) : Std.Antisymm r where
-  antisymm _ _ ab ba := h ba (refl_cod ab)
+  antisymm _ _ ab ba := h ba (reflOn_cod.of_cod ab)
 
 theorem rightUnique_trans (h : Relator.RightUnique r) : IsTrans α r where
   trans a b c ab bc := by
-    have eq : c = b := h bc (refl_cod ab)
+    have eq : c = b := h bc (reflOn_cod.of_cod ab)
     simpa [eq]
 
 theorem rightTotal_equiv (h : Relator.RightTotal r) : IsEquiv α r := by
-  have : Std.Refl r := ⟨fun a => refl_cod (h a).choose_spec⟩
+  have : Std.Refl r := ⟨fun a => reflOn_cod.of_cod (h a).choose_spec⟩
   exact {toIsTrans := ⟨fun _ _ _ ab bc => rightEuclidean (symm ab) bc⟩}
 
 omit [RightEuclidean r] in
@@ -92,7 +96,8 @@ private theorem three_contra [Std.Trichotomous r] [Std.Antisymm r] :
   have := @Std.Trichotomous.rel_or_eq_or_rel_swap _ r _ a c
   have := @Std.Trichotomous.rel_or_eq_or_rel_swap _ r _ b c
   have := antisymm_rightUnique (r := r)
-  have := @refl_cod (r := r)
+  have := @reflOn_cod (r := r)
+  simp [ReflOn] at this
   grind [Relator.RightUnique]
 
 theorem trichotomous_antisymm_finite [Std.Trichotomous r] [Std.Antisymm r] : Finite α := by
@@ -110,16 +115,10 @@ theorem trichotomous_antisymm_card [Std.Trichotomous r] [Std.Antisymm r] [Fintyp
   have ⟨a, b, c, _⟩ := Fintype.two_lt_card_iff.mp h
   use a, b, c
 
-theorem cod_subset_dom : cod r ⊆ dom r := fun b ⟨_, ab⟩ ↦ ⟨b, refl_cod ab⟩
-
-instance : RightEuclidean (α := cod r) r where
-  rightEuclidean := rightEuclidean
-
-instance : RightEuclidean (α := dom r) r where
-  rightEuclidean := rightEuclidean
+theorem cod_subset_dom : cod r ⊆ dom r := fun _ ⟨_, ab⟩ ↦ cod_of (reflOn_cod.of_cod ab)
 
 theorem rightTotal_cod : Relator.RightTotal (α := cod r) (β := cod r) r :=
-  fun ⟨_, _, h⟩ => ⟨_, refl_cod h⟩
+  fun ⟨_, _, h⟩ => cod_of (reflOn_cod.of_cod h)
 
 theorem equiv_cod : IsEquiv (cod r) r := rightTotal_equiv rightTotal_cod
 
@@ -130,9 +129,7 @@ namespace LeftEuclidean
 variable [LeftEuclidean r]
 
 /-- A `LeftEuclidean` relation is reflexive on its domain -/
-theorem refl_dom (ab : r a b) : r a a := leftEuclidean ab ab
-
-theorem refl_dom' : a ∈ dom r → r a a := fun ⟨_, ab⟩ ↦ refl_dom ab
+theorem reflOn_dom : ReflOn r (dom r) := fun _ ⟨_, ab⟩ ↦ leftEuclidean ab ab
 
 /-- The converse of a `LeftEuclidean` relation is `RightEuclidean` -/
 theorem rightEuclidean_swap : RightEuclidean (fun a b => r b a) where
@@ -144,7 +141,7 @@ instance [Std.Refl r] : Std.Symm r where
 theorem trichotomous_trans [Std.Trichotomous r] : IsTrans α r where
   trans a b c ab bc := by
     have := Std.Trichotomous.trichotomous (r := r) a c
-    have aa := refl_dom ab
+    have aa := reflOn_dom.of_dom ab
     have (ca : r c a) := leftEuclidean aa ca
     grind
 
@@ -153,15 +150,15 @@ theorem antisymm_leftUnique [Std.Antisymm r] : Relator.LeftUnique r := by
   exact antisymm (leftEuclidean ac bc) (leftEuclidean bc ac)
 
 theorem leftUnique_antisymm (h : Relator.LeftUnique r) : Std.Antisymm r where
-  antisymm _ _ ab ba := h ab (refl_dom ba)
+  antisymm _ _ ab ba := h ab (reflOn_dom.of_dom ba)
 
 theorem leftUnique_trans (h : Relator.LeftUnique r) : IsTrans α r where
   trans a b c ab bc := by
-    have eq : a = b := h ab (refl_dom bc)
+    have eq : a = b := h ab (reflOn_dom.of_dom bc)
     simpa [eq]
 
 theorem leftTotal_equiv (h : Relator.LeftTotal r) : IsEquiv α r := by
-  have : Std.Refl r := ⟨fun a => refl_dom (h a).choose_spec⟩
+  have : Std.Refl r := ⟨fun a => reflOn_dom.of_dom (h a).choose_spec⟩
   exact {toIsTrans := ⟨fun _ _ _ ab bc => leftEuclidean ab (symm bc)⟩}
 
 omit [LeftEuclidean r] in
@@ -180,7 +177,8 @@ private theorem three_contra [Std.Trichotomous r] [Std.Antisymm r] :
   have := @Std.Trichotomous.rel_or_eq_or_rel_swap _ r _ a c
   have := @Std.Trichotomous.rel_or_eq_or_rel_swap _ r _ b c
   have := antisymm_leftUnique (r := r)
-  have := @refl_dom (r := r)
+  have := @reflOn_dom (r := r)
+  simp [ReflOn] at this
   grind [Relator.LeftUnique]
 
 theorem trichotomous_antisymm_finite [Std.Trichotomous r] [Std.Antisymm r] : Finite α := by
@@ -198,16 +196,10 @@ theorem trichotomous_antisymm_card [Std.Trichotomous r] [Std.Antisymm r] [Fintyp
   have ⟨a, b, c, _⟩ := Fintype.two_lt_card_iff.mp h
   use a, b, c
 
-theorem dom_subset_cod : dom r ⊆ cod r := fun a ⟨_, ab⟩ ↦ ⟨a, refl_dom ab⟩
-
-instance : LeftEuclidean (α := cod r) r where
-  leftEuclidean := leftEuclidean
-
-instance : LeftEuclidean (α := dom r) r where
-  leftEuclidean := leftEuclidean
+theorem dom_subset_cod : dom r ⊆ cod r := fun _ ⟨_, ab⟩ ↦ dom_of (reflOn_dom.of_dom ab)
 
 theorem leftTotal_dom : Relator.LeftTotal (α := dom r) (β := dom r) r :=
-  fun ⟨_, _, h⟩ => ⟨_, refl_dom h⟩
+  fun ⟨a, _, h⟩ => ⟨⟨a, dom_of h⟩, reflOn_dom.of_dom h⟩
 
 theorem equiv_dom : IsEquiv (dom r) r := leftTotal_equiv leftTotal_dom
 

--- a/Cslib/Foundations/Relation/Euclidean.lean
+++ b/Cslib/Foundations/Relation/Euclidean.lean
@@ -115,10 +115,10 @@ theorem trichotomous_antisymm_card [Std.Trichotomous r] [Std.Antisymm r] [Fintyp
   have ⟨a, b, c, _⟩ := Fintype.two_lt_card_iff.mp h
   use a, b, c
 
-theorem cod_subset_dom : cod r ⊆ dom r := fun _ ⟨_, ab⟩ ↦ cod_of (reflOn_cod.of_cod ab)
+theorem cod_subset_dom : cod r ⊆ dom r := fun _ ⟨_, ab⟩ ↦ of_cod (reflOn_cod.of_cod ab)
 
 theorem rightTotal_cod : Relator.RightTotal (α := cod r) (β := cod r) r :=
-  fun ⟨_, _, h⟩ => cod_of (reflOn_cod.of_cod h)
+  fun ⟨_, _, h⟩ => of_cod (reflOn_cod.of_cod h)
 
 theorem equiv_cod : IsEquiv (cod r) r := rightTotal_equiv rightTotal_cod
 
@@ -196,10 +196,10 @@ theorem trichotomous_antisymm_card [Std.Trichotomous r] [Std.Antisymm r] [Fintyp
   have ⟨a, b, c, _⟩ := Fintype.two_lt_card_iff.mp h
   use a, b, c
 
-theorem dom_subset_cod : dom r ⊆ cod r := fun _ ⟨_, ab⟩ ↦ dom_of (reflOn_dom.of_dom ab)
+theorem dom_subset_cod : dom r ⊆ cod r := fun _ ⟨_, ab⟩ ↦ of_dom (reflOn_dom.of_dom ab)
 
 theorem leftTotal_dom : Relator.LeftTotal (α := dom r) (β := dom r) r :=
-  fun ⟨a, _, h⟩ => ⟨⟨a, dom_of h⟩, reflOn_dom.of_dom h⟩
+  fun ⟨a, _, h⟩ => ⟨⟨a, of_dom h⟩, reflOn_dom.of_dom h⟩
 
 theorem equiv_dom : IsEquiv (dom r) r := leftTotal_equiv leftTotal_dom
 

--- a/Cslib/Foundations/Relation/Restriction.lean
+++ b/Cslib/Foundations/Relation/Restriction.lean
@@ -38,15 +38,15 @@ theorem symm_iff_symmOn : Std.Symm (α := s) r ↔ SymmOn r s := by
 -- for special cases of (co)domain, we provide constructive shortcut lemmas
 
 theorem ReflOn.of_dom {r} : ReflOn r (dom r) → r a b → r a a
-| h, hab => h a (dom_of hab)
+| h, hab => h a (Relation.of_dom hab)
 
 theorem ReflOn.of_cod {r} : ReflOn r (cod r) → r a b → r b b
-| h, hab => h b (cod_of hab)
+| h, hab => h b (Relation.of_cod hab)
 
 theorem SymmOn.of_dom {r} : SymmOn r (dom r) → r a b → r b c → r b a
-| h, hab, hbc => h a (dom_of hab) b (dom_of hbc) hab
+| h, hab, hbc => h a (Relation.of_dom hab) b (Relation.of_dom hbc) hab
 
 theorem SymmOn.of_cod {r} : SymmOn r (cod r) → r a b → r c a → r b a
-| h, hab, hca => h a (cod_of hca) b (cod_of hab) hab
+| h, hab, hca => h a (Relation.of_cod hca) b (Relation.of_cod hab) hab
 
 end Relation

--- a/Cslib/Foundations/Relation/Restriction.lean
+++ b/Cslib/Foundations/Relation/Restriction.lean
@@ -1,0 +1,52 @@
+/-
+Copyright (c) 2026 Chris Henson. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Chris Henson
+-/
+
+module
+
+public import Cslib.Foundations.Relation.Defs
+public import Cslib.Foundations.Relation.Domain
+
+/-! # Relations: Properties on sestrictions
+
+## References
+
+* [*Simple Laws about Nonprominent Properties of Binary Relations*][Burghardt2018]
+
+-/
+
+@[expose] public section
+
+namespace Relation
+
+variable (r : α → α → Prop) (s : Set α)
+
+@[simp, grind .]
+theorem refl_iff_reflOn : Std.Refl (α := s) r ↔ ReflOn r s := by
+  constructor
+  · exact fun ⟨h⟩ a ha ↦ h ⟨a, ha⟩
+  · exact fun h ↦ ⟨fun ⟨a, ha⟩ ↦ h a ha⟩
+
+@[simp, grind .]
+theorem symm_iff_symmOn : Std.Symm (α := s) r ↔ SymmOn r s := by
+  constructor
+  · exact fun ⟨h⟩ a ha b hb ab ↦ h ⟨a, ha⟩ ⟨b, hb⟩ ab
+  · exact fun h ↦ ⟨fun ⟨a, ha⟩ ⟨b, hb⟩ ab ↦ h a ha b hb ab⟩
+
+-- for special cases of (co)domain, we provide constructive shortcut lemmas
+
+theorem ReflOn.of_dom {r} : ReflOn r (dom r) → r a b → r a a
+| h, hab => h a (dom_of hab)
+
+theorem ReflOn.of_cod {r} : ReflOn r (cod r) → r a b → r b b
+| h, hab => h b (cod_of hab)
+
+theorem SymmOn.of_dom {r} : SymmOn r (dom r) → r a b → r b c → r b a
+| h, hab, hbc => h a (dom_of hab) b (dom_of hbc) hab
+
+theorem SymmOn.of_cod {r} : SymmOn r (cod r) → r a b → r c a → r b a
+| h, hab, hca => h a (cod_of hca) b (cod_of hab) hab
+
+end Relation

--- a/Cslib/Foundations/Relation/Restriction.lean
+++ b/Cslib/Foundations/Relation/Restriction.lean
@@ -19,34 +19,36 @@ public import Cslib.Foundations.Relation.Domain
 
 @[expose] public section
 
-namespace Relation
+open Relation
+
+namespace Set
 
 variable (r : α → α → Prop) (s : Set α)
 
 @[simp, grind .]
-theorem refl_iff_reflOn : Std.Refl (α := s) r ↔ ReflOn r s := by
+theorem refl_iff_reflOn : Std.Refl (α := s) r ↔ s.ReflOn r := by
   constructor
   · exact fun ⟨h⟩ a ha ↦ h ⟨a, ha⟩
   · exact fun h ↦ ⟨fun ⟨a, ha⟩ ↦ h a ha⟩
 
 @[simp, grind .]
-theorem symm_iff_symmOn : Std.Symm (α := s) r ↔ SymmOn r s := by
+theorem symm_iff_symmOn : Std.Symm (α := s) r ↔ s.SymmOn r := by
   constructor
   · exact fun ⟨h⟩ a ha b hb ab ↦ h ⟨a, ha⟩ ⟨b, hb⟩ ab
   · exact fun h ↦ ⟨fun ⟨a, ha⟩ ⟨b, hb⟩ ab ↦ h a ha b hb ab⟩
 
 -- for special cases of (co)domain, we provide constructive shortcut lemmas
 
-theorem ReflOn.of_dom {r} : ReflOn r (dom r) → r a b → r a a
+theorem ReflOn.of_dom {r} : (dom r).ReflOn r → r a b → r a a
 | h, hab => h a (Relation.of_dom hab)
 
-theorem ReflOn.of_cod {r} : ReflOn r (cod r) → r a b → r b b
+theorem ReflOn.of_cod {r} : (cod r).ReflOn r → r a b → r b b
 | h, hab => h b (Relation.of_cod hab)
 
-theorem SymmOn.of_dom {r} : SymmOn r (dom r) → r a b → r b c → r b a
+theorem SymmOn.of_dom {r} : (dom r).SymmOn r → r a b → r b c → r b a
 | h, hab, hbc => h a (Relation.of_dom hab) b (Relation.of_dom hbc) hab
 
-theorem SymmOn.of_cod {r} : SymmOn r (cod r) → r a b → r c a → r b a
+theorem SymmOn.of_cod {r} : (cod r).SymmOn r → r a b → r c a → r b a
 | h, hab, hca => h a (Relation.of_cod hca) b (Relation.of_cod hab) hab
 
-end Relation
+end Set

--- a/Cslib/Foundations/Relation/Restriction.lean
+++ b/Cslib/Foundations/Relation/Restriction.lean
@@ -9,7 +9,7 @@ module
 public import Cslib.Foundations.Relation.Defs
 public import Cslib.Foundations.Relation.Domain
 
-/-! # Relations: Properties on sestrictions
+/-! # Relations: Properties on set restrictions
 
 ## References
 


### PR DESCRIPTION
A first pass at adding definitions corresponding to the concept of having some property of a (homogeneous) relation over a set restriction, as discussed in [this thread](https://leanprover.zulipchat.com/#narrow/channel/513188-CSLib/topic/unbundled.20relations.20with.20restricted.20.28co.29domain/with/596236853). I also add lemmas `of_{cod,dom}` for convenience of working in the "constructive" case where we explicitly are given the relation as evidence of the (co)domain.