### PR TITLE
feat(LocallyNameless/Untyped): add `FullEta.steps_lc_l`

### DIFF
--- a/Cslib/Languages/LambdaCalculus/LocallyNameless/Untyped/FullEta.lean
+++ b/Cslib/Languages/LambdaCalculus/LocallyNameless/Untyped/FullEta.lean
@@ -45,12 +45,16 @@ lemma step_lc_r (step : M ⭢ηᶠ M') : LC M' := by
   grind
 
 /-- The left side of an η-reduction is locally closed. -/
+@[scoped grind →]
 lemma step_lc_l [HasFresh Var] (step : M ⭢ηᶠ M') : LC M := by
   induction step with
   | base h_e => cases h_e with | eta => apply LC.abs ∅; grind
   | appL lc_Z _ ih => exact LC.app lc_Z ih
   | appR lc_Z _ ih => exact LC.app ih lc_Z
   | @abs M' _ xs _ ih => exact LC.abs xs M' ih
+
+lemma steps_lc_l [HasFresh Var] (step : M ↠ηᶠ M') (h : LC M') : LC M := by
+  induction step with grind
 
 /-- Left congruence rule for application in multiple reduction. -/
 theorem redex_app_l_cong (redex : M ↠ηᶠ M') (lc_N : LC N) : app M N ↠ηᶠ app M' N := by


### PR DESCRIPTION
- Introduce `FullEta.steps_lc_l` lemma: if `M ↠ηᶠ M'` and `LC M'`, then `LC M`
- Add `@[scoped grind →]` attribute to `step_lc_l`