### PR TITLE
feat(untyped): define CBN and Standard evaluation strategies

### DIFF
--- a/Cslib.lean
+++ b/Cslib.lean
@@ -125,6 +125,7 @@ public import Cslib.Languages.LambdaCalculus.LocallyNameless.Stlc.Basic
 public import Cslib.Languages.LambdaCalculus.LocallyNameless.Stlc.Safety
 public import Cslib.Languages.LambdaCalculus.LocallyNameless.Stlc.StrongNorm
 public import Cslib.Languages.LambdaCalculus.LocallyNameless.Untyped.Basic
+public import Cslib.Languages.LambdaCalculus.LocallyNameless.Untyped.CallByName
 public import Cslib.Languages.LambdaCalculus.LocallyNameless.Untyped.Congruence
 public import Cslib.Languages.LambdaCalculus.LocallyNameless.Untyped.FullBeta
 public import Cslib.Languages.LambdaCalculus.LocallyNameless.Untyped.FullBetaConfluence
@@ -136,6 +137,7 @@ public import Cslib.Languages.LambdaCalculus.LocallyNameless.Untyped.LcAt
 public import Cslib.Languages.LambdaCalculus.LocallyNameless.Untyped.MultiApp
 public import Cslib.Languages.LambdaCalculus.LocallyNameless.Untyped.MultiSubst
 public import Cslib.Languages.LambdaCalculus.LocallyNameless.Untyped.Properties
+public import Cslib.Languages.LambdaCalculus.LocallyNameless.Untyped.StandardReduction
 public import Cslib.Languages.LambdaCalculus.LocallyNameless.Untyped.StrongNorm
 public import Cslib.Languages.LambdaCalculus.Named.Untyped.Basic
 public import Cslib.Logics.HML.Basic

--- a/Cslib/Languages/LambdaCalculus/LocallyNameless/Untyped/CallByName.lean
+++ b/Cslib/Languages/LambdaCalculus/LocallyNameless/Untyped/CallByName.lean
@@ -1,0 +1,53 @@
+/-
+Copyright (c) 2026 Maximiliano Onofre Martínez. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Maximiliano Onofre Martínez
+-/
+
+module
+
+public import Cslib.Languages.LambdaCalculus.LocallyNameless.Untyped.FullBeta
+public import Cslib.Languages.LambdaCalculus.LocallyNameless.Untyped.Properties
+
+/-! # Call-by-Name Evaluation -/
+
+@[expose] public section
+
+set_option linter.unusedDecidableInType false
+
+namespace Cslib
+
+universe u
+
+variable {Var : Type u}
+
+namespace LambdaCalculus.LocallyNameless.Untyped.Term
+
+/-- A single step of Call-by-Name evaluation. -/
+@[reduction_sys "ₙ"]
+inductive CBN : Term Var → Term Var → Prop
+/-- Top-level β-reduction. -/
+| base : Beta M N → CBN M N
+/-- Evaluates the leftmost term. -/
+| app : LC Z → CBN M N → CBN (app M Z) (app N Z)
+
+variable {M N : Term Var}
+
+/-- The left side of a CBN reduction step is locally closed. -/
+lemma cbn_lc_l (step : M ⭢ₙ N) : LC M := by
+  induction step
+  all_goals grind
+
+variable [HasFresh Var] [DecidableEq Var]
+
+/-- The right side of a CBN reduction step is locally closed. -/
+lemma cbn_lc_r (step : M ⭢ₙ N) : LC N := by
+  induction step
+  case base beta_step =>
+    cases beta_step
+    apply beta_lc <;> assumption
+  case app lc_z _ lc_n => exact LC.app lc_n lc_z
+
+end LambdaCalculus.LocallyNameless.Untyped.Term
+
+end Cslib

--- a/Cslib/Languages/LambdaCalculus/LocallyNameless/Untyped/CallByName.lean
+++ b/Cslib/Languages/LambdaCalculus/LocallyNameless/Untyped/CallByName.lean
@@ -37,7 +37,7 @@ variable {M N : Term Var}
 lemma cbn_lc_l (step : M ⭢ₙ N) : LC M := by
   induction step
   all_goals grind
-
+  induction step with grind
 variable [HasFresh Var] [DecidableEq Var]
 
 /-- The right side of a CBN reduction step is locally closed. -/

--- a/Cslib/Languages/LambdaCalculus/LocallyNameless/Untyped/CallByName.lean
+++ b/Cslib/Languages/LambdaCalculus/LocallyNameless/Untyped/CallByName.lean
@@ -42,11 +42,7 @@ variable [HasFresh Var] [DecidableEq Var]
 
 /-- The right side of a CBN reduction step is locally closed. -/
 lemma cbn_lc_r (step : M ⭢ₙ N) : LC N := by
-  induction step
-  case base beta_step =>
-    cases beta_step
-    apply beta_lc <;> assumption
-  case app lc_z _ lc_n => exact LC.app lc_n lc_z
+  induction step with grind
 
 end LambdaCalculus.LocallyNameless.Untyped.Term
 

--- a/Cslib/Languages/LambdaCalculus/LocallyNameless/Untyped/CallByName.lean
+++ b/Cslib/Languages/LambdaCalculus/LocallyNameless/Untyped/CallByName.lean
@@ -34,13 +34,13 @@ inductive CBN : Term Var → Term Var → Prop
 variable {M N : Term Var}
 
 /-- The left side of a CBN reduction step is locally closed. -/
