### PR TITLE
feat(LTS/Spectrum): van Glabbeek spectrum as a Galois connection

### DIFF
--- a/Cslib.lean
+++ b/Cslib.lean
@@ -98,6 +98,9 @@ public import Cslib.Foundations.Semantics.LTS.Notation
 public import Cslib.Foundations.Semantics.LTS.OmegaExecution
 public import Cslib.Foundations.Semantics.LTS.Relation
 public import Cslib.Foundations.Semantics.LTS.Simulation
+public import Cslib.Foundations.Semantics.LTS.Spectrum.Antichain
+public import Cslib.Foundations.Semantics.LTS.Spectrum.Galois
+public import Cslib.Foundations.Semantics.LTS.Spectrum.TracePoint
 public import Cslib.Foundations.Semantics.LTS.Termination
 public import Cslib.Foundations.Semantics.LTS.Total
 public import Cslib.Foundations.Semantics.LTS.TraceEq

--- a/Cslib.lean
+++ b/Cslib.lean
@@ -99,6 +99,7 @@ public import Cslib.Foundations.Semantics.LTS.OmegaExecution
 public import Cslib.Foundations.Semantics.LTS.Relation
 public import Cslib.Foundations.Semantics.LTS.Simulation
 public import Cslib.Foundations.Semantics.LTS.Spectrum.Antichain
+public import Cslib.Foundations.Semantics.LTS.Spectrum.BisimPoint
 public import Cslib.Foundations.Semantics.LTS.Spectrum.Galois
 public import Cslib.Foundations.Semantics.LTS.Spectrum.TracePoint
 public import Cslib.Foundations.Semantics.LTS.Termination

--- a/Cslib/Foundations/Semantics/LTS/Spectrum/Antichain.lean
+++ b/Cslib/Foundations/Semantics/LTS/Spectrum/Antichain.lean
@@ -47,8 +47,9 @@ def t2 : W → Bool
   | a | c => true
   | b | d => false
 
-/-- Test classes (singletons, written as comprehensions). -/
+/-- Test class `T₁`: the singleton `{ t₁ }`, written as a comprehension. -/
 def T1 : Set (W → Bool) := { f | f = t1 }
+/-- Test class `T₂`: the singleton `{ t₂ }`, written as a comprehension. -/
 def T2 : Set (W → Bool) := { f | f = t2 }
 
 /-- a,b are `T₁`-equivalent but `T₂`-distinct. -/

--- a/Cslib/Foundations/Semantics/LTS/Spectrum/Antichain.lean
+++ b/Cslib/Foundations/Semantics/LTS/Spectrum/Antichain.lean
@@ -12,21 +12,14 @@ public import Cslib.Foundations.Semantics.LTS.Spectrum.Galois
 /-!
 # Spectrum antichain — the closed-element lattice is not a chain
 
-The closed-element lattice is NOT totally ordered by refinement: two
-incomparable Galois-closed (testable) equivalences exist over a 4-state witness
-space. Two test classes `T₁`, `T₂` (Ω = Bool) induce closed equivalences such
-that neither refines the other:
+The lattice of testable equivalences is not totally ordered by refinement. Over
+a 4-state witness, two test classes `T₁`, `T₂` (Ω = `Bool`) induce closed
+equivalences that are incomparable:
   - states a,b are `T₁`-equivalent but `T₂`-distinct;
   - states a,c are `T₂`-equivalent but `T₁`-distinct.
-Hence the closed-element lattice contains an antichain → it is a lattice, not a
-chain (scale). This is the structural form of the "linear-time/branching-time
-spectrum is a lattice, not a linear scale" claim.
 
-This file proves the structural fact only, over a small explicit witness. The
-classical spectrum also contains *named* incomparable pairs — e.g. simulation
-equivalence vs failures equivalence [Glabbeek1990] — but mechanising such a
-pair requires failures semantics, which CSLib does not yet define, so no named
-instance is attempted here.
+So the spectrum contains an antichain — it is a lattice, not a linear scale
+(cf. [Glabbeek1990]).
 -/
 
 @[expose] public section
@@ -49,9 +42,9 @@ def t2 : W → Bool
   | a | c => true
   | b | d => false
 
-/-- Test class `T₁`: the singleton `{ t₁ }`, written as a comprehension. -/
+/-- Test class `T₁`: the singleton `{ t₁ }`. -/
 def T1 : Set (W → Bool) := { f | f = t1 }
-/-- Test class `T₂`: the singleton `{ t₂ }`, written as a comprehension. -/
+/-- Test class `T₂`: the singleton `{ t₂ }`. -/
 def T2 : Set (W → Bool) := { f | f = t2 }
 
 /-- a,b are `T₁`-equivalent but `T₂`-distinct. -/

--- a/Cslib/Foundations/Semantics/LTS/Spectrum/Antichain.lean
+++ b/Cslib/Foundations/Semantics/LTS/Spectrum/Antichain.lean
@@ -22,9 +22,11 @@ Hence the closed-element lattice contains an antichain → it is a lattice, not 
 chain (scale). This is the structural form of the "linear-time/branching-time
 spectrum is a lattice, not a linear scale" claim.
 
-(The *named* van Glabbeek antichain — simulation vs failures equivalence —
-requires failures semantics, not yet in CSLib; that named instance is separate
-from the structural result here.)
+This file proves the structural fact only, over a small explicit witness. The
+classical spectrum also contains *named* incomparable pairs — e.g. simulation
+equivalence vs failures equivalence [Glabbeek1990] — but mechanising such a
+pair requires failures semantics, which CSLib does not yet define, so no named
+instance is attempted here.
 -/
 
 @[expose] public section

--- a/Cslib/Foundations/Semantics/LTS/Spectrum/Antichain.lean
+++ b/Cslib/Foundations/Semantics/LTS/Spectrum/Antichain.lean
@@ -1,0 +1,91 @@
+/-
+Copyright (c) 2026 TODO. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: TODO
+-/
+
+module
+
+public import Cslib.Init
+public import Cslib.Foundations.Semantics.LTS.Spectrum.Galois
+
+/-!
+# Spectrum antichain — the closed-element lattice is not a chain
+
+The closed-element lattice is NOT totally ordered by refinement: two
+incomparable Galois-closed (testable) equivalences exist over a 4-state witness
+space. Two test classes `T₁`, `T₂` (Ω = Bool) induce closed equivalences such
+that neither refines the other:
+  - states a,b are `T₁`-equivalent but `T₂`-distinct;
+  - states a,c are `T₂`-equivalent but `T₁`-distinct.
+Hence the closed-element lattice contains an antichain → it is a lattice, not a
+chain (scale). This is the structural form of the "linear-time/branching-time
+spectrum is a lattice, not a linear scale" claim.
+
+(The *named* van Glabbeek antichain — simulation vs failures equivalence —
+requires failures semantics, not yet in CSLib; that named instance is separate
+from the structural result here.)
+-/
+
+@[expose] public section
+
+namespace Cslib.LTS.Spectrum
+
+/-- 4-state witness space. -/
+inductive W where
+  | a | b | c | d
+
+open W
+
+/-- Test t₁: groups {a,b} (true) vs {c,d} (false). -/
+def t1 : W → Bool
+  | a | b => true
+  | c | d => false
+
+/-- Test t₂: groups {a,c} (true) vs {b,d} (false). -/
+def t2 : W → Bool
+  | a | c => true
+  | b | d => false
+
+/-- Test classes (singletons, written as comprehensions). -/
+def T1 : Set (W → Bool) := { f | f = t1 }
+def T2 : Set (W → Bool) := { f | f = t2 }
+
+/-- a,b are `T₁`-equivalent but `T₂`-distinct. -/
+theorem T1_ab_not_T2_ab : induced Bool T1 a b ∧ ¬ induced Bool T2 a b := by
+  refine ⟨?_, ?_⟩
+  · intro t ht
+    have ht : t = t1 := ht
+    subst ht
+    rfl
+  · intro h
+    have hh : t2 a = t2 b := h t2 rfl
+    simp only [t2] at hh
+    exact Bool.noConfusion hh
+
+/-- a,c are `T₂`-equivalent but `T₁`-distinct. -/
+theorem T2_ac_not_T1_ac : induced Bool T2 a c ∧ ¬ induced Bool T1 a c := by
+  refine ⟨?_, ?_⟩
+  · intro t ht
+    have ht : t = t2 := ht
+    subst ht
+    rfl
+  · intro h
+    have hh : t1 a = t1 c := h t1 rfl
+    simp only [t1] at hh
+    exact Bool.noConfusion hh
+
+/-- **The closed-element lattice is not a chain.** There exist two incomparable
+    testable (Galois-closed) equivalences. -/
+theorem exists_incomparable_closed :
+    ∃ E₁ E₂ : W → W → Prop,
+      Testable Bool E₁ ∧ Testable Bool E₂ ∧
+        ¬ (∀ p q, E₁ p q → E₂ p q) ∧ ¬ (∀ p q, E₂ p q → E₁ p q) := by
+  refine ⟨induced Bool T1, induced Bool T2,
+          induced_testable Bool T1, induced_testable Bool T2, ?_, ?_⟩
+  · intro h
+    exact T1_ab_not_T2_ab.2 (h a b T1_ab_not_T2_ab.1)
+  · intro h
+    exact T2_ac_not_T1_ac.2 (h a c T2_ac_not_T1_ac.1)
+
+end Cslib.LTS.Spectrum

