### PR TITLE
chore: disable .github/workflows/lake-update.yml on personal forks

### DIFF
--- a/.github/workflows/lake-update.yml
+++ b/.github/workflows/lake-update.yml
@@ -25,6 +25,7 @@ on:
 jobs:
   bump:
     runs-on: ubuntu-latest
+    if: github.repository == 'leanprover/cslib'
     steps:
       - name: Generate app token
         id: app-token
@@ -52,6 +53,7 @@ jobs:
 
   open-issue:
     runs-on: ubuntu-latest
+    if: github.repository == 'leanprover/cslib'
     permissions:
       issues: write
     steps:


### PR DESCRIPTION
Make sure this job is run only on the main cslib repo `leanprover/cslib'` and not on personal forks.