### PR TITLE
feat: add READMEs to main directories

### DIFF
--- a/Cslib/Algorithms/README.md
+++ b/Cslib/Algorithms/README.md
@@ -1,0 +1,30 @@
+<pre>
+Copyright (c) 2026 Fabrizio Montesi. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Clark Barrett, Swarat Chaudhuri, Jim Grundy, Fabrizio Montesi, Leonardo de Moura, Alexandre Rademaker, Sorrachai Yingchareonthawornchai
+</pre>
+
+# Algorithms
+
+This directory hosts **algorithms and their properties**. These properties concern functional correctness, complexity, and other relevant results. The directory also includes dedicated facilities for reasoning about algorithms written in Lean.
+
+The broader aim is to develop a library of verified algorithms, both in Lean and in other languages formalised in CSLib. Accordingly, it is in scope to study algorithms implemented as Lean programs as well as algorithms expressed inside one of CSLib's [Languages](../Languages), depending on the purpose of the development.
+
+## Principles
+
+### Synergies with languages and logics
+
+Important synergies are expected with both [Languages](../Languages) and [Logics](../Logics). Languages provide settings in which algorithms can be written and studied under formal semantics, while logics provide tools for specifying and proving their properties.
+
+One long-term aim is to support principled reasoning pipelines where algorithms are defined in a language, specified through logical notions, and verified inside shared semantic frameworks.
+
+### Dealing with optimisation
+
+Optimising an algorithm can make it harder to reason about it. When this happens, one can prove a relation (e.g., functional or behavioural) to a simpler, less optimised version, and then work by transferring results from it.
+In doing this, we expect contributions to leverage Lean's and CSLib's common infrastructures whenever reasonable.
+
+## Plans and notes
+
+- We aim at developing a comprehensive library of verified algorithms, covering both Lean implementations and algorithms represented in other languages.
+- We plan on expanding the infrastructure for proving properties of Lean algorithms, including correctness, complexity, and other forms of analysis.
+- Reusable mathematical and semantic infrastructure should live elsewhere in CSLib when it is more general-purpose, so developments in this directory should integrate well with [Foundations](../Foundations), [Languages](../Languages), and [Logics](../Logics).

--- a/Cslib/Algorithms/README.md
+++ b/Cslib/Algorithms/README.md
@@ -9,6 +9,7 @@ Authors: Clark Barrett, Swarat Chaudhuri, Jim Grundy, Fabrizio Montesi, Leonardo
 This directory hosts **algorithms and their properties**. These properties concern functional correctness, complexity, and other relevant results. The directory also includes dedicated facilities for reasoning about algorithms written in Lean.
 
 The broader aim is to develop a library of verified algorithms, both in Lean and in other languages formalised in CSLib. Accordingly, it is in scope to study algorithms implemented as Lean programs as well as algorithms expressed inside one of CSLib's [Languages](../Languages), depending on the purpose of the development.
+All algorithms sit in a language-specific subdirectory depending on the language they are written in, like `Boole`, `Lean`, etc.
 
 ## Principles
 

--- a/Cslib/Computability/README.md
+++ b/Cslib/Computability/README.md
@@ -1,0 +1,35 @@
+<pre>
+Copyright (c) 2026 Fabrizio Montesi. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+</pre>
+
+# Computability
+
+This directory hosts **formal developments in computability and neighbouring areas**. Its scope includes automata, complexity classes, formal languages over finite and infinite words, and other machine models.
+
+## Principles
+
+### Multiple computational models
+
+There is a plethora of computational models in the literature, some of which are very near to each other (e.g., Turing machines and Wang B-machines). Depending on the aim, one can be more convenient than the other.
+In general, computability can be studied through different kinds of objects.
+
+These representations can coexist when they serve different purposes. A central goal is to make their tradeoffs explicit and to connect them where possible.
+
+### Reuse of common infrastructure
+
+The [Foundations](../Foundations) directory offers abstractions that are directly useful for computability-theoretic developments and should be reused as much as possible. Examples already present in this directory include the use of labelled transition systems for automata and distributed algorithms, tape structures for Turing machines, and general relation-theoretic tools for machine semantics.
+
+This approach enables:
+1. Reusing and transferring constructions and results across different models.
+2. Applying CSLib's [logics](../Logics) to reason about computational models.
+3. Developing connections between computability models and other areas (like the constructions of automata based on transition systems).
+
+### Separation from languages
+
+Some of the developments here are close to [Languages](../Languages), but are placed here instead because the emphasis is on formal languages over words and models typically linked to computability studies.
+
+## Plans and notes
+
+- We plan on expanding this directory with more machine models and associated results, including equivalence results, closure properties, and other metatheory.
+- We plan on clarifying and formalising connections between language-theoretic, automata-theoretic, machine-based, and distributed perspectives on computation.