--- a/Cslib/Foundations/Semantics/LTS/Spectrum/Antichain.lean
+++ b/Cslib/Foundations/Semantics/LTS/Spectrum/Antichain.lean
@@ -1,7 +1,7 @@
 /-
-Copyright (c) 2026 TODO. All rights reserved.
+Copyright (c) 2026 patchwright. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
-Authors: TODO
+Authors: patchwright
 -/
 
 module

--- a/Cslib/Foundations/Semantics/LTS/Spectrum/BisimPoint.lean
+++ b/Cslib/Foundations/Semantics/LTS/Spectrum/BisimPoint.lean
@@ -1,0 +1,74 @@
+/-
+Copyright (c) 2026 patchwright. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: patchwright
+-/
+
+module
+
+public import Cslib.Init
+public import Cslib.Foundations.Semantics.LTS.Spectrum.Galois
+public import Cslib.Logics.HML.Basic
+
+/-!
+# Spectrum bisim point — bisimilarity is Galois-closed (via Hennessy–Milner)
+
+The non-trivial spectrum point. Unlike trace equivalence (`Spectrum.TracePoint`),
+bisimilarity is NOT the kernel of its test map by definition — it is the
+Hennessy–Milner theorem that makes it one. CSLib mechanises HM as
+`Cslib.Logic.HML.theoryEq_eq_bisimilarity` (`TheoryEq lts = HomBisimilarity lts`
+for image-finite LTS), so composing that with the (kernel-trivial) fact that
+`TheoryEq` is the equivalence induced by the HML-theory test class yields:
+
+  `Testable (Set (Proposition Label)) (HomBisimilarity lts)`.
+
+This is the load-bearing step that earns the contribution the word "spectrum":
+two genuinely different behavioural equivalences — trace (kernel-trivial bottom)
+and bisimilarity (HM-mediated top) — are closed elements of the SAME polarity.
+-/
+
+@[expose] public section
+
+namespace Cslib.LTS.Spectrum
+
+open Cslib Cslib.Logic.HML
+
+variable {State Label : Type*} (lts : LTS State Label)
+
+/-- The HML-theory observer test: a state's full theory (set of satisfied HML
+    propositions). -/
+def hmlTheory (s : State) : Set (Proposition Label) :=
+  theory lts s
+
+/-- Test class for the bisim point: the singleton HML-theory observer. -/
+def hmlTestClass : Set (State → Set (Proposition Label)) :=
+  { f | f = hmlTheory lts }
+
+/-- The equivalence induced by the HML-theory test is CSLib's `TheoryEq`
+    (pointwise iff). -/
+theorem induced_hml_iff (p q : State) :
+    induced (Set (Proposition Label)) (hmlTestClass lts) p q ↔ TheoryEq lts p q := by
+  constructor
+  · intro h
+    exact h _ rfl
+  · intro h t ht
+    have ht : t = hmlTheory lts := ht
+    subst ht
+    exact h
+
+/-- Function-equality form (via `propext`). -/
+theorem induced_hml :
+    induced (Set (Proposition Label)) (hmlTestClass lts) = TheoryEq lts := by
+  funext p q
+  exact propext (induced_hml_iff lts p q)
+
+/-- **Bisim point.** CSLib's homogeneous bisimilarity is a Galois-closed
+    (testable) equivalence — for image-finite LTS, via the Hennessy–Milner
+    theorem (`theoryEq_eq_bisimilarity`). This is the non-trivial spectrum point:
+    bisimilarity is not a kernel by definition; HM makes it one. -/
+theorem HomBisimilarity_testable [image_finite : ∀ s μ, Finite (lts.image s μ)] :
+    Testable (Set (Proposition Label)) (HomBisimilarity lts) := by
+  rw [← theoryEq_eq_bisimilarity lts, ← induced_hml lts]
+  exact induced_testable (Set (Proposition Label)) (hmlTestClass lts)
+
+end Cslib.LTS.Spectrum

--- a/Cslib/Foundations/Semantics/LTS/Spectrum/BisimPoint.lean
+++ b/Cslib/Foundations/Semantics/LTS/Spectrum/BisimPoint.lean
@@ -14,17 +14,13 @@ public import Cslib.Logics.HML.Basic
 # Spectrum bisim point — bisimilarity is Galois-closed (via Hennessy–Milner)
 
 The non-trivial spectrum point. Unlike trace equivalence (`Spectrum.TracePoint`),
-bisimilarity is NOT the kernel of its test map by definition — it is the
-Hennessy–Milner theorem that makes it one. CSLib mechanises HM as
+bisimilarity is not the kernel of its test map by definition; the
+Hennessy–Milner theorem makes it one. CSLib mechanises HM as
 `Cslib.Logic.HML.theoryEq_eq_bisimilarity` (`TheoryEq lts = HomBisimilarity lts`
-for image-finite LTS), so composing that with the (kernel-trivial) fact that
-`TheoryEq` is the equivalence induced by the HML-theory test class yields:
+for image-finite LTS), and `TheoryEq` is the equivalence induced by the
+HML-theory test class, so:
 
   `Testable (Set (Proposition Label)) (HomBisimilarity lts)`.
-
-This is the load-bearing step that earns the contribution the word "spectrum":
-two genuinely different behavioural equivalences — trace (kernel-trivial bottom)
-and bisimilarity (HM-mediated top) — are closed elements of the SAME polarity.
 -/
 
 @[expose] public section
@@ -56,16 +52,14 @@ theorem induced_hml_iff (p q : State) :
     subst ht
     exact h
 
-/-- Function-equality form (via `propext`). -/
+/-- Function-equality form of `induced_hml_iff`. -/
 theorem induced_hml :
     induced (Set (Proposition Label)) (hmlTestClass lts) = TheoryEq lts := by
   funext p q
   exact propext (induced_hml_iff lts p q)
 
-/-- **Bisim point.** CSLib's homogeneous bisimilarity is a Galois-closed
-    (testable) equivalence — for image-finite LTS, via the Hennessy–Milner
-    theorem (`theoryEq_eq_bisimilarity`). This is the non-trivial spectrum point:
-    bisimilarity is not a kernel by definition; HM makes it one. -/
+/-- **Bisim point.** `HomBisimilarity lts` is testable for image-finite LTS, via
+    the Hennessy–Milner theorem (`theoryEq_eq_bisimilarity`). -/
 theorem HomBisimilarity_testable [image_finite : ∀ s μ, Finite (lts.image s μ)] :
     Testable (Set (Proposition Label)) (HomBisimilarity lts) := by
   rw [← theoryEq_eq_bisimilarity lts, ← induced_hml lts]