-lemma cbn_lc_l (step : M ⭢ₙ N) : LC M := by
+lemma CBN.lc_l (step : M ⭢ₙ N) : LC M := by
   induction step with grind
 
 variable [HasFresh Var] [DecidableEq Var]
 
 /-- The right side of a CBN reduction step is locally closed. -/
-lemma cbn_lc_r (step : M ⭢ₙ N) : LC N := by
+lemma CBN.lc_r (step : M ⭢ₙ N) : LC N := by
   induction step with grind
 
 end LambdaCalculus.LocallyNameless.Untyped.Term

--- a/Cslib/Languages/LambdaCalculus/LocallyNameless/Untyped/CallByName.lean
+++ b/Cslib/Languages/LambdaCalculus/LocallyNameless/Untyped/CallByName.lean
@@ -35,9 +35,8 @@ variable {M N : Term Var}
 
 /-- The left side of a CBN reduction step is locally closed. -/
 lemma cbn_lc_l (step : M ⭢ₙ N) : LC M := by
-  induction step
-  all_goals grind
   induction step with grind
+
 variable [HasFresh Var] [DecidableEq Var]
 
 /-- The right side of a CBN reduction step is locally closed. -/

--- a/Cslib/Languages/LambdaCalculus/LocallyNameless/Untyped/StandardReduction.lean
+++ b/Cslib/Languages/LambdaCalculus/LocallyNameless/Untyped/StandardReduction.lean
@@ -1,0 +1,63 @@
+/-
+Copyright (c) 2026 Maximiliano Onofre Martínez. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Maximiliano Onofre Martínez
+-/
+
+module
+
+public import Cslib.Languages.LambdaCalculus.LocallyNameless.Untyped.CallByName
+
+/-! # Standard Reduction
+
+## Reference
+
+* [B. Calisto, *Formalization in Coq of the Standardization Theorem for λ-calculus*][Calisto2022]
+
+-/
+
+@[expose] public section
+
+namespace Cslib
+
+universe u
+
+variable {Var : Type u}
+
+namespace LambdaCalculus.LocallyNameless.Untyped.Term
+
+/-- The Standard reduction relation. -/
+@[reduction_sys "ₛ"]
+inductive Standard : Term Var → Term Var → Prop
+/-- Free variables standardly reduce to themselves. -/
+| fvar (x : Var) : Standard (fvar x) (fvar x)
+/-- Congruence rule for application. -/
+| app  : Standard L L' → Standard M M' → Standard (app L M) (app L' M')
+/-- Congruence rule for lambda terms. -/
+| abs (xs : Finset Var) :
+    (∀ x ∉ xs, Standard (m ^ fvar x) (m' ^ fvar x)) → Standard (abs m) (abs m')
+/-- Standard reduction of a head redex. -/
+| rdx : LC m → LC n → m ↠ₙ (abs m') → Standard (m' ^ n) p → Standard (app m n) p
+
+variable {M N : Term Var}
+
+/-- The left side of a standard reduction is locally closed. -/
+lemma stand_lc_l (step : M ⭢ₛ N) : LC M := by
+  induction step
+  case abs xs _ ih => exact LC.abs xs _ ih
+  all_goals grind
+
+/-- Standard reduction is reflexive for locally closed terms. -/
+lemma Standard.lc_refl (M : Term Var) (lc : LC M) : M ⭢ₛ M := by
+  induction lc
+  all_goals constructor <;> assumption
+
+/-- The right side of a standard reduction is locally closed. -/
+lemma stand_lc_r (step : M ⭢ₛ N) : LC N := by
+  induction step
+  case abs xs _ ih => exact LC.abs xs _ ih
+  all_goals grind
+
+end LambdaCalculus.LocallyNameless.Untyped.Term
+
+end Cslib

--- a/Cslib/Languages/LambdaCalculus/LocallyNameless/Untyped/StandardReduction.lean
+++ b/Cslib/Languages/LambdaCalculus/LocallyNameless/Untyped/StandardReduction.lean
@@ -42,7 +42,7 @@ inductive Standard : Term Var → Term Var → Prop
 variable {M N : Term Var}
 
 /-- The left side of a standard reduction is locally closed. -/
-lemma stand_lc_l (step : M ⭢ₛ N) : LC M := by
+lemma Standard.lc_l (step : M ⭢ₛ N) : LC M := by
   induction step
   case abs xs _ ih => exact LC.abs xs _ ih
   all_goals grind
@@ -53,7 +53,7 @@ lemma Standard.lc_refl (M : Term Var) (lc : LC M) : M ⭢ₛ M := by
   all_goals constructor <;> assumption
 
 /-- The right side of a standard reduction is locally closed. -/
-lemma stand_lc_r (step : M ⭢ₛ N) : LC N := by
+lemma Standard.lc_r (step : M ⭢ₛ N) : LC N := by
   induction step
   case abs xs _ ih => exact LC.abs xs _ ih
   all_goals grind

--- a/references.bib
+++ b/references.bib
@@ -470,3 +470,9 @@ address = {USA}
   publisher    = {McGraw-Hill},
   isbn         = {0070428077}
 }
+@mastersthesis{Calisto2022,
+  author       = {Calisto, Bruna},
+  title        = {Formalization in {Coq} of the {Standardization Theorem} for {$\lambda$}-calculus},
+  school       = {Universidade do Minho},
+  year         = {2022}
+}


### PR DESCRIPTION
This is the first step towards the Standardization Theorem.

Instead of the classic (and painful) Barendregt approach, I defined `Standard` reduction 
relying on `CBN` to find the head redex, which makes the proofs much nicer.