--- a/Cslib/Crypto/README.md
+++ b/Cslib/Crypto/README.md
@@ -1,0 +1,26 @@
+<pre>
+Copyright (c) 2026 Fabrizio Montesi. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+</pre>
+
+# Crypto
+
+This directory hosts **cryptographic definitions, primitives, protocol models, and related security metatheory**. Its scope includes both basic cryptographic notions and larger developments such as security protocols.
+
+We aim at supporting both abstract security reasoning and concrete protocol developments, while making explicit the relations between them. To this end, this part of CSLib has very important relationships with [Languages](../Languages) and [Logics](../Logics), explained in the remainder.
+
+## Principles
+
+### Integration with languages
+
+Whenever appropriate, cryptographic primitives should be developed so that they compose well with CSLib's [languages](../Languages) that offer a way to integrate a computational substrate. This is common, for example, in choreographic programming languages and many process calculi.
+
+The aim is to build end-to-end models where cryptographic operations appear inside larger communicating or computational systems.
+
+To this end, we expect to leverage the combination of `Crypto` and [Languages](../Languages) to define and formally reason about security protocols. CSLib's common semantics APIs connecting [Languages](../Languages) and [Logics](../Logics) should enable such reasoning.
+
+## Plans and notes
+
+- We plan on developing applied calculi and logics for modelling and reasoning about security protocols.
+- We plan on developing a comprehensive library of primitives and foundational protocols, together with their proofs of correctness.
+- We plan on supporting downstream efforts on the development of secure digital infrastructures (including implementation of complex secure applications and systems).

--- a/Cslib/Foundations/README.md
+++ b/Cslib/Foundations/README.md
@@ -1,0 +1,32 @@
+<pre>
+Copyright (c) 2026 Fabrizio Montesi. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+</pre>
+
+# Foundations
+
+This directory covers **common foundations** for the rest of CSLib and downstream developments. As such, it acts as its fulcrum of integration through common concepts and APIs.
+
+Please browse the subdirectories for details.
+
+The foundational approach to semantics spans multiple directories and has a large role; it is explained below.
+
+## Semantics
+
+A recurring aspect that cuts across different areas is semantics. Examples of such areas include concurrency theory, computational models, logics, modelling languages, programming languages, and security protocols.
+
+Most of the APIs for semantics provided in `Foundations` are in the [Semantics](Semantics) directory. An example of an exception is the [Relation](Relation) directory, which sits at the top level.
+
+The vision is to provide common abstractions that can be reused throughout CSLib. Beyond providing reusable definitions, having common APIs for semantics is important for multiple reasons. The next list covers some illustrative examples.
+
+- The modular use of modal and dynamic logics to reason about programs.
+- The sharing of semantic metatheory, such as behavioural equivalences for labelled transition systems (bisimulation, trace equivalence, etc.) and common definitions like confluence.
+- The development of provably-correct compilers between languages based on these abstractions, supporting for example proofs of bisimilarity or full abstraction.
+- The elicitation of connections between different domains, including computability, crypto, logic, programming languages, etc.
+
+### Plans
+
+- Many modules are still missing, for example facilities for probabilistic operational semantics, derivatives and antiderivatives for transition systems, logical relations, etc. We plan to develop develop a comprehensive library.
+- We plan on building general frameworks that give important metatheoretical properties about the semantics of objects that respect certain properties (e.g., rule formats, GSOS) for free (or at least in principled ways rather than doing it from scratch).
+- We plan both on developing constructions that embed different semantic models into each other and to prove separation results between them.
+- We plan on pushing towards building formal connections between different domains based on a semantic approach.

--- a/Cslib/Foundations/README.md
+++ b/Cslib/Foundations/README.md
@@ -5,7 +5,7 @@ Released under Apache 2.0 license as described in the file LICENSE.
 
 # Foundations
 
-This directory covers **common foundations** for the rest of CSLib and downstream developments. As such, it acts as its fulcrum of integration through common concepts and APIs.
+This directory covers **common foundations** for the rest of CSLib and downstream developments. As such, it acts as its fulcrum of integration through common concepts and APIs. This directory includes also additional results about foundational data objects defined in Mathlib, such as `Nat` and `Set`.
 
 Please browse the subdirectories for details.
 