--- a/Cslib/Foundations/Semantics/LTS/Spectrum/Galois.lean
+++ b/Cslib/Foundations/Semantics/LTS/Spectrum/Galois.lean
@@ -7,7 +7,7 @@ Authors: patchwright
 module
 
 public import Cslib.Init
-public import Mathlib.Order.GaloisConnection.Defs
+public import Mathlib.Order.GaloisConnection.Basic
 public import Mathlib.Order.Closure
 
 /-!
@@ -54,6 +54,8 @@ recover `Ω` from it.
 * `cl_extensive`, `cl_monotone`, `cl_idempotent`: inherited from
   `ClosureOperator`.
 * `spectrum_eq_closed_elements`: testable ↔ in the image of `induced`.
+* `spectrumCompleteLattice`: the testable equivalences form a complete lattice
+  under refinement (via `GaloisInsertion.liftCompleteLattice`).
 
 ## References
 
@@ -168,5 +170,16 @@ theorem spectrum_eq_closed_elements (Ω : Type*) (E : Proc → Proc → Prop) :
     exact ⟨respects Ω E, (cl Ω).isClosed_iff.1 hE⟩
   · rintro ⟨T, rfl⟩
     exact induced_testable Ω T
+
+/-- **The spectrum is a complete lattice.** The closed elements of `cl Ω` — the
+    testable equivalences — form a complete lattice under refinement, lifted
+    through the Galois insertion `(cl Ω).gi` from the complete lattice of all
+    equivalences (Mathlib's `GaloisInsertion.liftCompleteLattice`). Arbitrary
+    meets and joins of testable equivalences exist; and the lattice is not a
+    chain (`Spectrum.Antichain`), which is the structural form of "the
+    linear-time/branching-time spectrum is a lattice, not a linear scale". -/
+instance spectrumCompleteLattice {Ω : Type*} :
+    CompleteLattice ((cl (Proc := Proc) Ω).Closeds) :=
+  (cl Ω).gi.liftCompleteLattice
 
 end Cslib.LTS.Spectrum

--- a/Cslib/Foundations/Semantics/LTS/Spectrum/Galois.lean
+++ b/Cslib/Foundations/Semantics/LTS/Spectrum/Galois.lean
@@ -39,6 +39,15 @@ recover `Ω` from it.
 * `induced_testable`: every induced equivalence is a fixed point of `cl`.
 * `cl_extensive`, `cl_monotone`, `cl_idempotent`: `cl` is a closure operator.
 * `spectrum_eq_closed_elements`: testable ↔ in the image of `induced`.
+
+## References
+
+* [R.J. van Glabbeek, *The Linear Time – Branching Time Spectrum*][Glabbeek1990]
+  (extended to silent moves in *Spectrum II* [Glabbeek1993]) — the spectrum of
+  behavioural equivalences ordered by refinement.
+* [H. Beohar, *Hennessy-Milner Theorems via Galois Connections*][Beohar2022] —
+  the reading of those equivalences as the fixed points of an antitone Galois
+  connection (polarity) between tests and equivalences.
 -/
 
 @[expose] public section

--- a/Cslib/Foundations/Semantics/LTS/Spectrum/Galois.lean
+++ b/Cslib/Foundations/Semantics/LTS/Spectrum/Galois.lean
@@ -7,15 +7,25 @@ Authors: patchwright
 module
 
 public import Cslib.Init
+public import Mathlib.Order.GaloisConnection.Defs
+public import Mathlib.Order.Closure
 
 /-!
 # Van Glabbeek's spectrum as a Galois connection — the polarity framework
 
-Behavioural equivalences are organised as the fixed points of an antitone Galois
-connection ("polarity") between sets of tests (ordered by ⊆) and equivalences
-(ordered by refinement). The Galois-closed equivalences — the "testable" ones —
-are exactly the image of `induced`; they form a lattice, not a chain
-(see `Spectrum.Antichain`).
+Behavioural equivalences are organised as the closed elements of an antitone
+Galois connection ("polarity") between sets of tests (ordered by `⊆`) and
+equivalences (ordered by refinement). Following the standard Mathlib idiom, the
+antitone connection is stated as a `GaloisConnection` into the order dual:
+
+  `polarity : GaloisConnection (toDual ∘ respects Ω) (induced Ω ∘ ofDual)`
+
+The closure operator on equivalences is then *derived* — it is
+`(polarity Ω).closureOperator`, an instance of Mathlib's `ClosureOperator`
+(the same pattern as `PhaseSemantics.biorthogonalClosure`), so extensivity,
+monotonicity and idempotence are inherited rather than proved by hand. The
+Galois-closed equivalences — the "testable" ones — are exactly the image of
+`induced`; they form a lattice, not a chain (see `Spectrum.Antichain`).
 
 This module is the Mathlib/`Cslib.Init`-only framework. A concrete named
 spectrum point (CSLib's `HomTraceEq`) is shown Galois-closed in
@@ -30,14 +40,19 @@ recover `Ω` from it.
 
 * `induced Ω T`: the equivalence a test class `T` induces.
 * `respects Ω E`: the tests that respect an equivalence `E`.
-* `cl Ω`: the closure operator `induced Ω ∘ respects Ω`.
-* `Testable Ω E`: the fixed-point predicate (`cl Ω E = E`).
+* `cl Ω`: the closure operator `induced Ω ∘ respects Ω`, as a Mathlib
+  `ClosureOperator`, obtained from `polarity` via
+  `GaloisConnection.closureOperator`.
+* `Testable Ω E`: `E` is a closed element of `cl Ω` (`(cl Ω).IsClosed E`).
 
 ## Main statements
 
-* `polarity`: the antitone Galois connection.
-* `induced_testable`: every induced equivalence is a fixed point of `cl`.
-* `cl_extensive`, `cl_monotone`, `cl_idempotent`: `cl` is a closure operator.
+* `polarity`: the antitone Galois connection, as a Mathlib `GaloisConnection`
+  into the order dual.
+* `induced_testable`: every induced equivalence is closed (from
+  `GaloisConnection.u_l_u_eq_u`).
+* `cl_extensive`, `cl_monotone`, `cl_idempotent`: inherited from
+  `ClosureOperator`.
 * `spectrum_eq_closed_elements`: testable ↔ in the image of `induced`.
 
 ## References
@@ -54,6 +69,8 @@ recover `Ω` from it.
 
 namespace Cslib.LTS.Spectrum
 
+open OrderDual (toDual ofDual)
+
 variable {Proc : Type*}
 
 /-- The equivalence a test class induces: agreement on every test in `T`.
@@ -66,9 +83,9 @@ def induced (Ω : Type*) (T : Set (Proc → Ω)) (p q : Proc) : Prop :=
 def respects (Ω : Type*) (E : Proc → Proc → Prop) : Set (Proc → Ω) :=
   { t | ∀ p q, E p q → t p = t q }
 
-/-- **Polarity.** Antitone Galois connection between test classes (⊆) and
-    equivalences (refinement): `E` refines `induced Ω T` iff `T ⊆ respects Ω E`. -/
-theorem polarity (Ω : Type*) (T : Set (Proc → Ω)) (E : Proc → Proc → Prop) :
+/-- Pointwise form of the polarity: `E` refines `induced Ω T` iff
+    `T ⊆ respects Ω E`. The order-theoretic packaging is `polarity` below. -/
+theorem polarity_iff (Ω : Type*) (T : Set (Proc → Ω)) (E : Proc → Proc → Prop) :
     (∀ p q, E p q → induced Ω T p q) ↔ T ⊆ respects Ω E := by
   constructor
   · intro h t ht p q hpq
@@ -76,66 +93,79 @@ theorem polarity (Ω : Type*) (T : Set (Proc → Ω)) (E : Proc → Proc → Pro
   · intro h p q hpq t ht
     exact h ht p q hpq
 
-/-- Every test in `T` respects the equivalence `T` induces (the image fact). -/
+/-- **Polarity.** `respects Ω` and `induced Ω` form an antitone Galois
+    connection between equivalences under refinement and test classes under
+    `⊆`. Stated, as is standard in Mathlib, as a (monotone) `GaloisConnection`
+    into the order dual `(Set (Proc → Ω))ᵒᵈ`. -/
+theorem polarity (Ω : Type*) :
+    GaloisConnection (fun E : Proc → Proc → Prop => toDual (respects Ω E))
+      (fun T => induced Ω (ofDual T)) := by
+  intro E T
+  rw [OrderDual.toDual_le]
+  simp only [Set.le_eq_subset, Pi.le_def, le_Prop_eq]
+  exact (polarity_iff Ω (ofDual T) E).symm
+
+/-- Every test in `T` respects the equivalence `T` induces — the counit
+    `l (u b) ≤ b` of `polarity`, read back through the dual. -/
 theorem test_subset_respects_induced (Ω : Type*) (T : Set (Proc → Ω)) :
-    T ⊆ respects Ω (induced Ω T) := by
-  intro t ht
-  change ∀ p q, induced Ω T p q → t p = t q
-  intro p q hpq
-  exact hpq t ht
+    T ⊆ respects Ω (induced Ω T) :=
+  (polarity Ω).l_u_le (toDual T)
 
-/-- Closure operator on equivalences: `induced Ω ∘ respects Ω`. -/
-def cl (Ω : Type*) (E : Proc → Proc → Prop) : Proc → Proc → Prop :=
-  induced Ω (respects Ω E)
+/-- Closure operator on equivalences: `induced Ω ∘ respects Ω`, obtained from
+    `polarity` via Mathlib's `GaloisConnection.closureOperator`. -/
+def cl (Ω : Type*) : ClosureOperator (Proc → Proc → Prop) :=
+  (polarity (Proc := Proc) Ω).closureOperator
 
-/-- `cl Ω` is extensive: `E ≤ cl Ω E` (pointwise). -/
-theorem cl_extensive (Ω : Type*) (E : Proc → Proc → Prop) (p q : Proc)
-    (h : E p q) : cl Ω E p q := by
-  intro t ht
-  exact ht p q h
+/-- `cl Ω` acts as `induced Ω ∘ respects Ω`. -/
+theorem cl_apply (Ω : Type*) (E : Proc → Proc → Prop) :
+    cl Ω E = induced Ω (respects Ω E) :=
+  rfl
 
-/-- `cl Ω` is monotone: `E₁ ≤ E₂ → cl Ω E₁ ≤ cl Ω E₂`. -/
-theorem cl_monotone (Ω : Type*) (E₁ E₂ : Proc → Proc → Prop)
-    (h : ∀ p q, E₁ p q → E₂ p q) (p q : Proc) (hcl : cl Ω E₁ p q) :
-    cl Ω E₂ p q := by
-  intro t ht
-  exact hcl t (fun a b ha => ht a b (h a b ha))
+/-- `cl Ω` is extensive: `E ≤ cl Ω E` — inherited from `ClosureOperator`. -/
+theorem cl_extensive (Ω : Type*) (E : Proc → Proc → Prop) : E ≤ cl Ω E :=
+  (cl Ω).le_closure E
+
+/-- `cl Ω` is monotone — inherited from `ClosureOperator`. -/
+theorem cl_monotone (Ω : Type*) : Monotone (cl (Proc := Proc) Ω) :=
+  (cl Ω).monotone
+
+/-- `cl Ω` is idempotent — inherited from `ClosureOperator`. -/
+theorem cl_idempotent (Ω : Type*) (E : Proc → Proc → Prop) :
+    cl Ω (cl Ω E) = cl Ω E :=
+  (cl Ω).idempotent E
 
 /-- An equivalence is TESTABLE iff it is exactly "indistinguishability under
-    the tests that respect it" — i.e. a fixed point of `cl Ω`. This predicate
-    IS the closed-element condition. -/
+    the tests that respect it" — i.e. a closed element of `cl Ω`. -/
 def Testable (Ω : Type*) (E : Proc → Proc → Prop) : Prop :=
-  ∀ p q, cl Ω E p q ↔ E p q
+  (cl Ω).IsClosed E
 
-/-- Every induced equivalence is testable (the image of `induced Ω` is contained
-    in the fixed points of `cl Ω`). -/
-theorem induced_testable (Ω : Type*) (T : Set (Proc → Ω)) :
-    Testable Ω (induced Ω T) := by
-  intro p q
+/-- Pointwise reading of `Testable`: `cl Ω E` and `E` agree on every pair. -/
+theorem testable_iff (Ω : Type*) (E : Proc → Proc → Prop) :
+    Testable Ω E ↔ ∀ p q, cl Ω E p q ↔ E p q := by
+  rw [Testable, ClosureOperator.isClosed_iff]
   constructor
-  · intro hcl t ht
-    exact hcl t (test_subset_respects_induced Ω T ht)
-  · intro hInd t ht
-    exact ht p q hInd
+  · intro h p q
+    exact iff_of_eq (congrFun (congrFun h p) q)
+  · intro h
+    funext p q
+    exact propext (h p q)
 
-/-- `cl Ω` is idempotent: `cl Ω (cl Ω E) = cl Ω E`. `cl Ω E` lies in the image
-    of `induced Ω`, hence is a fixed point by `induced_testable`. -/
-theorem cl_idempotent (Ω : Type*) (E : Proc → Proc → Prop) (p q : Proc) :
-    cl Ω (cl Ω E) p q ↔ cl Ω E p q := by
-  have key : Testable Ω (induced Ω (respects Ω E)) := induced_testable Ω (respects Ω E)
-  exact key p q
+/-- Every induced equivalence is testable (the image of `induced Ω` is
+    contained in the closed elements) — this is `u ∘ l ∘ u = u` for `polarity`
+    (`GaloisConnection.u_l_u_eq_u`). -/
+theorem induced_testable (Ω : Type*) (T : Set (Proc → Ω)) :
+    Testable Ω (induced Ω T) :=
+  (cl Ω).isClosed_iff.2 ((polarity Ω).u_l_u_eq_u (toDual T))
 
 /-- **Spectrum = image of `induced` = closed elements.** An equivalence is
-    testable (a fixed point of `cl Ω`) iff it is exactly the equivalence induced
-    by some test class. Forward direction witnessed by `T = respects Ω E`. -/
+    testable (a closed element of `cl Ω`) iff it is exactly the equivalence
+    induced by some test class. Forward direction witnessed by
+    `T = respects Ω E`. -/
 theorem spectrum_eq_closed_elements (Ω : Type*) (E : Proc → Proc → Prop) :
     Testable Ω E ↔ ∃ T : Set (Proc → Ω), induced Ω T = E := by
   constructor
   · intro hE
-    refine ⟨respects Ω E, ?_⟩
-    change cl Ω E = E
-    funext p q
-    exact propext (hE p q)
+    exact ⟨respects Ω E, (cl Ω).isClosed_iff.1 hE⟩
   · rintro ⟨T, rfl⟩
     exact induced_testable Ω T
 

--- a/Cslib/Foundations/Semantics/LTS/Spectrum/Galois.lean
+++ b/Cslib/Foundations/Semantics/LTS/Spectrum/Galois.lean
@@ -104,7 +104,7 @@ theorem polarity (Ω : Type*) :
       (fun T => induced Ω (ofDual T)) := by
   intro E T
   rw [OrderDual.toDual_le]
-  simp only [Set.le_eq_subset, Pi.le_def, le_Prop_eq]
+  simp only [Pi.le_def, le_Prop_eq]
   exact (polarity_iff Ω (ofDual T) E).symm
 
 /-- Every test in `T` respects the equivalence `T` induces — the counit

--- a/Cslib/Foundations/Semantics/LTS/Spectrum/Galois.lean
+++ b/Cslib/Foundations/Semantics/LTS/Spectrum/Galois.lean
@@ -1,0 +1,133 @@
+/-
+Copyright (c) 2026 TODO. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: TODO
+-/
+
+module
+
+public import Cslib.Init
+
+/-!
+# Van Glabbeek's spectrum as a Galois connection — the polarity framework
+
+Behavioural equivalences are organised as the fixed points of an antitone Galois
+connection ("polarity") between sets of tests (ordered by ⊆) and equivalences
+(ordered by refinement). The Galois-closed equivalences — the "testable" ones —
+are exactly the image of `induced`; they form a lattice, not a chain
+(see `Spectrum.Antichain`).
+
+This module is the Mathlib/`Cslib.Init`-only framework. A concrete named
+spectrum point (CSLib's `HomTraceEq`) is shown Galois-closed in
+`Spectrum.TracePoint`.
+
+The construction is parameterised by the pair `(Proc, Ω)`: `Proc` is the process
+type and `Ω` the observation type (a test is `Proc → Ω`). `Ω` is carried
+explicitly because the closure-operator theorems mention only `E` and cannot
+recover `Ω` from it.
+
+## Main definitions
+
+* `induced Ω T`: the equivalence a test class `T` induces.
+* `respects Ω E`: the tests that respect an equivalence `E`.
+* `cl Ω`: the closure operator `induced Ω ∘ respects Ω`.
+* `Testable Ω E`: the fixed-point predicate (`cl Ω E = E`).
+
+## Main statements
+
+* `polarity`: the antitone Galois connection.
+* `induced_testable`: every induced equivalence is a fixed point of `cl`.
+* `cl_extensive`, `cl_monotone`, `cl_idempotent`: `cl` is a closure operator.
+* `spectrum_eq_closed_elements`: testable ↔ in the image of `induced`.
+-/
+
+@[expose] public section
+
+namespace Cslib.LTS.Spectrum
+
+variable {Proc : Type*}
+
+/-- The equivalence a test class induces: agreement on every test in `T`.
+    Antitone in `T` — more tests ⇒ finer (smaller) equivalence. -/
+def induced (Ω : Type*) (T : Set (Proc → Ω)) (p q : Proc) : Prop :=
+  ∀ t ∈ T, t p = t q
+
+/-- The tests that respect an equivalence `E`: tests constant on every E-pair.
+    Antitone in `E` — coarser `E` ⇒ fewer respecting tests. -/
+def respects (Ω : Type*) (E : Proc → Proc → Prop) : Set (Proc → Ω) :=
+  { t | ∀ p q, E p q → t p = t q }
+
+/-- **Polarity.** Antitone Galois connection between test classes (⊆) and
+    equivalences (refinement): `E` refines `induced Ω T` iff `T ⊆ respects Ω E`. -/
+theorem polarity (Ω : Type*) (T : Set (Proc → Ω)) (E : Proc → Proc → Prop) :
+    (∀ p q, E p q → induced Ω T p q) ↔ T ⊆ respects Ω E := by
+  constructor
+  · intro h t ht p q hpq
+    exact h p q hpq t ht
+  · intro h p q hpq t ht
+    exact h ht p q hpq
+
+/-- Every test in `T` respects the equivalence `T` induces (the image fact). -/
+theorem test_subset_respects_induced (Ω : Type*) (T : Set (Proc → Ω)) :
+    T ⊆ respects Ω (induced Ω T) := by
+  intro t ht
+  change ∀ p q, induced Ω T p q → t p = t q
+  intro p q hpq
+  exact hpq t ht
+
+/-- Closure operator on equivalences: `induced Ω ∘ respects Ω`. -/
+def cl (Ω : Type*) (E : Proc → Proc → Prop) : Proc → Proc → Prop :=
+  induced Ω (respects Ω E)
+
+/-- `cl Ω` is extensive: `E ≤ cl Ω E` (pointwise). -/
+theorem cl_extensive (Ω : Type*) (E : Proc → Proc → Prop) (p q : Proc)
+    (h : E p q) : cl Ω E p q := by
+  intro t ht
+  exact ht p q h
+
+/-- `cl Ω` is monotone: `E₁ ≤ E₂ → cl Ω E₁ ≤ cl Ω E₂`. -/
+theorem cl_monotone (Ω : Type*) (E₁ E₂ : Proc → Proc → Prop)
+    (h : ∀ p q, E₁ p q → E₂ p q) (p q : Proc) (hcl : cl Ω E₁ p q) :
+    cl Ω E₂ p q := by
+  intro t ht
+  exact hcl t (fun a b ha => ht a b (h a b ha))
+
+/-- An equivalence is TESTABLE iff it is exactly "indistinguishability under
+    the tests that respect it" — i.e. a fixed point of `cl Ω`. This predicate
+    IS the closed-element condition. -/
+def Testable (Ω : Type*) (E : Proc → Proc → Prop) : Prop :=
+  ∀ p q, cl Ω E p q ↔ E p q
+
+/-- Every induced equivalence is testable (the image of `induced Ω` is contained
+    in the fixed points of `cl Ω`). -/
+theorem induced_testable (Ω : Type*) (T : Set (Proc → Ω)) :
+    Testable Ω (induced Ω T) := by
+  intro p q
+  constructor
+  · intro hcl t ht
+    exact hcl t (test_subset_respects_induced Ω T ht)
+  · intro hInd t ht
+    exact ht p q hInd
+
+/-- `cl Ω` is idempotent: `cl Ω (cl Ω E) = cl Ω E`. `cl Ω E` lies in the image
+    of `induced Ω`, hence is a fixed point by `induced_testable`. -/
+theorem cl_idempotent (Ω : Type*) (E : Proc → Proc → Prop) (p q : Proc) :
+    cl Ω (cl Ω E) p q ↔ cl Ω E p q := by
+  have key : Testable Ω (induced Ω (respects Ω E)) := induced_testable Ω (respects Ω E)
+  exact key p q
+
+/-- **Spectrum = image of `induced` = closed elements.** An equivalence is
+    testable (a fixed point of `cl Ω`) iff it is exactly the equivalence induced
+    by some test class. Forward direction witnessed by `T = respects Ω E`. -/
+theorem spectrum_eq_closed_elements (Ω : Type*) (E : Proc → Proc → Prop) :
+    Testable Ω E ↔ ∃ T : Set (Proc → Ω), induced Ω T = E := by
+  constructor
+  · intro hE
+    refine ⟨respects Ω E, ?_⟩
+    change cl Ω E = E
+    funext p q
+    exact propext (hE p q)
+  · rintro ⟨T, rfl⟩
+    exact induced_testable Ω T
+
+end Cslib.LTS.Spectrum

--- a/Cslib/Foundations/Semantics/LTS/Spectrum/Galois.lean
+++ b/Cslib/Foundations/Semantics/LTS/Spectrum/Galois.lean
@@ -1,7 +1,7 @@
 /-
-Copyright (c) 2026 TODO. All rights reserved.
+Copyright (c) 2026 patchwright. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
-Authors: TODO
+Authors: patchwright
 -/
 
 module

--- a/Cslib/Foundations/Semantics/LTS/Spectrum/Galois.lean
+++ b/Cslib/Foundations/Semantics/LTS/Spectrum/Galois.lean
@@ -11,60 +11,54 @@ public import Mathlib.Order.GaloisConnection.Basic
 public import Mathlib.Order.Closure
 
 /-!
-# Van Glabbeek's spectrum as a Galois connection — the polarity framework
+# The van Glabbeek spectrum as a Galois connection
 
-Behavioural equivalences are organised as the closed elements of an antitone
-Galois connection ("polarity") between sets of tests (ordered by `⊆`) and
-equivalences (ordered by refinement). Following the standard Mathlib idiom, the
-antitone connection is stated as a `GaloisConnection` into the order dual:
+The linear time–branching time spectrum of behavioural equivalences is the set
+of *testable* equivalences on a process type: those an observer recovers exactly
+as indistinguishability under the tests that respect them. This set is the
+collection of closed elements of an antitone Galois connection — a *polarity* —
+between equivalences and tests.
+
+The two preorders of the connection are:
+
+* equivalences `E : Proc → Proc → Prop`, ordered by pointwise implication
+  `E ≤ E' ↔ ∀ p q, E p q → E' p q` (graph inclusion);
+* test classes `T : Set (Proc → Ω)`, ordered by `(⊆)`.
+
+The antitone connection is packaged as a monotone `GaloisConnection` into the
+order dual on the test side:
 
   `polarity : GaloisConnection (toDual ∘ respects Ω) (induced Ω ∘ ofDual)`
 
-The closure operator on equivalences is then *derived* — it is
-`(polarity Ω).closureOperator`, an instance of Mathlib's `ClosureOperator`
-(the same pattern as `PhaseSemantics.biorthogonalClosure`), so extensivity,
-monotonicity and idempotence are inherited rather than proved by hand. The
-Galois-closed equivalences — the "testable" ones — are exactly the image of
-`induced`; they form a lattice, not a chain (see `Spectrum.Antichain`).
+Its closure operator is `cl Ω = induced Ω ∘ respects Ω`, and the spectrum is the
+set of its closed elements. A named spectrum point (`HomTraceEq`) is shown closed
+in `Spectrum.TracePoint`; the spectrum is a lattice rather than a chain
+(`Spectrum.Antichain`).
 
-This module is the Mathlib/`Cslib.Init`-only framework. A concrete named
-spectrum point (CSLib's `HomTraceEq`) is shown Galois-closed in
-`Spectrum.TracePoint`.
-
-The construction is parameterised by the pair `(Proc, Ω)`: `Proc` is the process
-type and `Ω` the observation type (a test is `Proc → Ω`). `Ω` is carried
-explicitly because the closure-operator theorems mention only `E` and cannot
-recover `Ω` from it.
+The construction is parameterised by `Proc` (the process type) and `Ω` (the
+observation type; a test is `Proc → Ω`). `Ω` is carried explicitly because the
+closure operator itself mentions only `E`.
 
 ## Main definitions
 
-* `induced Ω T`: the equivalence a test class `T` induces.
-* `respects Ω E`: the tests that respect an equivalence `E`.
-* `cl Ω`: the closure operator `induced Ω ∘ respects Ω`, as a Mathlib
-  `ClosureOperator`, obtained from `polarity` via
-  `GaloisConnection.closureOperator`.
-* `Testable Ω E`: `E` is a closed element of `cl Ω` (`(cl Ω).IsClosed E`).
+* `induced Ω T`: the equivalence a test class induces.
+* `respects Ω E`: the tests constant on every `E`-pair.
+* `polarity Ω`: the Galois connection above.
+* `cl Ω`: the closure operator `induced Ω ∘ respects Ω`.
+* `Testable Ω E`: the proposition that `E` is `cl Ω`-closed.
+* `spectrum Ω`: the set of testable equivalences.
 
 ## Main statements
 
-* `polarity`: the antitone Galois connection, as a Mathlib `GaloisConnection`
-  into the order dual.
-* `induced_testable`: every induced equivalence is closed (from
-  `GaloisConnection.u_l_u_eq_u`).
-* `cl_extensive`, `cl_monotone`, `cl_idempotent`: inherited from
-  `ClosureOperator`.
-* `spectrum_eq_closed_elements`: testable ↔ in the image of `induced`.
-* `spectrumCompleteLattice`: the testable equivalences form a complete lattice
-  under refinement (via `GaloisInsertion.liftCompleteLattice`).
+* `spectrum_eq_closed_elements`: the testable equivalences are exactly the image
+  of `induced`.
+* `spectrumCompleteLattice`: the spectrum is a complete lattice under refinement.
 
 ## References
 
-* [R.J. van Glabbeek, *The Linear Time – Branching Time Spectrum*][Glabbeek1990]
-  (extended to silent moves in *Spectrum II* [Glabbeek1993]) — the spectrum of
-  behavioural equivalences ordered by refinement.
-* [H. Beohar, *Hennessy-Milner Theorems via Galois Connections*][Beohar2022] —
-  the reading of those equivalences as the fixed points of an antitone Galois
-  connection (polarity) between tests and equivalences.
+* [R.J. van Glabbeek, *The Linear Time – Branching Time Spectrum*][Glabbeek1990],
+  extended to silent moves in *Spectrum II* [Glabbeek1993].
+* [H. Beohar, *Hennessy-Milner Theorems via Galois Connections*][Beohar2022].
 -/
 
 @[expose] public section
@@ -75,18 +69,16 @@ open OrderDual (toDual ofDual)
 
 variable {Proc : Type*}
 
-/-- The equivalence a test class induces: agreement on every test in `T`.
-    Antitone in `T` — more tests ⇒ finer (smaller) equivalence. -/
+/-- Equivalence induced by a test class `T`: two processes agree on every test
+    in `T`. -/
 def induced (Ω : Type*) (T : Set (Proc → Ω)) (p q : Proc) : Prop :=
   ∀ t ∈ T, t p = t q
 
-/-- The tests that respect an equivalence `E`: tests constant on every E-pair.
-    Antitone in `E` — coarser `E` ⇒ fewer respecting tests. -/
+/-- Tests that respect an equivalence `E`: constant on every `E`-pair. -/
 def respects (Ω : Type*) (E : Proc → Proc → Prop) : Set (Proc → Ω) :=
   { t | ∀ p q, E p q → t p = t q }
 
-/-- Pointwise form of the polarity: `E` refines `induced Ω T` iff
-    `T ⊆ respects Ω E`. The order-theoretic packaging is `polarity` below. -/
+/-- `E` refines `induced Ω T` iff every test in `T` respects `E`. -/
 theorem polarity_iff (Ω : Type*) (T : Set (Proc → Ω)) (E : Proc → Proc → Prop) :
     (∀ p q, E p q → induced Ω T p q) ↔ T ⊆ respects Ω E := by
   constructor
@@ -95,10 +87,9 @@ theorem polarity_iff (Ω : Type*) (T : Set (Proc → Ω)) (E : Proc → Proc →
   · intro h p q hpq t ht
     exact h ht p q hpq
 
-/-- **Polarity.** `respects Ω` and `induced Ω` form an antitone Galois
-    connection between equivalences under refinement and test classes under
-    `⊆`. Stated, as is standard in Mathlib, as a (monotone) `GaloisConnection`
-    into the order dual `(Set (Proc → Ω))ᵒᵈ`. -/
+/-- The polarity: `respects Ω` and `induced Ω` form an antitone Galois connection
+    between equivalences (pointwise implication) and test classes (`(⊆)`, into
+    the order dual). -/
 theorem polarity (Ω : Type*) :
     GaloisConnection (fun E : Proc → Proc → Prop => toDual (respects Ω E))
       (fun T => induced Ω (ofDual T)) := by
@@ -107,41 +98,30 @@ theorem polarity (Ω : Type*) :
   simp only [Pi.le_def, le_Prop_eq]
   exact (polarity_iff Ω (ofDual T) E).symm
 
-/-- Every test in `T` respects the equivalence `T` induces — the counit
-    `l (u b) ≤ b` of `polarity`, read back through the dual. -/
+/-- Every test in `T` respects the equivalence `T` induces. -/
 theorem test_subset_respects_induced (Ω : Type*) (T : Set (Proc → Ω)) :
     T ⊆ respects Ω (induced Ω T) :=
   (polarity Ω).l_u_le (toDual T)
 
-/-- Closure operator on equivalences: `induced Ω ∘ respects Ω`, obtained from
-    `polarity` via Mathlib's `GaloisConnection.closureOperator`. -/
+/-- Closure operator `induced Ω ∘ respects Ω`, obtained from `polarity` as a
+    `ClosureOperator`. -/
 def cl (Ω : Type*) : ClosureOperator (Proc → Proc → Prop) :=
   (polarity (Proc := Proc) Ω).closureOperator
 
-/-- `cl Ω` acts as `induced Ω ∘ respects Ω`. -/
+/-- `cl Ω E = induced Ω (respects Ω E)`. -/
 theorem cl_apply (Ω : Type*) (E : Proc → Proc → Prop) :
     cl Ω E = induced Ω (respects Ω E) :=
   rfl
 
-/-- `cl Ω` is extensive: `E ≤ cl Ω E` — inherited from `ClosureOperator`. -/
-theorem cl_extensive (Ω : Type*) (E : Proc → Proc → Prop) : E ≤ cl Ω E :=
-  (cl Ω).le_closure E
-
-/-- `cl Ω` is monotone — inherited from `ClosureOperator`. -/
-theorem cl_monotone (Ω : Type*) : Monotone (cl (Proc := Proc) Ω) :=
-  (cl Ω).monotone
-
-/-- `cl Ω` is idempotent — inherited from `ClosureOperator`. -/
-theorem cl_idempotent (Ω : Type*) (E : Proc → Proc → Prop) :
-    cl Ω (cl Ω E) = cl Ω E :=
-  (cl Ω).idempotent E
-
-/-- An equivalence is TESTABLE iff it is exactly "indistinguishability under
-    the tests that respect it" — i.e. a closed element of `cl Ω`. -/
+/-- An equivalence is *testable* iff it is a closed element of `cl Ω`. -/
 def Testable (Ω : Type*) (E : Proc → Proc → Prop) : Prop :=
   (cl Ω).IsClosed E
 
-/-- Pointwise reading of `Testable`: `cl Ω E` and `E` agree on every pair. -/
+/-- The **van Glabbeek spectrum**: the set of testable equivalences on `Proc`. -/
+def spectrum (Ω : Type*) : Set (Proc → Proc → Prop) :=
+  { E | Testable Ω E }
+
+/-- `Testable Ω E` iff `cl Ω E` and `E` agree pointwise. -/
 theorem testable_iff (Ω : Type*) (E : Proc → Proc → Prop) :
     Testable Ω E ↔ ∀ p q, cl Ω E p q ↔ E p q := by
   rw [Testable, ClosureOperator.isClosed_iff]
@@ -152,17 +132,12 @@ theorem testable_iff (Ω : Type*) (E : Proc → Proc → Prop) :
     funext p q
     exact propext (h p q)
 
-/-- Every induced equivalence is testable (the image of `induced Ω` is
-    contained in the closed elements) — this is `u ∘ l ∘ u = u` for `polarity`
-    (`GaloisConnection.u_l_u_eq_u`). -/
+/-- Every induced equivalence is testable. -/
 theorem induced_testable (Ω : Type*) (T : Set (Proc → Ω)) :
     Testable Ω (induced Ω T) :=
   (cl Ω).isClosed_iff.2 ((polarity Ω).u_l_u_eq_u (toDual T))
 
-/-- **Spectrum = image of `induced` = closed elements.** An equivalence is
-    testable (a closed element of `cl Ω`) iff it is exactly the equivalence
-    induced by some test class. Forward direction witnessed by
-    `T = respects Ω E`. -/
+/-- An equivalence is testable iff it is induced by some test class. -/
 theorem spectrum_eq_closed_elements (Ω : Type*) (E : Proc → Proc → Prop) :
     Testable Ω E ↔ ∃ T : Set (Proc → Ω), induced Ω T = E := by
   constructor
@@ -171,13 +146,8 @@ theorem spectrum_eq_closed_elements (Ω : Type*) (E : Proc → Proc → Prop) :
   · rintro ⟨T, rfl⟩
     exact induced_testable Ω T
 
-/-- **The spectrum is a complete lattice.** The closed elements of `cl Ω` — the
-    testable equivalences — form a complete lattice under refinement, lifted
-    through the Galois insertion `(cl Ω).gi` from the complete lattice of all
-    equivalences (Mathlib's `GaloisInsertion.liftCompleteLattice`). Arbitrary
-    meets and joins of testable equivalences exist; and the lattice is not a
-    chain (`Spectrum.Antichain`), which is the structural form of "the
-    linear-time/branching-time spectrum is a lattice, not a linear scale". -/
+/-- The spectrum is a complete lattice under refinement; it is not a chain
+    (see `Spectrum.Antichain`). -/
 instance spectrumCompleteLattice {Ω : Type*} :
     CompleteLattice ((cl (Proc := Proc) Ω).Closeds) :=
   (cl Ω).gi.liftCompleteLattice

--- a/Cslib/Foundations/Semantics/LTS/Spectrum/TracePoint.lean
+++ b/Cslib/Foundations/Semantics/LTS/Spectrum/TracePoint.lean
@@ -1,0 +1,73 @@
+/-
+Copyright (c) 2026 TODO. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: TODO
+-/
+
+module
+
+public import Cslib.Init
+public import Cslib.Foundations.Semantics.LTS.TraceEq
+public import Cslib.Foundations.Semantics.LTS.Spectrum.Galois
+
+/-!
+# Spectrum trace point — trace equivalence is Galois-closed
+
+A concrete named spectrum point: CSLib's homogeneous trace equivalence
+(`Cslib.LTS.HomTraceEq`) is a Galois-closed (testable) equivalence, via the
+trace-set observer test class (`fun s => lts.traces s`, `Ω = Set (List Label)`).
+`HomTraceEq` lies in the image of `induced`, hence is a fixed point of the
+closure operator `cl`.
+
+This proves the structural result (TraceEq ∈ closed elements). The standard
+testing-semantics refinement — one `Bool` test per trace — gives a finer witness
+for the SAME closed element but requires decidability of trace membership; it
+does not change the closed-element verdict.
+
+The Hennessy–Milner theorem (bisim ↔ same HML formulas) is not used; CSLib does
+not yet mechanise it.
+-/
+
+@[expose] public section
+
+namespace Cslib.LTS.Spectrum
+
+open Cslib
+
+variable {State Label : Type*} (lts : LTS State Label)
+
+/-- The trace-set observer test: a state's full set of traces. -/
+def traceSetTest (s : State) : Set (List Label) :=
+  lts.traces s
+
+/-- Test class for the trace point: the singleton trace-set observer. -/
+def traceTestClass : Set (State → Set (List Label)) :=
+  { f | f = traceSetTest lts }
+
+/-- The equivalence induced by the trace-set test is CSLib's homogeneous trace
+    equivalence (pointwise iff). -/
+theorem induced_traceSet_iff (p q : State) :
+    induced (Set (List Label)) (traceTestClass lts) p q ↔ HomTraceEq lts p q := by
+  unfold induced traceTestClass
+  simp only [Set.mem_setOf_eq]
+  constructor
+  · intro h
+    exact h _ rfl
+  · intro h t ht
+    rw [ht]
+    exact h
+
+/-- Function-equality form (via `propext`). -/
+theorem induced_traceSet :
+    induced (Set (List Label)) (traceTestClass lts) = HomTraceEq lts := by
+  funext p q
+  exact propext (induced_traceSet_iff lts p q)
+
+/-- **Trace point.** CSLib's homogeneous trace equivalence is a Galois-closed
+    (testable) equivalence. -/
+theorem HomTraceEq_testable :
+    Testable (Set (List Label)) (HomTraceEq lts) := by
+  rw [← induced_traceSet lts]
+  exact induced_testable (Set (List Label)) (traceTestClass lts)
+
+end Cslib.LTS.Spectrum

--- a/Cslib/Foundations/Semantics/LTS/Spectrum/TracePoint.lean
+++ b/Cslib/Foundations/Semantics/LTS/Spectrum/TracePoint.lean
@@ -13,21 +13,13 @@ public import Cslib.Foundations.Semantics.LTS.Spectrum.Galois
 /-!
 # Spectrum trace point — trace equivalence is Galois-closed
 
-A concrete named spectrum point: CSLib's homogeneous trace equivalence
-(`Cslib.LTS.HomTraceEq`) is a Galois-closed (testable) equivalence, via the
-trace-set observer test class (`fun s => lts.traces s`, `Ω = Set (List Label)`).
-`HomTraceEq` lies in the image of `induced`, hence is a fixed point of the
-closure operator `cl`.
+CSLib's homogeneous trace equivalence (`HomTraceEq`) is a Galois-closed
+(testable) equivalence: it is the equivalence induced by the trace-set observer
+test class (`Ω = Set (List Label)`), hence a fixed point of the closure operator
+`cl`.
 
-This proves the structural result (TraceEq ∈ closed elements). The standard
-testing-semantics refinement — one `Bool` test per trace — gives a finer witness
-for the SAME closed element but requires decidability of trace membership; it
-does not change the closed-element verdict.
-
-The Hennessy–Milner theorem IS mechanised in CSLib as
-`Cslib.Logic.HML.theoryEq_eq_bisimilarity`; the bisim point built on it is in
-`Spectrum.BisimPoint`. This file (the trace point, kernel-trivial bottom) does
-not use HM — bisimilarity (HM-mediated top) is the companion point there.
+The companion bisimilarity point (which uses the Hennessy–Milner theorem) is in
+`Spectrum.BisimPoint`.
 -/
 
 @[expose] public section
@@ -58,7 +50,7 @@ theorem induced_traceSet_iff (p q : State) :
     subst ht
     exact h
 
-/-- Function-equality form (via `propext`). -/
+/-- Function-equality form of `induced_traceSet_iff`. -/
 theorem induced_traceSet :
     induced (Set (List Label)) (traceTestClass lts) = HomTraceEq lts := by
   funext p q

--- a/Cslib/Foundations/Semantics/LTS/Spectrum/TracePoint.lean
+++ b/Cslib/Foundations/Semantics/LTS/Spectrum/TracePoint.lean
@@ -50,13 +50,12 @@ def traceTestClass : Set (State → Set (List Label)) :=
     equivalence (pointwise iff). -/
 theorem induced_traceSet_iff (p q : State) :
     induced (Set (List Label)) (traceTestClass lts) p q ↔ HomTraceEq lts p q := by
-  unfold induced traceTestClass
-  simp only [Set.mem_setOf_eq]
   constructor
   · intro h
     exact h _ rfl
   · intro h t ht
-    rw [ht]
+    have ht : t = traceSetTest lts := ht
+    subst ht
     exact h
 
 /-- Function-equality form (via `propext`). -/

--- a/Cslib/Foundations/Semantics/LTS/Spectrum/TracePoint.lean
+++ b/Cslib/Foundations/Semantics/LTS/Spectrum/TracePoint.lean
@@ -1,7 +1,7 @@
 /-
-Copyright (c) 2026 TODO. All rights reserved.
+Copyright (c) 2026 patchwright. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
-Authors: TODO
+Authors: patchwright
 -/
 
 module
@@ -24,8 +24,10 @@ testing-semantics refinement — one `Bool` test per trace — gives a finer wit
 for the SAME closed element but requires decidability of trace membership; it
 does not change the closed-element verdict.
 
-The Hennessy–Milner theorem (bisim ↔ same HML formulas) is not used; CSLib does
-not yet mechanise it.
+The Hennessy–Milner theorem IS mechanised in CSLib as
+`Cslib.Logic.HML.theoryEq_eq_bisimilarity`; the bisim point built on it is in
+`Spectrum.BisimPoint`. This file (the trace point, kernel-trivial bottom) does
+not use HM — bisimilarity (HM-mediated top) is the companion point there.
 -/
 
 @[expose] public section

--- a/references.bib
+++ b/references.bib
@@ -39,6 +39,15 @@ publisher = {Cambridge University Press},
 address = {USA}
 }
 
+@misc{Beohar2022,
+  author       = {Beohar, Harsh},
+  title        = {Hennessy-Milner Theorems via Galois Connections},
+  year         = {2022},
+  eprint       = {2207.05407},
+  archiveprefix = {arXiv},
+  url          = {https://arxiv.org/abs/2207.05407}
+}
+
 @book{Blackburn2001,
   place={Cambridge},
   series={Cambridge Tracts in Theoretical Computer Science},
@@ -174,6 +183,24 @@ address = {USA}
   year={1995},
   pages={1–42},
   collection={London Mathematical Society Lecture Note Series}
+}
+
+@inproceedings{Glabbeek1990,
+  author       = {van Glabbeek, R.J.},
+  title        = {The Linear Time -- Branching Time Spectrum},
+  booktitle    = {CONCUR '90: Theories of Concurrency (Unification and Extension)},
+  series       = {Lecture Notes in Computer Science},
+  volume       = {458},
+  year         = {1990},
+  pages        = {278--297},
+  publisher    = {Springer}
+}
+
+@misc{Glabbeek1993,
+  author       = {van Glabbeek, R.J.},
+  title        = {The Linear Time -- Branching Time Spectrum II},
+  year         = {1993},
+  note         = {Extended manuscript; adds silent moves (branching/weak semantics)}
 }
 
 @article{Haussler1992,

--- a/references.bib
+++ b/references.bib
@@ -40,7 +40,7 @@ address = {USA}
 }
 
 @misc{Beohar2022,
-  author       = {Beohar, Harsh},
+  author       = {Beohar, Harsh and Gurke, Sebastian and K{\"o}nig, Barbara and Messing, Karla},
   title        = {Hennessy-Milner Theorems via Galois Connections},
   year         = {2022},
   eprint       = {2207.05407},


### PR DESCRIPTION
## Summary

Organises behavioural equivalences as the fixed points of an antitone Galois connection ("polarity") between test classes (ordered by ⊆) and equivalences (ordered by refinement). The Galois-closed equivalences — the "testable" ones — are exactly the image of `induced`. Two named behavioural equivalences are exhibited as closed elements of the SAME polarity: **trace equivalence** (kernel-trivial) and **bisimilarity** (Hennessy–Milner-mediated) — the actual "spectrum as Galois" statement.

## What's added

New module `Cslib.Foundations.Semantics.LTS.Spectrum` (4 files):

- **`Galois.lean`** — the framework (`Cslib.Init` only): `induced Ω T`, `respects Ω E`, closure operator `cl Ω`, `polarity` (the antitone Galois connection), `induced_testable`, `spectrum_eq_closed_elements`.
- **`TracePoint.lean`** — `HomTraceEq_testable`: homogeneous trace equivalence is Galois-closed, via the trace-set observer test class. (Kernel-trivial bottom point.)
- **`BisimPoint.lean`** — `HomBisimilarity_testable`: homogeneous bisimilarity is Galois-closed for image-finite LTS, via the Hennessy–Milner theorem (`theoryEq_eq_bisimilarity`). (**Non-trivial** top point — bisimilarity is not a kernel by definition; HM makes it one.)
- **`Antichain.lean`** — `exists_incomparable_closed`: the closed-element lattice contains an antichain (a lattice, not a chain).

## Why it's additive

CSLib has `Bisimilarity`, `Simulation`/`SimulationEquiv`, `TraceEq`, HML, and the Hennessy–Milner theorem (`theoryEq_eq_bisimilarity`), but no organisation of the spectrum as a Galois structure. This provides that organisation, reusing CSLib's existing equivalences + HM as named closed instances. It does not redefine any existing equivalence.

## Scope notes / honesty

- The trace point is **kernel-trivial**: the test class IS the trace-set map, so `induced = HomTraceEq` is near-definitional. It's the honest bottom point; the per-trace `Bool`-test refinement (decidability-gated) is a finer witness for the same closed element.
- The bisim point is the **non-trivial** one: it relies on HM (`theoryEq_eq_bisimilarity`) to connect bisimilarity to the HML-theory kernel. That step does real work — it's what earns the word "spectrum."
- The antichain is framework-internal (two custom test classes over a 4-state space). The *named* van Glabbeek antichain (simulation vs failures) requires failures semantics, not in CSLib — left as future work.
- (An earlier draft of this PR falsely claimed "CSLib does not yet mechanise HM"; that was a grep miss — corrected by reading `Cslib.Logic.HML.Basic`.)

## Verification

Builds clean (Lean v4.32.0-rc1), 0 sorry / 0 axiom. All four modules compile and reach `Cslib.Init` transitively. Full-lib CI runs on this PR.

## AI use disclosure

Per CSLib's AI policy (following Mathlib): this contribution was developed with AI assistance. An AI coding assistant (Claude Code, glm-5.2 model) wrote the Lean definitions and proofs under the contributor's direction; the contributor designed the approach, reviewed each definition and proof, and accepts responsibility for the content. All proofs are verified by the Lean compiler (0 sorry / 0 axiom), which mitigates the AI-typical errors this disclosure helps reviewers spot. Please flag anything that looks off.

## Open questions for maintainers

- Placement: `Cslib/Foundations/Semantics/LTS/Spectrum/` — appropriate, or preferred elsewhere?