### PR TITLE
chore: replace terminal `refine`

### DIFF
--- a/Cslib/Computability/Automata/EpsilonNA/ToSingleAccept.lean
+++ b/Cslib/Computability/Automata/EpsilonNA/ToSingleAccept.lean
@@ -118,7 +118,7 @@ theorem toSingleAccept_τSTr_τSTr {a : εNA.FinAcc State Symbol}
     | tail hτstr htr ih =>
       subst hos'
       obtain ⟨_, rfl⟩ := Option.isSome_iff_exists.mp <| toSingleAccept_tr_antiDerivative_isSome htr
-      refine .trans (ih rfl) (.single htr)
+      exact .trans (ih rfl) (.single htr)
   · intro h
     cases h with
     | refl => exact LTS.τSTr.refl

--- a/Cslib/Computability/Automata/NA/Loop.lean
+++ b/Cslib/Computability/Automata/NA/Loop.lean
@@ -215,10 +215,10 @@ theorem loop_language_eq [Inhabited Symbol] (h : ¬ language na = 0) :
     · obtain ⟨xl1, ⟨h_xl1, _⟩, xl2, h_xl2, rfl⟩ := h
       rw [← totalize_language_eq] at h_xl1
       have := loop_fin_run_mtr h_xl1
-      obtain ⟨s1, _, s2, _, _⟩ := h_xl2
+      obtain ⟨s1, hs, s2, sa, sb⟩ := h_xl2
       obtain ⟨rfl⟩ : s1 = inl () := by grind [finLoop, loop]
       obtain ⟨rfl⟩ : s2 = inl () := by grind [finLoop, loop]
-      refine ⟨inl (), ?_, inl (), ?_, LTS.MTr.comp _ this ?_⟩ <;> assumption
+      exact ⟨inl (), sa, inl (), hs, LTS.MTr.comp _ this sb⟩
     · obtain ⟨rfl⟩ := (Language.mem_one xl).mp h
       refine ⟨inl (), ?_, inl (), ?_, ?_⟩ <;> grind [finLoop, loop]
 

--- a/Cslib/MachineLearning/PACLearning/VersionSpace.lean
+++ b/Cslib/MachineLearning/PACLearning/VersionSpace.lean
@@ -82,7 +82,7 @@ theorem versionSpace_empty_sample (C : ConceptClass α β)
     (S : LabeledSample α β 0) :
     VersionSpace C S = C := by
   ext h
-  refine ⟨fun hh => hh.1, fun hh => ⟨hh, fun i => i.elim0⟩⟩
+  exact ⟨fun hh => hh.1, fun hh => ⟨hh, fun i => i.elim0⟩⟩
 
 /-- *Version space reindexing.* For any reindexing `f : Fin m → Fin n`, the
 version space on `S` is contained in the version space on the reindexed sample


### PR DESCRIPTION
There is no reason for a `refine` to ever be terminal, it should be `exact`