### PR TITLE
chore: prefer `simp` over `simp_all`

### DIFF
--- a/Cslib/Computability/Automata/DA/ToNA.lean
+++ b/Cslib/Computability/Automata/DA/ToNA.lean
@@ -60,7 +60,7 @@ theorem toNAFinAcc_language_eq {a : DA.FinAcc State Symbol} :
   #adaptation_note
   /-- A grind regression found moving to nightly-2026-03-31 (changes from lean#13166) -/
   constructor
-  · simp_all [mem_language a xs, Accepts, toNAFinAcc, toNA, FLTS.toLTS_mtr]
+  · simp [mem_language a xs, Accepts, toNAFinAcc, toNA, FLTS.toLTS_mtr]
   · intro _
     use a.start
     simp_all [Accepts, toNAFinAcc, toNA, FLTS.toLTS_mtr]
@@ -82,7 +82,7 @@ theorem toNABuchi_language_eq {a : DA.Buchi State Symbol} :
   ext xs; constructor
   #adaptation_note
   /-- A grind regression found moving to nightly-2026-03-31 (changes from lean#13166) -/
-  · simp_all [Accepts, language, toNABuchi]
+  · simp [Accepts, language, toNABuchi]
   · intro h
     use (a.run xs)
     split_ands

--- a/Cslib/Computability/Languages/OmegaLanguage.lean
+++ b/Cslib/Computability/Languages/OmegaLanguage.lean
@@ -311,7 +311,7 @@ theorem le_hmul_congr {l1 l2 : Language α} {p1 p2 : ωLanguage α} (hl : l1 ≤
     l1 * p1 ≤ l2 * p2 := by
   simp only [le_def]
   intros _
-  simp_all only [hmul_def, mem_image2]
+  simp only [hmul_def, mem_image2]
   tauto
 
 theorem le_omegaPow_congr [Inhabited α] {l1 l2 : Language α} (h : l1 ≤ l2) : l1^ω ≤ l2^ω := by

--- a/Cslib/Crypto/Protocols/SecretSharing/Shamir.lean
+++ b/Cslib/Crypto/Protocols/SecretSharing/Shamir.lean
@@ -174,7 +174,7 @@ private theorem privacyCorrectionPolynomial_degree_lt
       (r := fun i : s => (secret₀ - secret₁) / params.point i)
       (points_injOn_subtype (F := F) params s))
     ?_
-  simpa using hcard
+  simp [hcard]
 
 private noncomputable def privacyCorrection
     (params : Params F Party) (s : Finset Party)
@@ -270,11 +270,10 @@ noncomputable def schemeWith (params : Params F Party) (sampler : TailSampler pa
           (Polynomial.sharingPolynomial secretValue
               (Polynomial.tailPolynomial params.threshold coeffs)).degree <
             Fintype.card s := by
-        simpa using
-          (lt_of_lt_of_le hdeg₀ (by exact_mod_cast hs) :
-            (Polynomial.sharingPolynomial secretValue
-                (Polynomial.tailPolynomial params.threshold coeffs)).degree <
-              s.card)
+        simp [(lt_of_lt_of_le hdeg₀ (by exact_mod_cast hs) :
+          (Polynomial.sharingPolynomial secretValue
+            (Polynomial.tailPolynomial params.threshold coeffs)).degree <
+              s.card)]
       have hx : Function.Injective (fun i : s => params.point i) := by
         intro i j hij
         exact Subtype.ext (params.point_injective hij)

--- a/Cslib/Crypto/Protocols/SecretSharing/Shamir/Polynomial.lean
+++ b/Cslib/Crypto/Protocols/SecretSharing/Shamir/Polynomial.lean
@@ -126,7 +126,7 @@ theorem reconstruct_eq_constantCoeff_of_eval_eq
       (s := Finset.univ)
       (v := x)
       hx.injOn
-      (by simpa using hdeg)
+      (by simp [hdeg])
   simpa [reconstruct] using congrArg _root_.Polynomial.constantCoeff hp.symm
 
 /-- Reconstruction succeeds on the values of a Shamir sharing polynomial once

--- a/Cslib/Foundations/Control/Monad/Free.lean
+++ b/Cslib/Foundations/Control/Monad/Free.lean
@@ -186,11 +186,11 @@ theorem map_bind (f : β → γ) (x : FreeM F α) (c : α → FreeM F β) :
 @[simp]
 theorem id_map : ∀ x : FreeM F α, map id x = x
   | .pure a => rfl
-  | .liftBind op cont => by simp_all [map, id_map]
+  | .liftBind op cont => by simp [map, id_map]
 
 theorem comp_map (h : β → γ) (g : α → β) : ∀ x : FreeM F α, map (h ∘ g) x = map h (map g x)
   | .pure a => rfl
-  | .liftBind op cont => by simp_all [map, comp_map]
+  | .liftBind op cont => by simp [map, comp_map]
 
 instance : LawfulFunctor (FreeM F) where
   map_const := rfl

--- a/Cslib/Logics/LinearLogic/CLL/PhaseSemantics/Basic.lean
+++ b/Cslib/Logics/LinearLogic/CLL/PhaseSemantics/Basic.lean
@@ -197,7 +197,7 @@ lemma coe_mk {X : Set P} {h : isFact X} : ((⟨X, h⟩ : Fact P) : Set P) = X :=
 
 /-- In any phase space, `{1}⫠ = ⊥`. -/
 lemma orth_one_eq_bot : ({(1 : P)} : Set P)⫠ = (PhaseSpace.bot : Set P) := by
-  simp
+  simp_all
 
 /-- The fact given by the dual of G. -/
 @[simps!] def dualFact (G : Set P) : Fact P := Fact.mkDual (G⫠) G rfl

--- a/Cslib/Logics/LinearLogic/CLL/PhaseSemantics/Basic.lean
+++ b/Cslib/Logics/LinearLogic/CLL/PhaseSemantics/Basic.lean
@@ -197,7 +197,7 @@ lemma coe_mk {X : Set P} {h : isFact X} : ((⟨X, h⟩ : Fact P) : Set P) = X :=
 
 /-- In any phase space, `{1}⫠ = ⊥`. -/
 lemma orth_one_eq_bot : ({(1 : P)} : Set P)⫠ = (PhaseSpace.bot : Set P) := by
-  simp_all
+  simp
 
 /-- The fact given by the dual of G. -/
 @[simps!] def dualFact (G : Set P) : Fact P := Fact.mkDual (G⫠) G rfl

--- a/Cslib/MachineLearning/PACLearning/VersionSpace.lean
+++ b/Cslib/MachineLearning/PACLearning/VersionSpace.lean
@@ -153,7 +153,7 @@ theorem mem_versionSpace_iff_empiricalError_zero
   unfold empiricalError empiricalMeasure error
   rcases Nat.eq_zero_or_pos m with hm | hm
   · subst hm
-    simp_all
+    simp
   · simp_all [Nat.pos_iff_ne_zero]
 
 /-- The empirical 0-1 error equals the empirical miscount divided by the


### PR DESCRIPTION
Self explanotory.

Additionally, this PR replaces `simpa using X` with `simp [X]` whenever possible. `simpa using` is not very good codestyle for various reasons, but at least in this case there is an easy replacement

I did many cleanup PRs like this in mathlib recently and try to repeat the applicable ones here