--- a/Cslib/Languages/README.md
+++ b/Cslib/Languages/README.md
@@ -1,0 +1,29 @@
+<pre>
+Copyright (c) 2026 Fabrizio Montesi. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+</pre>
+
+# Languages
+
+This directory hosts **modelling and programming languages** formalised in CSLib and their properties. Their components can include syntax, semantics, typing and other reasoning disciplines, execution facilities (compilers, interpreters, etc.), behavioural theories, supporting metatheory, etc.
+We are interested in many kinds of languages, from foundational calculi to applied programming frameworks.
+
+The focus is not only on individual languages in isolation, but also on exposing them through reusable abstractions from [Foundations](../Foundations), such as contexts, substitution, congruence, reduction systems, and labelled transition systems.
+
+## Principles
+
+### Reuse of common infrastructure
+
+The [Foundations](../Foundations) directory offers useful modules for language development, which should be used as much as possible.
+These modules include support for syntax (like contexts and congruence relations), semantics (like transition systems),  compiler correctness (like behavioural relations), and more.
+
+### Multiple representations are welcome
+
+Different representations can coexist when they serve different purposes. For example `LambdaCalculus` currently contains both named and locally nameless developments. The goal is to make tradeoffs explicit and to connect them where possible.
+
+## Plans and notes
+
+- We expect this directory to grow with many more languages, as well as connections between languages, logics, and other reasoning techniques.
+- A recurring issue is how to handle binders. We still need to develop general facilities for this. Leveraging multiple representations of languages, we also plan on formally exploring the connection between standard pen & paper definitions and convenient formal representations, for example the relation between α-equivalence and techniques based on de Brujin indices.
+- We aim at providing reusable infrastructure for defining languages and provably-correct compilers.
+- Some topics that are often associated with languages also appear elsewhere in CSLib when a more general placement is preferrable. For example, automata and formal languages over words are in [Computability](../Computability), while reusable semantic infrastructure lives in [Foundations](../Foundations).

--- a/Cslib/Logics/README.md
+++ b/Cslib/Logics/README.md
@@ -1,0 +1,46 @@
+<pre>
+Copyright (c) 2026 Fabrizio Montesi. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+</pre>
+
+# Logic
+
+CSLib offers **formal logics** for defining specifications and reasoning about programs and systems. Each subdirectory focuses on a specific logic or framework.
+
+Shared foundations can be found in [Foundations/Logic](../Foundations/Logic).
+
+## Principles
+
+### Operators
+
+Please instantiate and use the typeclasses for logical operators (connectives, modalities, etc.) found in [Foundations/Logic](../Foundations/Logic).
+
+### Inference system and logical equivalence
+
+We adopt a unified approach to proof systems and semantics, whereby they instantiate `InferenceSystem`. See [linear logic](LinearLogic) and [modal logic](Modal) for examples.
+
+When defining logical equivalence for a given inference system, instantiate `LogicalEquivalence`. This class also acts as a check that you use the correct APIs.
+
+### Proof relevance in proof systems
+
+A recurring choice when defining a proof system (like a sequent calculus) is whether they should go into `Prop` (proof irrelevance) or a `Type` (proof relevance).
+The default choice is to use a `Type` -- at the appropriate universe level, polymorphic if it has type parameters. This makes it easy to define computations on derivations, e.g., to compute their height, display them, or make tools that show how they can be transformed.
+
+### Fragments
+
+To define a fragment of a proof system, you can use a predicate. See [MLL](LinearLogic/CLL/MLL.lean) for an example.
+
+### Notation for judgements
+
+To avoid notation clashes in the notation for judgements, use a wrapper tag that clearly describes the logic. For example, in modal logic this is `Modal[m,w ⊨ φ]`.
+
+## Plans and notes
+
+### Logical equivalence
+
+We plan on leveraging the common infrastructure of `InferenceSystem`, `LogicalEquivalence`, and similar to build common interfaces for manipulating proofs.
+If any of these APIs do not suit your needs, we are interested in expanding them or creating new ones that can cover your use cases.
+
+### Notation
+
+We will explore alternative approaches to dealing with notation clashes. An example of a current shortcoming is the necessity of prefixing dynamic logic modalities with a `d`, because they use common notation such as `[...]`. One way of doing this could be to establish typeclasses/syntax also for judgemental notation, such as `m,w ⊨ φ`, and make it accessible within a tag like `Logic`, giving for example `Logic[m,w ⊨ φ]`. This would then scope the notation for propositions only to `φ`.

--- a/ORGANISATION.md
+++ b/ORGANISATION.md
@@ -1,6 +1,8 @@
 # Code organisation
 
-This document gives an overview of how the codebase is structured, in terms of directories.
+This document gives an overview of how the codebase is structured, in terms of directories. 
+
+For more details about the high-level principles that govern these directories, please refer to their internal `README.md` files when present.
 
 **Note** that this organisation is still under active discussion and is subject to change.
 


### PR DESCRIPTION
This PR adds README files to some of the main source code directories, covering explanations on principles and vision for CSLib that I've found myself repeating often in private and public conversations.