### PR TITLE
fix(Foundations/Syntax): guard substitution notation with noWs

### DIFF
--- a/Cslib/Foundations/Syntax/HasSubstitution.lean
+++ b/Cslib/Foundations/Syntax/HasSubstitution.lean
@@ -19,7 +19,23 @@ class HasSubstitution (α : Type u) (β : Type v) (γ : Type w) where
   /-- Substitution function. Replaces `x` in `t` with `t'`. -/
   subst (t : α) (x : β) (t' : γ) : α
 
-/-- Notation for substitution. -/
-notation t:max "[" x ":=" t' "]" => HasSubstitution.subst t x t'
+/--
+Notation for substitution.
+
+The `noWs` guard is intentional: substitution must be written as `t[x := s]`,
+not `t [x := s]`. Without the guard, the term parser can attach a bracket from
+following syntax, such as an instance-binder field in a structure declaration,
+to the preceding term.
+-/
+syntax:max term noWs "[" term " := " term "]" : term
+
+macro_rules
+  | `($t[$x := $s]) => `(HasSubstitution.subst $t $x $s)
+
+/-- Pretty-printer support for `HasSubstitution.subst`. -/
+@[app_unexpander HasSubstitution.subst]
+meta def unexpandHasSubstitutionSubst : Lean.PrettyPrinter.Unexpander
+  | `($_ $t $x $s) => `($t[$x := $s])
+  | _ => throw ()
 
 end Cslib

--- a/Cslib/Languages/LambdaCalculus/LocallyNameless/Fsub/Opening.lean
+++ b/Cslib/Languages/LambdaCalculus/LocallyNameless/Fsub/Opening.lean
@@ -235,9 +235,9 @@ lemma openRecTy_lc {t : Term Var} (lc : t.LC) : t = t⟦X ↝ σ⟧ᵗᵞ := by
 def substTy (X : Var) (δ : Ty Var) : Term Var → Term Var
 | bvar x => bvar x
 | fvar x => fvar x
-| abs σ t₁ => abs (σ [X := δ]) (substTy X δ t₁)
+| abs σ t₁ => abs (σ[X := δ]) (substTy X δ t₁)
 | app t₁ t₂ => app (substTy X δ t₁) (substTy X δ t₂)
-| tabs σ t₁ => tabs (σ [X := δ]) (substTy X δ t₁)
+| tabs σ t₁ => tabs (σ[X := δ]) (substTy X δ t₁)
 | tapp t₁ σ => tapp (substTy X δ t₁) (σ[X := δ])
 | let' t₁ t₂ => let' (substTy X δ t₁) (substTy X δ t₂)
 | inl t₁ => inl (substTy X δ t₁)
@@ -253,7 +253,7 @@ lemma substTy_def : substTy (X : Var) (δ : Ty Var) (t : Term Var) = t[X := δ] 
 
 omit [HasFresh Var] in
 /-- Substitution of a free type variable not present in a term leaves it unchanged. -/
-lemma substTy_fresh (nmem : X ∉ t.fvTy) (δ : Ty Var) : t = t [X := δ] :=
+lemma substTy_fresh (nmem : X ∉ t.fvTy) (δ : Ty Var) : t = t[X := δ] :=
   by induction t <;> grind [Ty.subst_fresh]
 
 /-- Substitution of a locally closed type distributes with term opening to a type . -/

--- a/Cslib/Languages/LambdaCalculus/LocallyNameless/Fsub/Safety.lean
+++ b/Cslib/Languages/LambdaCalculus/LocallyNameless/Fsub/Safety.lean
@@ -50,7 +50,7 @@ lemma Typing.preservation (der : Typing Γ t τ) (step : t ⭢βᵛ t') : Typing
       have ⟨_, _, ⟨_, _⟩⟩ := der.tabs_inv sub
       have ⟨X, mem⟩ := fresh_exists <| free_union [Ty.fv, fvTy] Var
       simp at mem
-      have : Γ = (Context.mapVal (·[X:=σ']) []) ++ Γ := by grind
+      have : Γ = (Context.mapVal (·[X := σ']) []) ++ Γ := by grind
       rw [openTy_substTy_intro (X := X), open_subst_intro (X := X)] <;> grind [subst_ty]
     case tapp => grind
   case let' Γ _ _ _ _ L der _ ih₁ _ =>

--- a/Cslib/Languages/LambdaCalculus/LocallyNameless/Fsub/Subtype.lean
+++ b/Cslib/Languages/LambdaCalculus/LocallyNameless/Fsub/Subtype.lean
@@ -144,7 +144,7 @@ lemma narrow (sub_δ : Sub Δ δ δ') (sub_narrow : Sub (Γ ++ ⟨X, Binding.sub
 variable [HasFresh Var] in
 /-- Subtyping of substitutions. -/
 lemma map_subst (sub₁ : Sub (Γ ++ ⟨X, Binding.sub δ'⟩ :: Δ) σ τ) (sub₂ : Sub Δ δ δ') :
-    Sub (Γ.mapVal (·[X:=δ]) ++ Δ) (σ[X:=δ]) (τ[X:=δ]) := by
+    Sub (Γ.mapVal (·[X := δ]) ++ Δ) (σ[X := δ]) (τ[X := δ]) := by
   generalize eq : Γ ++ ⟨X, Binding.sub δ'⟩ :: Δ = Θ at sub₁
   induction sub₁ generalizing Γ
   case all => apply Sub.all (free_union Var) <;> grind [open_subst_var]
@@ -152,7 +152,7 @@ lemma map_subst (sub₁ : Sub (Γ ++ ⟨X, Binding.sub δ'⟩ :: Δ) σ τ) (sub
     have := map_subst_nmem Δ X δ
     have : Γ ++ ⟨X, .sub δ'⟩ :: Δ ~ ⟨X, .sub δ'⟩ :: (Γ ++ Δ) := perm_middle
     have : .sub σ ∈ dlookup X' (⟨X, .sub δ'⟩ :: (Γ ++ Δ)) := by grind [perm_dlookup]
-    have := @mapVal_mem Var (f := ((·[X:=δ]) : Binding Var → Binding Var))
+    have := @mapVal_mem Var (f := ((·[X := δ]) : Binding Var → Binding Var))
     by_cases X = X'
     · trans δ' <;> grind [→ mem_dlookup, Ty.subst_fresh, Ty.Wf.nmem_fv, weaken_head]
     · grind

--- a/Cslib/Languages/LambdaCalculus/LocallyNameless/Fsub/Typing.lean
+++ b/Cslib/Languages/LambdaCalculus/LocallyNameless/Fsub/Typing.lean
@@ -144,7 +144,7 @@ lemma subst_ty (der : Typing (Γ ++ ⟨X, Binding.sub δ'⟩ :: Δ) t τ) (sub :
   induction der generalizing Γ X
   case var σ _ X' _ mem =>
     have := map_subst_nmem Δ X δ
-    have := @mapVal_mem Var (f := ((·[X:=δ]) : Binding Var → Binding Var))
+    have := @mapVal_mem Var (f := ((·[X := δ]) : Binding Var → Binding Var))
     grind [Env.Wf.map_subst, → notMem_keys_of_nodupKeys_cons]
   case abs => grind [abs (free_union [Ty.fv] Var), Ty.subst_fresh, openTm_substTy_var]
   case tabs => grind [tabs (free_union Var), openTy_substTy_var, open_subst_var]

--- a/Cslib/Languages/LambdaCalculus/LocallyNameless/Fsub/WellFormed.lean
+++ b/Cslib/Languages/LambdaCalculus/LocallyNameless/Fsub/WellFormed.lean
@@ -121,7 +121,7 @@ lemma strengthen (wf : σ.Wf (Γ ++ ⟨X, Binding.ty τ⟩ :: Δ)) : σ.Wf (Γ +
 variable [HasFresh Var] in
 /-- A type remains well-formed under context substitution (of a well-formed type). -/
 lemma map_subst (wf_σ : σ.Wf (Γ ++ ⟨X, Binding.sub τ⟩ :: Δ)) (wf_τ' : τ'.Wf Δ)
-    (ok : (Γ.mapVal (·[X:=τ']) ++ Δ)✓) : σ[X:=τ'].Wf <| Γ.mapVal (·[X:=τ']) ++ Δ := by
+    (ok : (Γ.mapVal (·[X := τ']) ++ Δ)✓) : σ[X := τ'].Wf <| Γ.mapVal (·[X := τ']) ++ Δ := by
   have := @mapVal_mem Var (Binding Var)
   generalize eq : Γ ++ ⟨X, Binding.sub τ⟩ :: Δ = Θ at wf_σ
   induction wf_σ generalizing Γ τ' with
@@ -133,7 +133,7 @@ variable [HasFresh Var] in
 lemma open_lc (ok_Γ : Γ✓) (wf_all : (Ty.all σ τ).Wf Γ) (wf_δ : δ.Wf Γ) : (τ ^ᵞ δ).Wf Γ := by
   cases wf_all with | all =>
     let ⟨X, _⟩ := fresh_exists <| free_union [fv, Context.dom] Var
-    have : Γ = Context.mapVal (·[X:=δ]) [] ++ Γ := by grind
+    have : Γ = Context.mapVal (·[X := δ]) [] ++ Γ := by grind
     grind [open_subst_intro, map_subst]
 
 /-- A type bound in a context is well formed. -/
@@ -177,7 +177,7 @@ lemma strengthen (wf : Env.Wf <| Γ ++ ⟨X, Binding.ty τ⟩ :: Δ) : Env.Wf <|
 variable [HasFresh Var] in
 /-- A context remains well-formed under substitution (of a well-formed type). -/
 lemma map_subst (wf_env : Env.Wf (Γ ++ ⟨X, Binding.sub τ⟩ :: Δ)) (wf_τ' : τ'.Wf Δ) :
-    Env.Wf <| Γ.mapVal (·[X:=τ']) ++ Δ := by
+    Env.Wf <| Γ.mapVal (·[X := τ']) ++ Δ := by
   induction Γ generalizing wf_τ' Δ τ' <;> cases wf_env
   case nil => grind
   case cons.sub | cons.ty => constructor <;> grind [Ty.Wf.map_subst]
@@ -186,7 +186,7 @@ variable [HasFresh Var]
 
 /-- A well-formed context is unchanged by substituting for a free key. -/
 lemma map_subst_nmem (Γ : Env Var) (X : Var) (σ : Ty Var) (wf : Γ.Wf) (nmem : X ∉ Γ.dom) :
-    Γ = Γ.mapVal (·[X:=σ]) := by
+    Γ = Γ.mapVal (·[X := σ]) := by
   induction wf <;> grind [Ty.Wf.nmem_fv, Binding.subst_fresh]
 
 end Env.Wf

--- a/Cslib/Languages/LambdaCalculus/LocallyNameless/Stlc/Basic.lean
+++ b/Cslib/Languages/LambdaCalculus/LocallyNameless/Stlc/Basic.lean
@@ -117,7 +117,7 @@ lemma subst_aux (h : Δ ++ ⟨x, σ⟩ :: Γ ⊢ t ∶ τ) (der : Γ ⊢ s ∶ �
 
 /-- Substitution for a context weakened by a single type. -/
 lemma typing_subst_head (weak : ⟨x, σ⟩ :: Γ ⊢ t ∶ τ) (der : Γ ⊢ s ∶ σ) :
-    Γ ⊢ (t [x := s]) ∶ τ := by
+    Γ ⊢ (t[x := s]) ∶ τ := by
   grind [subst_aux]
 
 /-- Typing preservation for opening. -/

--- a/Cslib/Languages/LambdaCalculus/LocallyNameless/Untyped/FullBeta.lean
+++ b/Cslib/Languages/LambdaCalculus/LocallyNameless/Untyped/FullBeta.lean
@@ -87,7 +87,7 @@ lemma steps_lc_or_rfl {M M' : Term Var} (redex : M ↠βᶠ M') : (LC M ∧ LC M
 
 /-- Substitution of a locally closed term respects a single reduction step. -/
 lemma redex_subst_cong_lc (s s' t : Term Var) (x : Var) (step : s ⭢βᶠ s') (h_lc : LC t) :
-    s [ x := t ] ⭢βᶠ s' [ x := t ] := by
+    s[x := t] ⭢βᶠ s'[x := t] := by
   induction step with
   | base beta => cases beta; grind [subst_open]
   | abs  => grind [Xi.abs <| free_union Var]
@@ -95,7 +95,7 @@ lemma redex_subst_cong_lc (s s' t : Term Var) (x : Var) (step : s ⭢βᶠ s') (
 
 /-- Substitution respects a single reduction step of a free variable. -/
 lemma redex_subst_cong (s s' : Term Var) (x y : Var) (step : s ⭢βᶠ s') :
-    s [ x := fvar y ] ⭢βᶠ s' [ x := fvar y ] :=
+    s[x := fvar y] ⭢βᶠ s'[x := fvar y] :=
   redex_subst_cong_lc _ _ _ _ step (.fvar y)
 
 /-- An β-reduction step does not introduce new free variables. -/
@@ -159,25 +159,25 @@ lemma steps_open_cong_l_abs
     specialize ih s
     cases step with grind [invert_steps_abs, step_open_cong_l (L := free_union Var)]
 
-/- `t ↠βᶠ t'` implies `s [ x := t ] ↠βᶠ s [ x := t' ]`.
+/- `t ↠βᶠ t'` implies `s[x := t] ↠βᶠ s[x := t']`.
    There is no single step lemma in this case because x
    may be substituted for n times, so a single step t ↠βᶠ t
-   in general requires n steps in `s [ x := t ] ↠βᶠ (s [ x := t' ])` -/
+   in general requires n steps in `s[x := t] ↠βᶠ (s[x := t'])` -/
 lemma step_subst_cong_r {x : Var} (s t t' : Term Var) (step : t ⭢βᶠ t') (h_lc : LC s) :
-    (s [ x := t ]) ↠βᶠ (s [ x := t' ]) := by
+    (s[x := t]) ↠βᶠ (s[x := t']) := by
   induction h_lc with
   | fvar y => grind
   | abs => grind [redex_abs_cong (free_union Var)]
   | @app l r =>
      calc
-       (l.app r)[x:=t] ↠βᶠ l[x := t].app (r[x:=t']) := by grind
-       _               ↠βᶠ (l.app r)[x:=t'] := by grind
+       (l.app r)[x := t] ↠βᶠ l[x := t].app (r[x := t']) := by grind
+       _                 ↠βᶠ (l.app r)[x := t'] := by grind
 
 /- `step_subst_cong_r` can be generalized to multiple reductions `t ↠βᶠ t'`.
    This requires s to be locally closed, locally closedness of t and t'
    can be inferred by the fact t reduces to t' -/
 lemma steps_subst_cong_r {x : Var} (s t t' : Term Var) (step : t ↠βᶠ t') (h_lc : LC s) :
-    (s [ x := t ]) ↠βᶠ (s [ x := t' ]) := by
+    (s[x := t]) ↠βᶠ (s[x := t']) := by
   induction step with
   | refl => rfl
   | tail steps step ih => grind [Relation.ReflTransGen.trans, step_subst_cong_r]
@@ -190,7 +190,7 @@ lemma steps_open_cong_abs (s s' t t' : Term Var)
   | abs L =>
     have ⟨x, _⟩ := fresh_exists <| free_union [fv] Var
     rw [subst_intro x t s, subst_intro x t' s']
-    · trans (s ^ fvar x)[x:=t']
+    · trans (s ^ fvar x)[x := t']
       · grind [steps_subst_cong_r]
       · grind [=_ subst_intro, steps_open_cong_l_abs]
     all_goals grind

--- a/Cslib/Languages/LambdaCalculus/LocallyNameless/Untyped/FullBetaConfluence.lean
+++ b/Cslib/Languages/LambdaCalculus/LocallyNameless/Untyped/FullBetaConfluence.lean
@@ -175,7 +175,7 @@ theorem para_diamond : Diamond (@Parallel Var) := by
       have ⟨q1, q2, _⟩ := qx
       have ⟨t', _⟩ := ih2 s2pu2'
       have ⟨t'', _⟩ := @ih1 x q1 _ (mem' _ q2)
-      refine ⟨t'' [x := t'], ?_⟩
+      refine ⟨t''[x := t'], ?_⟩
       grind
   case app s1 s1' s2 s2' s1ps1' _ ih1 ih2  =>
     cases tpt2

--- a/Cslib/Languages/LambdaCalculus/LocallyNameless/Untyped/FullEta.lean
+++ b/Cslib/Languages/LambdaCalculus/LocallyNameless/Untyped/FullEta.lean
@@ -81,9 +81,9 @@ lemma step_not_fv (step : M ⭢ηᶠ M') : M.fv = M'.fv := by
     grind [open_preserve_not_fvar]
   | _ => grind
 
-/- `s ⭢ηᶠ s'` implies `s [ x := N ] ⭢ηᶠ s' [ x := N ]`. -/
+/- `s ⭢ηᶠ s'` implies `s[x := N] ⭢ηᶠ s'[x := N]`. -/
 lemma step_subst_cong_l {x : Var} (s s' N : Term Var) (step : s ⭢ηᶠ s') (lc_N : LC N) :
-    s [ x := N ] ⭢ηᶠ s' [ x := N ] := by
+    s[x := N] ⭢ηᶠ s'[x := N] := by
   induction step
   case base h => cases h with | eta lc => exact Xi.base (.eta (subst_lc lc lc_N))
   case abs => apply Xi.abs <| free_union Var; grind
@@ -91,7 +91,7 @@ lemma step_subst_cong_l {x : Var} (s s' N : Term Var) (step : s ⭢ηᶠ s') (lc
 
 /- `steps_subst_cong_l` can be generalized to multiple reductions `s ↠ηᶠ s'`. -/
 lemma steps_subst_cong_l {x : Var} (s s' N : Term Var) (steps : s ↠ηᶠ s') (lc_N : LC N) :
-    s [ x := N ] ↠ηᶠ s' [ x := N ] := by
+    s[x := N] ↠ηᶠ s'[x := N] := by
   induction steps with
   | refl => rfl
   | tail _ step ih => grind [step_subst_cong_l]
@@ -117,9 +117,9 @@ theorem redex_abs_cong {M M' : Term Var} (xs : Finset Var)
     rw [open_close x M 0, open_close x M' 0]
     all_goals grind [redex_abs_close (x := x) (cofin x ?_) (hL x ?_)]
 
-/- `t ⭢ηᶠ t'` implies `s [ x := t ] ↠ηᶠ s [ x := t' ]`. -/
+/- `t ⭢ηᶠ t'` implies `s[x := t] ↠ηᶠ s[x := t']`. -/
 lemma step_subst_cong_r {x : Var} (s t t' : Term Var) (st : t ⭢ηᶠ t') (lc_s : LC s) (lc_t : LC t) :
-    s [ x := t ] ↠ηᶠ s [ x := t' ] := by
+    s[x := t] ↠ηᶠ s[x := t'] := by
   induction lc_s generalizing t t' with
   | fvar => grind
   | app hl hr ih_l ih_r =>
@@ -136,7 +136,7 @@ lemma step_subst_cong_r {x : Var} (s t t' : Term Var) (st : t ⭢ηᶠ t') (lc_s
 
 /- `steps_subst_cong_r` can be generalized to multiple reductions `t ↠ηᶠ t'`. -/
 lemma steps_subst_cong_r {x : Var} (s t t' : Term Var) (st : t ↠ηᶠ t') (lc_s : LC s) (lc_t : LC t) :
-    s [ x := t ] ↠ηᶠ s [ x := t' ] := by
+    s[x := t] ↠ηᶠ s[x := t'] := by
   induction st using Relation.ReflTransGen.head_induction_on
   case refl => rfl
   case head _ _ st _ ih => exact .trans (step_subst_cong_r s _ _ st lc_s lc_t) (ih (step_lc_r st))

--- a/Cslib/Languages/LambdaCalculus/LocallyNameless/Untyped/MultiSubst.lean
+++ b/Cslib/Languages/LambdaCalculus/LocallyNameless/Untyped/MultiSubst.lean
@@ -37,7 +37,7 @@ abbrev Env (Var : Type u) := Context Var (Term Var)
 def multiSubst (E : Env Var) (M : Term Var) : Term Var :=
   match E with
   | [] => M
-  | ⟨i, sub⟩ :: E' => (multiSubst E' M) [ i := sub ]
+  | ⟨i, sub⟩ :: E' => (multiSubst E' M)[i := sub]
 
 /-- The free variables of an environment are the union of
     the free variables of all terms in the environment.

--- a/Cslib/Languages/LambdaCalculus/LocallyNameless/Untyped/Properties.lean
+++ b/Cslib/Languages/LambdaCalculus/LocallyNameless/Untyped/Properties.lean
@@ -25,7 +25,7 @@ attribute [grind =] Finset.union_singleton
 variable [DecidableEq Var]
 
 /-- Substitution of a free variable not present in a term leaves it unchanged. -/
-theorem subst_fresh (x : Var) (t sub : Term Var) (nmem : x ∉ t.fv) : t [x := sub] = t := by
+theorem subst_fresh (x : Var) (t sub : Term Var) (nmem : x ∉ t.fv) : t[x := sub] = t := by
   induction t <;> grind
 
 /- Opening and closing are inverses. -/
@@ -66,7 +66,7 @@ theorem open_preserve_not_fvar (k) (m n : Term Var) :
 set_option linter.tacticAnalysis.verifyGrindOnly false in
 /-- Substitution preserves free variables. -/
 lemma subst_preserve_not_fvar {y : Var} (m n : Term Var) :
-    m [y := n].fv = m.fv.erase y ∨ m [y := n].fv = m.fv.erase y ∪ n.fv:= by
+    m[y := n].fv = m.fv.erase y ∨ m[y := n].fv = m.fv.erase y ∪ n.fv:= by
   induction m with
   | app => grind only [fv, = subst_app, = Finset.mem_union, = Finset.mem_erase]
   | _ => grind
@@ -80,7 +80,7 @@ lemma subst_intro_openRec {x} {t e : Term Var} (mem : x ∉ e.fv) {k : ℕ} :
 
 /-- Opening to a term `t` is equivalent to opening to a free variable and substituting for `t`. -/
 lemma subst_intro (x : Var) (t e : Term Var) (mem : x ∉ e.fv) :
-    e ^ t = (e ^ fvar x) [ x := t ] := subst_intro_openRec mem
+    e ^ t = (e ^ fvar x)[x := t] := subst_intro_openRec mem
 
 scoped grind_pattern subst_intro => open' e t, open' e (fvar x)
 
@@ -107,12 +107,12 @@ lemma open_eq_app {x : Var} {m n : Term Var} (hw_n : x ∉ n.fv) (hw_m : x ∉ m
 /-- Substitution of a locally closed term distributes with opening. -/
 @[scoped grind =]
 lemma subst_openRec (x : Var) (t : Term Var) (k : ℕ) (u e : Term Var) (lc : LC t) :
-    (e⟦ k ↝ u ⟧)[x := t] = e[x := t]⟦k ↝ u [ x := t ]⟧ := by
+    (e⟦ k ↝ u ⟧)[x := t] = e[x := t]⟦k ↝ u[x := t]⟧ := by
   induction e generalizing k with grind
 
 /-- Specialize `subst_openRec` to the first opening. -/
 lemma subst_open (x : Var) (t : Term Var) (u e : Term Var) (lc : LC t) :
-    (e ^ u)[x := t] = e[x := t] ^ u [ x := t ] := by grind
+    (e ^ u)[x := t] = e[x := t] ^ u[x := t] := by grind
 
 /-- Specialize `subst_open` to the free variables. -/
 theorem subst_open_var (x y : Var) (u e : Term Var) (neq : y ≠ x) (u_lc : LC u) :
@@ -120,7 +120,7 @@ theorem subst_open_var (x y : Var) (u e : Term Var) (neq : y ≠ x) (u_lc : LC u
 
 /-- Substitution of locally closed terms is locally closed. -/
 @[scoped grind ←]
-theorem subst_lc {x : Var} {e u : Term Var} (e_lc : LC e) (u_lc : LC u) : LC (e [x := u]) := by
+theorem subst_lc {x : Var} {e u : Term Var} (e_lc : LC e) (u_lc : LC u) : LC (e[x := u]) := by
   induction e_lc
   case' abs => apply LC.abs (free_union Var)
   all_goals grind
@@ -135,7 +135,7 @@ theorem beta_lc {M N : Term Var} (m_lc : M.abs.LC) (n_lc : LC N) : LC (M ^ N) :=
 /-- Closing then opening is equivalent to substitution. -/
 @[scoped grind =]
 lemma close_openRec_to_subst (m n : Term Var) (x : Var) (k : ℕ) (m_lc : LC m) (n_lc : LC n) :
-    m ⟦k ↜ x⟧⟦k ↝ n⟧ = m [x := n] := by
+    m ⟦k ↜ x⟧⟦k ↝ n⟧ = m[x := n] := by
   induction m_lc generalizing k with
   | abs xs t =>
     have ⟨x', _⟩ := fresh_exists <| free_union [fv] Var
@@ -148,7 +148,7 @@ lemma close_openRec_to_subst (m n : Term Var) (x : Var) (k : ℕ) (m_lc : LC m) 
 
 @[scoped grind =]
 lemma close_open_to_subst (m n : Term Var) (x : Var) (m_lc : LC m) (n_lc : LC n) :
-    (m ^* x) ^ n = m [x := n] := close_openRec_to_subst m n x 0 m_lc n_lc
+    (m ^* x) ^ n = m[x := n] := close_openRec_to_subst m n x 0 m_lc n_lc
 
 /-- Closing and opening are inverses. -/
 lemma close_open (x : Var) (t : Term Var) (k : ℕ) (t_lc : LC t) : t⟦k ↜ x⟧⟦k ↝ fvar x⟧ = t := by

--- a/CslibTests.lean
+++ b/CslibTests.lean
@@ -6,6 +6,7 @@ import CslibTests.FreeMonad
 import CslibTests.GrindLint
 import CslibTests.HML
 import CslibTests.HasFresh
+import CslibTests.HasSubstitution
 import CslibTests.ImportWithMathlib
 import CslibTests.LTS
 import CslibTests.LambdaCalculus

--- a/CslibTests/HasSubstitution.lean
+++ b/CslibTests/HasSubstitution.lean
@@ -1,0 +1,21 @@
+import Cslib.Foundations.Syntax.HasSubstitution
+
+namespace CslibTests
+namespace HasSubstitution
+
+/-- Regression test for leanprover/cslib#631.
+
+Before the notation was guarded by `noWs`, the parser tried to read the instance
+binder below as part of a substitution expression attached to `Type`.
+-/
+structure InstanceBinderAfterField where
+  A : Type
+  [inst : Inhabited A]
+
+instance : Cslib.HasSubstitution Nat Nat Nat where
+  subst t _ _ := t
+
+example : (1[2 := 3]) = 1 := rfl
+
+end HasSubstitution
+end CslibTests


### PR DESCRIPTION
Fixes #631.

My PR changes `HasSubstitution` notation from a plain trailing notation to a `syntax`/`macro_rules` form guarded by `noWs`. 
The substitution spelling remains`t[x := s]`; 
the spaced receiver spelling `t [x := s]` is migrated internally because it can capture brackets from following syntax.

The new regression test checks that a structure field followed by an instance-binder field parses after importing `Cslib.Foundations.Syntax.HasSubstitution`.
