### PR TITLE
chore: add the consequences of an empty alphabet type on Language and OmegaLanguage

### DIFF
--- a/Cslib/Computability/Automata/NA/Pair.lean
+++ b/Cslib/Computability/Automata/NA/Pair.lean
@@ -50,7 +50,7 @@ theorem LTS.mem_pairViaLang {lts : LTS State Symbol} {via : Set State}
 
 /-- `LTS.pairViaLang via s t` is a regular language if there are only finitely many states. -/
 @[simp]
-theorem LTS.pairViaLang_regular [Inhabited Symbol] [Finite State] {lts : LTS State Symbol}
+theorem LTS.pairViaLang_regular [Finite State] {lts : LTS State Symbol}
     {via : Set State} {s t : State} : (lts.pairViaLang via s t).IsRegular := by
   apply IsRegular.iSup
   grind [Language.IsRegular.mul, LTS.pairLang_regular]

--- a/Cslib/Computability/Languages/Language.lean
+++ b/Cslib/Computability/Languages/Language.lean
@@ -18,12 +18,34 @@ as defined and developed in `Mathlib.Computability.Language`.
 
 @[expose] public section
 
+namespace List
+
+variable {α : Type*}
+
+/-- `[]` is the only list over an empty type. -/
+theorem eq_nil_ofIsEmpty [IsEmpty α] (xl : List α) : xl = [] := by
+  have hu := List.uniqueOfIsEmpty (α := α)
+  grind [Unique.eq_default xl, Unique.eq_default ([] : List α)]
+
+end List
+
 namespace Language
 
 open Set List
 open scoped Computability
 
 variable {α : Type*} {l m : Language α}
+
+/-- `0` and `1` are the only possible languages over an empty type. -/
+theorem eq_zero_or_one_ofIsEmpty [IsEmpty α] (l : Language α) : l = 0 ∨ l = 1 := by
+  by_cases h : l = 0
+  · simp [h]
+  · right
+    ext xl
+    obtain ⟨yl, _⟩ := nonempty_iff_ne_empty.mpr h
+    obtain ⟨rfl⟩ := eq_nil_ofIsEmpty xl
+    obtain ⟨rfl⟩ := eq_nil_ofIsEmpty yl
+    simpa
 
 @[simp]
 theorem mem_biInf {I : Type*} (s : Set I) (l : I → Language α) (x : List α) :

--- a/Cslib/Computability/Languages/Language.lean
+++ b/Cslib/Computability/Languages/Language.lean
@@ -25,7 +25,7 @@ variable {α : Type*}
 /-- `[]` is the only list over an empty type. -/
 theorem eq_nil_ofIsEmpty [IsEmpty α] (xl : List α) : xl = [] := by
   have hu := List.uniqueOfIsEmpty (α := α)
-  grind [Unique.eq_default xl, Unique.eq_default ([] : List α)]
+  simp [Unique.eq_default]
 
 end List
 

--- a/Cslib/Computability/Languages/OmegaLanguage.lean
+++ b/Cslib/Computability/Languages/OmegaLanguage.lean
@@ -98,6 +98,11 @@ def equiv : ωLanguage α ≃ Set (ωSequence α) where
 instance : CompleteAtomicBooleanAlgebra (ωLanguage α) :=
   equiv.completeAtomicBooleanAlgebra
 
+/-- `⊥` is the only possible ω-language over an empty type. -/
+theorem eq_bot_ofIsEmpty [IsEmpty α] (p : ωLanguage α) : p = ⊥ := by
+  ext xs
+  grind [IsEmpty.false xs]
+
 set_option linter.tacticAnalysis.verifyGrindOnly false in
 instance : SetLike (ωLanguage α) (ωSequence α) where
   coe := ωLanguage.toSet

--- a/Cslib/Computability/Languages/OmegaLanguage.lean
+++ b/Cslib/Computability/Languages/OmegaLanguage.lean
@@ -101,7 +101,8 @@ instance : CompleteAtomicBooleanAlgebra (ωLanguage α) :=
 /-- `⊥` is the only possible ω-language over an empty type. -/
 theorem eq_bot_ofIsEmpty [IsEmpty α] (p : ωLanguage α) : p = ⊥ := by
   ext xs
-  grind [IsEmpty.false xs]
+  exfalso
+  exact IsEmpty.false xs
 
 set_option linter.tacticAnalysis.verifyGrindOnly false in
 instance : SetLike (ωLanguage α) (ωSequence α) where

--- a/Cslib/Computability/Languages/RegularLanguage.lean
+++ b/Cslib/Computability/Languages/RegularLanguage.lean
@@ -209,7 +209,7 @@ theorem IsRegular.char (a : Symbol) : ({[a]} : Language Symbol).IsRegular := by
     · simp_all [flts, List.append_eq_cons_iff]
 
 /-- Languages matching regular expressions are regular. -/
-theorem IsRegular.regex [Inhabited Symbol] {r : RegularExpression Symbol} :
+theorem IsRegular.regex {r : RegularExpression Symbol} :
     r.matches'.IsRegular := by
   induction r with
   | zero => simp

