### PR TITLE
fix(Modal): combine frame conditions in modal cube

### DIFF
--- a/Cslib/Logics/Modal/Cube.lean
+++ b/Cslib/Logics/Modal/Cube.lean
@@ -45,7 +45,8 @@ def Five World Atom := logic {m : Model World Atom | Relation.RightEuclidean m.r
 
 /-- The modal logic K45. -/
 @[scoped grind =]
-def K45 World Atom := (K World Atom) ∪ (Four World Atom) ∪ (Five World Atom)
+def K45 World Atom :=
+  logic {m : Model World Atom | IsTrans World m.r ∧ Relation.RightEuclidean m.r}
 
 /-- The modal logic D. -/
 @[scoped grind =]
@@ -53,44 +54,52 @@ def D World Atom := logic {m : Model World Atom | Relation.Serial m.r}
 
 /-- The modal logic D4. -/
 @[scoped grind =]
-def D4 World Atom := (K World Atom) ∪ (D World Atom) ∪ (Four World Atom)
+def D4 World Atom :=
+  logic {m : Model World Atom | Relation.Serial m.r ∧ IsTrans World m.r}
 
 /-- The modal logic D5. -/
 @[scoped grind =]
-def D5 World Atom := (K World Atom) ∪ (D World Atom) ∪ (Five World Atom)
+def D5 World Atom :=
+  logic {m : Model World Atom | Relation.Serial m.r ∧ Relation.RightEuclidean m.r}
 
 /-- The modal logic D45. -/
 @[scoped grind =]
-def D45 World Atom := (K World Atom) ∪ (D World Atom) ∪ (Four World Atom) ∪ (Five World Atom)
+def D45 World Atom :=
+  logic {m : Model World Atom |
+    Relation.Serial m.r ∧ IsTrans World m.r ∧ Relation.RightEuclidean m.r}
 
 /-- The modal logic DB. -/
 @[scoped grind =]
-def DB World Atom := (K World Atom) ∪ (D World Atom) ∪ (B World Atom)
+def DB World Atom :=
+  logic {m : Model World Atom | Relation.Serial m.r ∧ Std.Symm m.r}
 
 /-- The modal logic TB. -/
 @[scoped grind =]
-def TB World Atom := (K World Atom) ∪ (T World Atom) ∪ (B World Atom)
+def TB World Atom :=
+  logic {m : Model World Atom | Std.Refl m.r ∧ Std.Symm m.r}
 
 /-- The modal logic KB5. -/
 @[scoped grind =]
-def KB5 World Atom := (K World Atom) ∪ (B World Atom) ∪ (Five World Atom)
+def KB5 World Atom :=
+  logic {m : Model World Atom | Std.Symm m.r ∧ Relation.RightEuclidean m.r}
 
 /-- The modal logic S4. -/
 @[scoped grind =]
-def S4 World Atom := (K World Atom) ∪ (T World Atom) ∪ (Four World Atom)
+def S4 World Atom :=
+  logic {m : Model World Atom | Std.Refl m.r ∧ IsTrans World m.r}
 
 /-- The modal logic S5. -/
 @[scoped grind =]
-def S5 World Atom := (K World Atom) ∪ (T World Atom) ∪ (Four World Atom) ∪ (Five World Atom)
+def S5 World Atom :=
+  logic {m : Model World Atom |
+    Std.Refl m.r ∧ IsTrans World m.r ∧ Relation.RightEuclidean m.r}
 
 section Order
 
 /-! ## Ordering of Modal Logics
 
-This section proves the essential inclusions of modal logics.
-
-The other inclusions in the Modal Cube can be derived from the properties of `⊆` and `∪`, as shown
-in `k_subset_t`.
+This section proves the essential inclusions of modal logics. Inclusions among compound logics
+follow by forgetting frame conditions in their defining model classes.
 -/
 
 open scoped Proposition

--- a/CslibTests.lean
+++ b/CslibTests.lean
@@ -12,4 +12,5 @@ import CslibTests.ImportWithMathlib
 import CslibTests.LTS
 import CslibTests.LambdaCalculus
 import CslibTests.MLL
+import CslibTests.Modal
 import CslibTests.Reduction

--- a/CslibTests/Modal.lean
+++ b/CslibTests/Modal.lean
@@ -1,0 +1,78 @@
+/-
+Copyright (c) 2026 Samuel Schlesinger. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Samuel Schlesinger
+-/
+
+import Cslib.Logics.Modal.Cube
+
+namespace Cslib.Logic.Modal
+
+open scoped Proposition
+
+variable {World Atom : Type*} {φ : Proposition Atom}
+
+-- Compound modal logics contain conjunctions of the axioms validated by their combined frame
+-- conditions. Defining them as unions of the individual logics loses these conjunctions.
+
+example : ((◇◇φ → ◇φ) ∧ (◇φ → □◇φ) : Proposition Atom) ∈ K45 World Atom := by
+  intro m h w
+  letI : IsTrans World m.r := h.1
+  letI : Relation.RightEuclidean m.r := h.2
+  exact ⟨Satisfies.four φ, Satisfies.five φ⟩
+
+example : ((□φ → ◇φ) ∧ (◇◇φ → ◇φ) : Proposition Atom) ∈ D4 World Atom := by
+  intro m h w
+  letI : Relation.Serial m.r := h.1
+  letI : IsTrans World m.r := h.2
+  exact ⟨Satisfies.d φ, Satisfies.four φ⟩
+
+example : ((□φ → ◇φ) ∧ (◇φ → □◇φ) : Proposition Atom) ∈ D5 World Atom := by
+  intro m h w
+  letI : Relation.Serial m.r := h.1
+  letI : Relation.RightEuclidean m.r := h.2
+  exact ⟨Satisfies.d φ, Satisfies.five φ⟩
+
+example :
+    Proposition.and (□φ → ◇φ) (Proposition.and (◇◇φ → ◇φ) (◇φ → □◇φ)) ∈
+      D45 World Atom := by
+  intro m h w
+  letI : Relation.Serial m.r := h.1
+  letI : IsTrans World m.r := h.2.1
+  letI : Relation.RightEuclidean m.r := h.2.2
+  exact ⟨Satisfies.d φ, Satisfies.four φ, Satisfies.five φ⟩
+
+example : ((□φ → ◇φ) ∧ (φ → □◇φ) : Proposition Atom) ∈ DB World Atom := by
+  intro m h w
+  letI : Relation.Serial m.r := h.1
+  letI : Std.Symm m.r := h.2
+  exact ⟨Satisfies.d φ, Satisfies.b φ⟩
+
+example : ((φ → ◇φ) ∧ (φ → □◇φ) : Proposition Atom) ∈ TB World Atom := by
+  intro m h w
+  letI : Std.Refl m.r := h.1
+  letI : Std.Symm m.r := h.2
+  exact ⟨Satisfies.t φ, Satisfies.b φ⟩
+
+example : ((φ → □◇φ) ∧ (◇φ → □◇φ) : Proposition Atom) ∈ KB5 World Atom := by
+  intro m h w
+  letI : Std.Symm m.r := h.1
+  letI : Relation.RightEuclidean m.r := h.2
+  exact ⟨Satisfies.b φ, Satisfies.five φ⟩
+
+example : ((φ → ◇φ) ∧ (◇◇φ → ◇φ) : Proposition Atom) ∈ S4 World Atom := by
+  intro m h w
+  letI : Std.Refl m.r := h.1
+  letI : IsTrans World m.r := h.2
+  exact ⟨Satisfies.t φ, Satisfies.four φ⟩
+
+example :
+    Proposition.and (φ → ◇φ) (Proposition.and (◇◇φ → ◇φ) (◇φ → □◇φ)) ∈
+      S5 World Atom := by
+  intro m h w
+  letI : Std.Refl m.r := h.1
+  letI : IsTrans World m.r := h.2.1
+  letI : Relation.RightEuclidean m.r := h.2.2
+  exact ⟨Satisfies.t φ, Satisfies.four φ, Satisfies.five φ⟩
+
+end Cslib.Logic.Modal


### PR DESCRIPTION
Fixes the compound modal logics in the cube to include compound sentences instead of the union of sentences from the individual logics.