--- a/Cslib/Computability/Languages/RegularLanguage.lean
+++ b/Cslib/Computability/Languages/RegularLanguage.lean
@@ -153,27 +153,34 @@ theorem IsRegular.iSup {I : Type*} [Finite I] {s : Set I} {l : I → Language Sy
 open NA.FinAcc Sum in
 /-- The concatenation of two regular languages is regular. -/
 @[simp]
-theorem IsRegular.mul [Inhabited Symbol] {l1 l2 : Language Symbol}
+theorem IsRegular.mul {l1 l2 : Language Symbol}
     (h1 : l1.IsRegular) (h2 : l2.IsRegular) : (l1 * l2).IsRegular := by
-  rw [IsRegular.iff_nfa] at h1 h2 ⊢
-  obtain ⟨State1, h_fin1, nfa1, rfl⟩ := h1
-  obtain ⟨State2, h_fin1, nfa2, rfl⟩ := h2
-  use Option State1 ⊕ Option State2, inferInstance,
-    ⟨finConcat nfa1 nfa2, inr '' (some '' nfa2.accept)⟩
-  exact finConcat_language_eq
+  obtain (he | hne) := isEmpty_or_nonempty Symbol
+  · obtain (rfl | rfl) := Language.eq_zero_or_one_ofIsEmpty l1 <;>
+    obtain (rfl | rfl) := Language.eq_zero_or_one_ofIsEmpty l2 <;> simp
+  · have := Classical.inhabited_of_nonempty hne
+    rw [IsRegular.iff_nfa] at h1 h2 ⊢
+    obtain ⟨State1, h_fin1, nfa1, rfl⟩ := h1
+    obtain ⟨State2, h_fin1, nfa2, rfl⟩ := h2
+    use Option State1 ⊕ Option State2, inferInstance,
+      ⟨finConcat nfa1 nfa2, inr '' (some '' nfa2.accept)⟩
+    exact finConcat_language_eq
 
 -- TODO: fix proof to work with backward.isDefEq.respectTransparency
 set_option backward.isDefEq.respectTransparency false in
 open NA.FinAcc Sum in
 /-- The Kleene star of a regular language is regular. -/
 @[simp]
-theorem IsRegular.kstar [Inhabited Symbol] {l : Language Symbol}
+theorem IsRegular.kstar {l : Language Symbol}
     (h : l.IsRegular) : (l∗).IsRegular := by
-  by_cases h_l : l = 0
-  · simp [h_l]
-  · rw [IsRegular.iff_nfa] at h ⊢
-    obtain ⟨State, h_fin, nfa, rfl⟩ := h
-    use Unit ⊕ Option State, inferInstance, ⟨finLoop nfa, {inl ()}⟩, loop_language_eq h_l
+  obtain (he | hne) := isEmpty_or_nonempty Symbol
+  · obtain (rfl | rfl) := Language.eq_zero_or_one_ofIsEmpty l <;> simp
+  · have := Classical.inhabited_of_nonempty hne
+    by_cases h_l : l = 0
+    · simp [h_l]
+    · rw [IsRegular.iff_nfa] at h ⊢
+      obtain ⟨State, h_fin, nfa, rfl⟩ := h
+      use Unit ⊕ Option State, inferInstance, ⟨finLoop nfa, {inl ()}⟩, loop_language_eq h_l
 
 /-- If a right congruence is of finite index, then each of its equivalence classes is regular. -/
 @[simp]

--- a/Cslib/Foundations/Data/OmegaSequence/Init.lean
+++ b/Cslib/Foundations/Data/OmegaSequence/Init.lean
@@ -32,6 +32,11 @@ variable (m n : ℕ) (x y : List α) (a b : ωSequence α)
 instance [Inhabited α] : Inhabited (ωSequence α) :=
   ⟨ωSequence.const default⟩
 
+instance [h : IsEmpty α] : IsEmpty (ωSequence α) := by
+  apply IsEmpty.mk
+  intro xs
+  exact IsEmpty.false (xs 0)
+
 @[simp, scoped grind =]
 protected theorem eta (s : ωSequence α) : head s ::ω tail s = s := by
   apply DFunLike.ext

--- a/Cslib/Foundations/Data/OmegaSequence/Init.lean
+++ b/Cslib/Foundations/Data/OmegaSequence/Init.lean
@@ -32,10 +32,8 @@ variable (m n : ℕ) (x y : List α) (a b : ωSequence α)
 instance [Inhabited α] : Inhabited (ωSequence α) :=
   ⟨ωSequence.const default⟩
 
-instance [h : IsEmpty α] : IsEmpty (ωSequence α) := by
-  apply IsEmpty.mk
-  intro xs
-  exact IsEmpty.false (xs 0)
+instance [h : IsEmpty α] : IsEmpty (ωSequence α) where
+  false xs := IsEmpty.false (xs 0)
 
 @[simp, scoped grind =]
 protected theorem eta (s : ωSequence α) : head s ::ω tail s = s := by


### PR DESCRIPTION
This PR proves some consequences of an empty alphabet type (denoted by `Symbol`) on Language and OmegaLanguage:
(1) The only possible languages over an empty alphabet are {} and {[]}.
(2) The only possible omega-language over an empty alphabet is {}.
Furthermore, (1) enables the assumption `[Inhabited Symbol]` to be removed from the regular language closure properties `IsRegular.mul` and `IsRegular.kstar`.  Now no closure property for regular languages has that assumption.
